### PR TITLE
Room history visibility

### DIFF
--- a/lib/irclib/server.js
+++ b/lib/irclib/server.js
@@ -446,7 +446,7 @@ IrcServer.prototype.getChannelFromAlias = function(alias) {
             "$SERVER": this.domain
         },
         {
-            "$CHANNEL": "(.*)"
+            "$CHANNEL": "([^:]*)"
         },
         ":.*"
     );
@@ -454,6 +454,7 @@ IrcServer.prototype.getChannelFromAlias = function(alias) {
     if (!match) {
         return null;
     }
+    log.info("getChannelFromAlias -> %s -> %s -> %s", alias, regex, match[1]);
     return match[1];
 };
 

--- a/lib/mxlib/matrix.js
+++ b/lib/mxlib/matrix.js
@@ -168,16 +168,11 @@ MatrixLib.prototype.createRoomWithAlias = function(alias, name, topic, joinRule,
             return setJoinRule(
               client, roomId, joinRuleToSet
             ).then(function(roomId) {
-              var d = setRoomHistoryVisibility(client, roomId, "joined");
-              self.log.info("setRoomHistoryVisibility2 -> %s", d);
-              return d;
+              return setRoomHistoryVisibility(client, roomId, "joined");
             });
         }
         else {
-            self.log.info("setRoomHistoryVisibility");
-            var d = setRoomHistoryVisibility(client, roomId, "joined");
-            self.log.info("setRoomHistoryVisibility -> %s", d);
-            return d;
+            return setRoomHistoryVisibility(client, roomId, "joined");
         }
     }, function(err) {
         if (err.errcode === "M_UNKNOWN") {

--- a/lib/mxlib/matrix.js
+++ b/lib/mxlib/matrix.js
@@ -133,7 +133,6 @@ MatrixLib.prototype.createRoomWithUser = function(fromUserId, toUserId, name) {
 MatrixLib.prototype.createRoomWithAlias = function(alias, name, topic, joinRule,
                                                    publishRoom) {
     var aliasLocalpart = getAliasLocalpart(alias);
-    var defer = q.defer();
     var client = this._getClient();
     var self = this;
 
@@ -151,7 +150,7 @@ MatrixLib.prototype.createRoomWithAlias = function(alias, name, topic, joinRule,
 
 
     // if alias already used (M_UNKNOWN), query it and use that. Return a Room.
-    client.createRoom({
+    return client.createRoom({
         room_alias_name: aliasLocalpart,
         name: name,
         topic: topic,
@@ -163,33 +162,36 @@ MatrixLib.prototype.createRoomWithAlias = function(alias, name, topic, joinRule,
                 "Created room. Setting join_rules for %s to %s",
                 alias, joinRuleToSet
             );
-            setJoinRule(client, roomId, joinRuleToSet).done(function() {
-                defer.resolve(new MatrixRoom(roomId));
-            }, function(e) {
-                 defer.reject(
-                    "Failed to set join_rules on newly created room: %s",
-                    JSON.stringify(e)
-                );
+
+            // For new rooms we want to set the join_rules and
+            // history_visibility state
+            return setJoinRule(
+              client, roomId, joinRuleToSet
+            ).then(function(roomId) {
+              var d = setRoomHistoryVisibility(client, roomId, "joined");
+              self.log.info("setRoomHistoryVisibility2 -> %s", d);
+              return d;
             });
         }
         else {
-            defer.resolve(new MatrixRoom(roomId));
+            self.log.info("setRoomHistoryVisibility");
+            var d = setRoomHistoryVisibility(client, roomId, "joined");
+            self.log.info("setRoomHistoryVisibility -> %s", d);
+            return d;
         }
     }, function(err) {
         if (err.errcode === "M_UNKNOWN") {
             // alias already taken, must be us. Join the room alias.
-            return client.joinRoom(alias);
+            return client.joinRoom(alias).then(function(response) {
+                return response.room_id;
+            });
         }
         else {
-            defer.reject("Failed to create room: %s", JSON.stringify(err));
+            throw "Failed to create room: " + JSON.stringify(err);
         }
-    }).then(function(response) {
-        if (response) {
-            defer.resolve(new MatrixRoom(response.room_id));
-        }
-    }).catch(log.logErr);
-
-    return defer.promise;
+    }).then(function(roomId) {
+        return new MatrixRoom(roomId);
+    });
 };
 
 MatrixLib.prototype.leaveRoom = function(userId, roomId) {
@@ -322,7 +324,19 @@ var setJoinRule = function(client, roomId, joinRule) {
         roomId, "m.room.join_rules", {
             join_rule: joinRule
         }, ""
-    );
+    ).then(function() {
+        return roomId;
+    });
+};
+
+var setRoomHistoryVisibility = function(client, roomId, history_visibility) {
+    return client.sendStateEvent(
+        roomId, "m.room.history_visibility", {
+            "history_visibility": history_visibility
+        }, ""
+    ).then(function() {
+        return roomId;
+    });
 };
 
 var setTopic = function(lib, room, from, topic) {

--- a/spec/integ/dynamic-channels.spec.js
+++ b/spec/integ/dynamic-channels.spec.js
@@ -62,6 +62,12 @@ describe("Dynamic channels", function() {
                 room_id: tRoomId
             });
         });
+        sdk.sendStateEvent.andCallFake(function(roomId, eventType) {
+            expect(roomId).toEqual(tRoomId);
+            expect(eventType).toEqual("m.room.history_visibility");
+            return q({});
+        });
+
         env.mockAsapiController._queryAlias(tAlias).done(function() {
             if (joinedIrcChannel) {
                 done();
@@ -97,6 +103,12 @@ describe("Dynamic channels", function() {
             return q({
                 room_id: tRoomId
             });
+        });
+
+        sdk.sendStateEvent.andCallFake(function(roomId, eventType) {
+            expect(roomId).toEqual(tRoomId);
+            expect(eventType).toEqual("m.room.history_visibility");
+            return q({});
         });
 
         var madeAlias = false;
@@ -173,6 +185,12 @@ describe("Dynamic channels (disabled)", function() {
             return q({
                 room_id: tRoomId
             });
+        });
+
+        sdk.sendStateEvent.andCallFake(function(roomId, eventType) {
+            expect(roomId).toEqual(tRoomId);
+            expect(eventType).toEqual("m.room.history_visibility");
+            return q({});
         });
 
         env.mockAsapiController._queryAlias(tAlias).catch(function() {

--- a/spec/integ/dynamic-channels.spec.js
+++ b/spec/integ/dynamic-channels.spec.js
@@ -62,9 +62,10 @@ describe("Dynamic channels", function() {
                 room_id: tRoomId
             });
         });
-        sdk.sendStateEvent.andCallFake(function(roomId, eventType) {
+        sdk.sendStateEvent.andCallFake(function(roomId, eventType, obj) {
             expect(roomId).toEqual(tRoomId);
             expect(eventType).toEqual("m.room.history_visibility");
+            expect(obj).toEqual({history_visibility: "joined"});
             return q({});
         });
 
@@ -105,9 +106,10 @@ describe("Dynamic channels", function() {
             });
         });
 
-        sdk.sendStateEvent.andCallFake(function(roomId, eventType) {
+        sdk.sendStateEvent.andCallFake(function(roomId, eventType, obj) {
             expect(roomId).toEqual(tRoomId);
             expect(eventType).toEqual("m.room.history_visibility");
+            expect(obj).toEqual({history_visibility: "joined"});
             return q({});
         });
 
@@ -187,9 +189,10 @@ describe("Dynamic channels (disabled)", function() {
             });
         });
 
-        sdk.sendStateEvent.andCallFake(function(roomId, eventType) {
+        sdk.sendStateEvent.andCallFake(function(roomId, eventType, obj) {
             expect(roomId).toEqual(tRoomId);
             expect(eventType).toEqual("m.room.history_visibility");
+            expect(obj).toEqual({history_visibility: "joined"});
             return q({});
         });
 

--- a/spec/integ/hs-queries.spec.js
+++ b/spec/integ/hs-queries.spec.js
@@ -93,6 +93,11 @@ describe("Homeserver alias queries", function() {
             });
         });
 
+        sdk.sendStateEvent.andCallFake(function(roomId, eventType) {
+            expect(eventType).toEqual("m.room.history_visibility");
+            return q({});
+        });
+
         var botJoined = false;
         env.ircMock._whenClient(roomMapping.server, roomMapping.botNick, "join",
         function(client, channel, cb) {

--- a/spec/integ/hs-queries.spec.js
+++ b/spec/integ/hs-queries.spec.js
@@ -93,8 +93,9 @@ describe("Homeserver alias queries", function() {
             });
         });
 
-        sdk.sendStateEvent.andCallFake(function(roomId, eventType) {
+        sdk.sendStateEvent.andCallFake(function(roomId, eventType, obj) {
             expect(eventType).toEqual("m.room.history_visibility");
+            expect(obj).toEqual({history_visibility: "joined"});
             return q({});
         });
 


### PR DESCRIPTION
Add support for setting `m.room.history_visibility`.

This requires a yet unreleased version of synapse.