### PR TITLE
Patches to allow for Self Signed IRC Certs

### DIFF
--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -29,6 +29,8 @@ ircService:
       port: 6697
       # Whether to use SSL or not. Default: false.
       ssl: true
+      # Whether or not IRC server is using a self-signed cert or not providing CA Chain
+      sslselfsign: false
 
       botConfig:
         # Enable the presence of the bot in IRC channels. The bot serves as the entity
@@ -48,7 +50,7 @@ ircService:
         enabled: true
         # The nickname to give the AS bot.
         nick: "appservicebot"
-        # The password to give to NickServ for this nick. Optional.
+        # The password to give to NickServ or IRC Server for this nick. Optional.
         password: "helloworld"
         # Join channels even if there are no Matrix users on the other side of
         # the bridge. Set to false to prevent the bot from joining channels which have no

--- a/lib/config/schema.yml
+++ b/lib/config/schema.yml
@@ -80,6 +80,8 @@ properties:
                             type: "integer"
                         ssl:
                             type: "boolean"
+                        sslselfsign:
+                            type: "boolean"
                         botConfig:
                             type: "object"
                             properties:

--- a/lib/irclib/client-connection.js
+++ b/lib/irclib/client-connection.js
@@ -229,7 +229,8 @@ module.exports = {
             floodProtection: true,
             floodProtectionDelay: FLOOD_PROTECTION_DELAY_MS,
             port: server.getPort(),
-            secure: server.useSsl()
+            secure: server.useSsl(),
+            selfSigned: server.useSslSelfSigned()
         };
         var d = q.defer();
         var returnClient = function(cli) {

--- a/lib/irclib/server.js
+++ b/lib/irclib/server.js
@@ -41,6 +41,10 @@ IrcServer.prototype.useSsl = function() {
     return Boolean(this.config.ssl);
 };
 
+IrcServer.prototype.useSslSelfSigned = function() {
+    return Boolean(this.config.sslselfsign);
+};
+
 IrcServer.prototype.getIdleTimeoutMs = function() {
     return this.config.ircClients.idleTimeout;
 };


### PR DESCRIPTION
See subject.

Ran into an issue where I couldn't connect to a server with a self-signed cert / server that doesn't provide a CA Intermediate.   This solves that problem. (Though the error messages were less than useful that it was a SSL issue, but I've not looked at node.js before today)

