### PR TITLE
matrix-to-irc.js still uses q, should use bluebird

### DIFF
--- a/lib/bridge/matrix-to-irc.js
+++ b/lib/bridge/matrix-to-irc.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var q = require("q");
+var Promise = require("bluebird");
 var promiseutil = require("../promiseutil");
 
 var matrixLib = require("../mxlib/matrix");
@@ -115,7 +115,7 @@ var handleInviteFromUser = function(event, req, invitedIrcUser) {
     // Real MX user inviting VMX to a matrix room for PM chat
     if (!invitedIrcUser.server.allowsPms()) {
         req.log.error("Rejecting invite: This server does not allow PMs.");
-        return q.reject("Server disallows PMs");
+        return Promise.reject(new Error("Server disallows PMs"));
     }
     // create a virtual Matrix user for the IRC user
     var invitedUser = null;
@@ -266,7 +266,7 @@ var onAdminMessage = function(event, req, adminRoom) {
                     );
                     promises.push(req.mxLib.invite(room, event.user_id));
                 });
-                q.all(promises).done(req.sucFn, req.errFn);
+                Promise.all(promises).done(req.sucFn, req.errFn);
             }
             else {
                 // track the channel then invite them.
@@ -408,7 +408,7 @@ module.exports.onJoin = function(event, user) {
                 })
             );
         });
-        q.all(promises).done(req.sucFn, req.errFn);
+        Promise.all(promises).done(req.sucFn, req.errFn);
     }, req.errFn);
     return req.defer.promise;
 };
@@ -463,7 +463,7 @@ module.exports.onLeave = function(event, user) {
             }
         });
 
-        q.all(promises).done(req.sucFn, req.errFn);
+        Promise.all(promises).done(req.sucFn, req.errFn);
     }, req.errFn);
     return req.defer.promise;
 };
@@ -564,7 +564,7 @@ module.exports.onMessage = function(event, existingRequest) {
             }
         });
 
-        q.all(promises).done(req.sucFn, req.errFn);
+        Promise.all(promises).done(req.sucFn, req.errFn);
     }, req.errFn);
 
     return req.defer.promise;


### PR DESCRIPTION
q has been removed in 3fd3ab5a75f5d29d5ee6ce9027a6acb4fd00a8f2 but not every references to it has been switched to bluebird. This PR fixes it.