### PR TITLE
Add support for unique per-user IPv6 addresses

### DIFF
--- a/HOWTO.md
+++ b/HOWTO.md
@@ -313,6 +313,16 @@ Logging is configurable in the yaml, but there is also an extra verbose setting
 you can enable. This is done by passing ``--verbose`` or ``-v`` to 
 ``node app.js``.
 
+### Unique IPv6 addresses
+You may want to assign unique IPv6 addresses to the generated IRC clients
+e.g. to scope bans to Matrix users rather than the entire application service.
+To enable this:
+```yaml
+ircService:
+  uniqueIPv6:
+    prefix: "2001:0db8:85a3::"  # modify appropriately
+```
+
 Contributing
 ------------
 

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -241,3 +241,9 @@ ircService:
   # dump .db files to. This is relative to the project directory.
   # Required.
   databaseUri: "nedb://data"
+  
+  # Optional. The IPv6 prefix to use for generating unique addresses for each
+  # connected user. If not specified, all users will connect from the same
+  # (default) address.
+  uniqueIPv6:
+    prefix: "2001:0db8:85a3::"

--- a/lib/config/schema.yml
+++ b/lib/config/schema.yml
@@ -34,6 +34,12 @@ properties:
     ircService:
         type: "object"
         properties:
+            uniqueIPv6:
+                type: "object"
+                properties:
+                    prefix:
+                        type: "string"
+                required: ["prefix"]
             databaseUri:
                 type: "string"
             statsd:

--- a/lib/config/validator.js
+++ b/lib/config/validator.js
@@ -80,6 +80,7 @@ function createNewConfig(cfg) {
     self.appService = cfg.appService;
     self.databaseUri = cfg.ircService.databaseUri;
     self.statsd = cfg.ircService.statsd || {};
+    self.uniqueIPv6 = cfg.ircService.uniqueIPv6 || {};
 
     var defaultIdent = {
         enabled: false,

--- a/lib/irc-appservice.js
+++ b/lib/irc-appservice.js
@@ -11,6 +11,7 @@ var matrixToIrc = require("./bridge/matrix-to-irc.js");
 var ircToMatrix = require("./bridge/irc-to-matrix.js");
 var membershiplists = require("./bridge/membershiplists.js");
 var IrcServer = require("./irclib/server.js").IrcServer;
+var ircClient = require("./irclib/client.js");
 var ircLib = require("./irclib/irc.js");
 var matrixLib = require("./mxlib/matrix");
 var MatrixUser = require("./models/users").MatrixUser;
@@ -35,6 +36,9 @@ module.exports.configure = function(config) {
     if (config.ident.enabled) {
         ident.configure(config.ident);
         ident.run();
+    }
+    if (config.uniqueIPv6.prefix) {
+        ircClient.ip6Prefix = config.uniqueIPv6.prefix;
     }
 
     dbConnPromise = store.connectToDatabase(config.databaseUri);

--- a/lib/irclib/client-connection.js
+++ b/lib/irclib/client-connection.js
@@ -212,6 +212,7 @@ module.exports = {
      * @param {string} opts.username The username to use.
      * @param {string} opts.realname The real name of the user.
      * @param {string} opts.password The password to give NickServ.
+     * @param {string} opts.localAddress The address to bind to when connecting.
      * @param {Function} onCreatedCallback Called with the client when created.
      * @return {Promise} Resolves to an ConnectionInstance or rejects.
      */
@@ -232,6 +233,9 @@ module.exports = {
             secure: server.useSsl(),
             selfSigned: server.useSslSelfSigned()
         };
+        if (opts.localAddress) {
+            connectionOpts.localAddress = opts.localAddress;
+        }
         var d = q.defer();
         var returnClient = function(cli) {
             d.resolve(cli);

--- a/lib/irclib/client.js
+++ b/lib/irclib/client.js
@@ -13,6 +13,12 @@ var log = require("../logging").get("irc-client");
 // The length of time to wait before trying to join the channel again
 var JOIN_TIMEOUT_MS = 15 * 1000; // 15s
 
+// A global counter for generating unique numerical user IDs
+var userCount = 0;
+
+// IPv6 prefix to use
+var ip6Prefix = null;
+
 /**
  * Create a new bridged IRC client.
  * @constructor
@@ -60,6 +66,9 @@ BridgedClient.prototype.setIrcUserInfo = function(ircUser) {
     this.server = ircUser.server;
     this.nick = ircUser.nick;
     this.password = ircUser.password;
+    if (ircUser.localAddress) {
+        this.localAddress = ircUser.localAddress;
+    }
     this.userId = this.matrixUser ? this.matrixUser.userId : ircUser.username;
 };
 
@@ -85,13 +94,22 @@ BridgedClient.prototype.connect = function(callbacks) {
             "Connecting to IRC server %s as %s (user=%s)",
             server.domain, nameInfo.nick, nameInfo.username
         );
+        userCount++;
 
-        return clientConnection.create(server, {
+        var opts = {
             nick: nameInfo.nick,
             username: nameInfo.username,
             realname: nameInfo.realname,
             password: self.password
-        }, function(inst) {
+        };
+        if (ip6Prefix) {
+            var suffix = userCount.toString(16);
+            // insert colons: "deadbeef" => "dead:beef"
+            suffix = suffix.replace(/\B(?=(.{4})+(?!.))/g, ':');
+            opts.localAddress = ip6Prefix + suffix;
+            self.log.info("Using IPv6 address %s", opts.localAddress);
+        }
+        return clientConnection.create(server, opts, function(inst) {
             self._onConnectionCreated(inst, nameInfo, callbacks);
         });
     }).done(function(connInst) {


### PR DESCRIPTION
I've tried to clean up [Tor's patch](https://xt.gg/matrix.ircbridge.ipv6range.diff.txt) for [BOTS-113](https://matrix.org/jira/browse/BOTS-113). I haven't had a chance to test this yet, but wanted to submit it for feedback in the meantime.

CC: @ara4n 