### PR TITLE
Use the Bridge class from matrix-appservice-bridge

### DIFF
--- a/lib/bridge/instance.js
+++ b/lib/bridge/instance.js
@@ -17,7 +17,7 @@ var log = logging.get("IrcBridge");
 var Bridge = require("matrix-appservice-bridge").Bridge;
 
 const DELAY_TIME_MS = 10 * 1000;
-const DEAD_TIME_MS = 60 * 1000 * 5; // 5min
+const DEAD_TIME_MS = 5 * 60 * 1000;
 
 
 function IrcBridge(config, registration) {
@@ -137,6 +137,7 @@ IrcBridge.prototype._onEvent = Promise.coroutine(function*(request, context) {
         if (!event.content || !event.content.membership) {
             return;
         }
+        // MatrixUser(userId, displayName, isVirtual)
         var target = new MatrixUser(event.state_key, null, null);
         var sender = new MatrixUser(event.user_id, null, null);
         if (event.content.membership === "invite") {

--- a/lib/bridge/instance.js
+++ b/lib/bridge/instance.js
@@ -70,11 +70,10 @@ IrcBridge.prototype.run = Promise.coroutine(function*(port) {
         userStore: "_unused_users.db", // we use our own for now
         suppressEcho: false, // we use our own dupe suppress for now
         queue: {
-            type: "per_room",
-            perRequest: true
+            type: "none",
+            perRequest: false
         }
     });
-
 
     if (this.config.appService) {
         console.warn(
@@ -116,7 +115,7 @@ IrcBridge.prototype.run = Promise.coroutine(function*(port) {
     this.ircServers.forEach(function(server) {
         membershiplists.sync(server);
     });
-    this.bridge.run(port);
+    yield this.bridge.run(port);
     this.bridge.getRequestFactory().addDefaultTimeoutCallback((req) => {
         this.onLog("[" + req.getId() + "] DELAYED (" + req.getDuration() + "ms)");
     }, DELAY_TIME_MS);
@@ -132,7 +131,7 @@ IrcBridge.prototype.onEvent = function(request, context) {
 IrcBridge.prototype._onEvent = Promise.coroutine(function*(request, context) {
     var event = request.getData();
     if (event.type === "m.room.message" || event.type === "m.room.topic") {
-        yield matrixToIrc.onMessage(event)
+        yield matrixToIrc.onMessage(request, event)
     }
     else if (event.type === "m.room.member") {
         if (!event.content || !event.content.membership) {
@@ -141,13 +140,13 @@ IrcBridge.prototype._onEvent = Promise.coroutine(function*(request, context) {
         var target = new MatrixUser(event.state_key, null, null);
         var sender = new MatrixUser(event.user_id, null, null);
         if (event.content.membership === "invite") {
-            yield matrixToIrc.onInvite(event, sender, target);
+            yield matrixToIrc.onInvite(request, event, sender, target);
         }
         else if (event.content.membership === "join") {
-            yield matrixToIrc.onJoin(event, target);
+            yield matrixToIrc.onJoin(request, event, target);
         }
         else if (["ban", "leave"].indexOf(event.content.membership) !== -1) {
-            yield matrixToIrc.onLeave(event, target);
+            yield matrixToIrc.onLeave(request, event, target);
         }
     }
 });

--- a/lib/bridge/instance.js
+++ b/lib/bridge/instance.js
@@ -1,0 +1,176 @@
+/*eslint no-invalid-this: 0*/ // eslint doesn't understand Promise.coroutine wrapping
+"use strict";
+var Promise = require("bluebird");
+var extend = require("extend");
+
+var store = require("../store");
+var ircToMatrix = require("./irc-to-matrix.js");
+var matrixToIrc = require("./matrix-to-irc.js");
+var membershiplists = require("./membershiplists.js");
+var ircLib = require("../irclib/irc.js");
+var names = require("../irclib/names.js");
+var IrcServer = require("../irclib/server.js").IrcServer;
+var matrixLib = require("../mxlib/matrix");
+var MatrixUser = require("../models/users").MatrixUser;
+var logging = require("../logging");
+var log = logging.get("IrcBridge");
+var Bridge = require("matrix-appservice-bridge").Bridge;
+
+const DELAY_TIME_MS = 10 * 1000;
+const DEAD_TIME_MS = 60 * 1000 * 5; // 5min
+
+
+function IrcBridge(config, registration) {
+    this.config = config;
+    this.registration = registration;
+    this.ircServers = [];
+    this.bridge = null; // Bridge
+}
+
+IrcBridge.prototype.run = Promise.coroutine(function*(port) {
+    // connect to the DB, blow away any old config mappings, we're setting new ones now.
+    yield store.connectToDatabase(this.config.ircService.databaseUri);
+    yield store.rooms.removeConfigMappings();
+
+    // maintain a list of IRC servers in-use
+    let serverDomains = Object.keys(this.config.ircService.servers);
+    for (var i = 0; i < serverDomains.length; i++) {
+        let domain = serverDomains[i];
+        let server = new IrcServer(
+            domain,
+            extend(true, IrcServer.DEFAULT_CONFIG, this.config.ircService.servers[domain])
+        );
+        // store the config mappings in the DB to keep everything in one place.
+        yield store.setServerFromConfig(server, this.config.ircService.servers[domain]);
+        this.ircServers.push(server);
+    }
+
+    if (this.ircServers.length === 0) {
+        throw new Error("No IRC servers specified.");
+    }
+
+    // glue IRC side
+    ircLib.registerHooks({ // FIXME: inject ircLib.
+        onMessage: ircToMatrix.onMessage,
+        onPrivateMessage: ircToMatrix.onPrivateMessage,
+        onJoin: ircToMatrix.onJoin,
+        onPart: ircToMatrix.onPart,
+        onMode: ircToMatrix.onMode
+    });
+    ircLib.setServers(this.ircServers);
+    names.initQueue();
+
+    // glue Matrix side
+    this.bridge = new Bridge({
+        registration: this.registration,
+        homeserverUrl: this.config.homeserver.url,
+        domain: this.config.homeserver.domain,
+        controller: this,
+        roomStore: "_unused_rooms.db", // we use our own for now
+        userStore: "_unused_users.db", // we use our own for now
+        suppressEcho: false, // we use our own dupe suppress for now
+        queue: {
+            type: "per_room",
+            perRequest: true
+        }
+    });
+
+
+    if (this.config.appService) {
+        console.warn(
+            `[DEPRECATED] Use of config field 'appService' is deprecated. Remove this
+            field from the config file to remove this warning.
+
+            This release will use values from this config file. This will produce
+            a fatal error in a later release.`
+        );
+        matrixLib.setMatrixClientConfig({
+            baseUrl: this.config.appService.homeserver.url,
+            accessToken: this.config.appService.appservice.token,
+            domain: this.config.appService.homeserver.domain,
+            localpart: this.config.appService.localpart || IrcBridge.DEFAULT_LOCALPART
+        });
+    }
+    else {
+        if (!this.registration.getSenderLocalpart() ||
+                !this.registration.getAppServiceToken()) {
+            throw new Error(
+                "FATAL: Registration file is missing a sender_localpart and/or AS token."
+            );
+        }
+        matrixLib.setMatrixClientConfig({
+            baseUrl: this.config.homeserver.url,
+            accessToken: this.registration.getAppServiceToken(),
+            domain: this.config.homeserver.domain,
+            localpart: this.registration.getSenderLocalpart()
+        });
+    }
+
+
+    // start things going
+    log.info("Joining mapped Matrix rooms...");
+    yield matrixLib.joinMappedRooms();
+    log.info("Connecting to IRC networks...");
+    yield ircLib.connect();
+    log.info("Syncing relevant membership lists...");
+    this.ircServers.forEach(function(server) {
+        membershiplists.sync(server);
+    });
+    this.bridge.run(port);
+    this.bridge.getRequestFactory().addDefaultTimeoutCallback((req) => {
+        this.onLog("[" + req.getId() + "] DELAYED (" + req.getDuration() + "ms)");
+    }, DELAY_TIME_MS);
+    this.bridge.getRequestFactory().addDefaultTimeoutCallback((req) => {
+        this.onLog("[" + req.getId() + "] DEAD (" + req.getDuration() + "ms)");
+    }, DEAD_TIME_MS);
+});
+
+IrcBridge.prototype.onEvent = function(request, context) {
+    request.outcomeFrom(this._onEvent(request, context));
+};
+
+IrcBridge.prototype._onEvent = Promise.coroutine(function*(request, context) {
+    var event = request.getData();
+    if (event.type === "m.room.message" || event.type === "m.room.topic") {
+        yield matrixToIrc.onMessage(event)
+    }
+    else if (event.type === "m.room.member") {
+        if (!event.content || !event.content.membership) {
+            return;
+        }
+        var target = new MatrixUser(event.state_key, null, null);
+        var sender = new MatrixUser(event.user_id, null, null);
+        if (event.content.membership === "invite") {
+            yield matrixToIrc.onInvite(event, sender, target);
+        }
+        else if (event.content.membership === "join") {
+            yield matrixToIrc.onJoin(event, target);
+        }
+        else if (["ban", "leave"].indexOf(event.content.membership) !== -1) {
+            yield matrixToIrc.onLeave(event, target);
+        }
+    }
+});
+
+IrcBridge.prototype.onUserQuery = Promise.coroutine(function*(matrixUser) {
+    yield matrixToIrc.onUserQuery(matrixUser.userId);
+    return null; // don't provision, we already do atm
+});
+
+IrcBridge.prototype.onAliasQuery = Promise.coroutine(function*(alias, aliasLocalpart) {
+    yield matrixToIrc.onAliasQuery(alias);
+    return null; // don't provision, we already do atm
+});
+
+IrcBridge.prototype.onLog = function(line, isError) {
+    if (isError) {
+        log.error(line);
+    }
+    else {
+        log.info(line);
+    }
+};
+
+IrcBridge.DEFAULT_LOCALPART = "appservice-irc";
+
+module.exports = IrcBridge;

--- a/lib/bridge/matrix-to-irc.js
+++ b/lib/bridge/matrix-to-irc.js
@@ -385,8 +385,8 @@ var _onJoin = Promise.coroutine(function*(req, event, user) {
     yield Promise.all(promises);
 });
 
-module.exports.onLeave = function(event, user) {
-    var req = requests.newRequest(false);
+module.exports.onLeave = function(req, event, user) {
+    monkeyPatch(req);
     req.log.info("onLeave: %s", JSON.stringify(event));
     // membershiplists injects leave events when syncing initial membership
     // lists. We know if this event is injected because this flag is set.
@@ -466,7 +466,7 @@ let _onMessage = Promise.coroutine(function*(req, event) {
             event.user_id, event.room_id
         );
         yield processingInvitesForRooms[event.room_id + event.user_id];
-        request.log.info(
+        req.log.info(
             "Finished holding event for %s in room %s", event.user_id, event.room_id
         );
     }
@@ -614,18 +614,18 @@ let _onUserQuery = Promise.coroutine(function*(req, userId) {
 
 // EXPORTS
 
-module.exports.onInvite = function(event, inviter, invitee) {
-    let req = requests.newRequest(false);
+module.exports.onInvite = function(req, event, inviter, invitee) {
+    monkeyPatch(req);
     return reqHandler(req, _onInvite(req, event, inviter, invitee));
 };
 
-module.exports.onJoin = function(event, user) {
-    let req = requests.newRequest(false);
+module.exports.onJoin = function(req, event, user) {
+    monkeyPatch(req);
     return reqHandler(req, _onJoin(req, event, user));
 };
 
-module.exports.onMessage = function(event) {
-    let req = requests.newRequest(false);
+module.exports.onMessage = function(req, event) {
+    monkeyPatch(req);
     return reqHandler(req, _onMessage(req, event));
 };
 
@@ -638,6 +638,21 @@ module.exports.onUserQuery = function(userId) {
     let req = requests.newRequest(false);
     return reqHandler(req, _onUserQuery(req, userId))
 };
+
+function monkeyPatch(req) {
+    // FIXME: Bodge whilst we have 2 request formats
+    if (!req.sucFn) {
+        req.sucFn = req.resolve.bind(req);
+        req.errFn = req.reject.bind(req);
+        req.log = {
+            debug: function() { },
+            info: function() { },
+            error: function() { }
+        };
+        req.mxLib = matrixLib.getMatrixLibFor(req);
+        req.ircLib = ircLib.getIrcLibFor(req);
+    }
+}
 
 function reqHandler(req, promise) {
     return promise.then(function(res) {

--- a/lib/irclib/server.js
+++ b/lib/irclib/server.js
@@ -309,4 +309,52 @@ function escapeRegExp(string) {
     return string.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
+IrcServer.DEFAULT_CONFIG = {
+    botConfig: {
+        nick: "appservicebot",
+        joinChannelsIfNoUsers: true,
+        enabled: true
+    },
+    privateMessages: {
+        enabled: true,
+        exclude: []
+    },
+    dynamicChannels: {
+        enabled: false,
+        published: true,
+        createAlias: true,
+        joinRule: "public",
+        federate: true,
+        aliasTemplate: "#irc_$SERVER_$CHANNEL",
+        whitelist: [],
+        exclude: []
+    },
+    mappings: {},
+    matrixClients: {
+        userTemplate: "@$SERVER_$NICK",
+        displayName: "$NICK (IRC)"
+    },
+    ircClients: {
+        nickTemplate: "M-$DISPLAY",
+        maxClients: 30,
+        idleTimeout: 172800,
+        allowNickChanges: false
+    },
+    membershipLists: {
+        enabled: false,
+        global: {
+            ircToMatrix: {
+                initial: false,
+                incremental: false
+            },
+            matrixToIrc: {
+                initial: false,
+                incremental: false
+            }
+        },
+        channels: [],
+        rooms: []
+    }
+};
+
 module.exports.IrcServer = IrcServer;

--- a/lib/main.js
+++ b/lib/main.js
@@ -3,27 +3,16 @@ var Promise = require("bluebird");
 var extend = require("extend");
 
 var AppServiceRegistration = require("matrix-appservice-bridge").AppServiceRegistration;
-var AppService = require("matrix-appservice").AppService;
 
-var ircToMatrix = require("./bridge/irc-to-matrix.js");
-var matrixToIrc = require("./bridge/matrix-to-irc.js");
-var membershiplists = require("./bridge/membershiplists.js");
+var IrcBridge = require("./bridge/instance.js");
 var IrcServer = require("./irclib/server.js").IrcServer;
-var ircLib = require("./irclib/irc.js");
-var matrixLib = require("./mxlib/matrix");
-var MatrixUser = require("./models/users").MatrixUser;
-var store = require("./store");
 var stats = require("./config/stats");
 var ident = require("./irclib/ident");
-var names = require("./irclib/names");
 var logging = require("./logging");
 var log = logging.get("main");
 
-const DEFAULT_LOCALPART = "appservice-irc";
-
 var _toServer = function(domain, serverConfig) {
     // set server config defaults
-    var defaultServerConfig = module.exports.defaultServerConfig();
     if (serverConfig.dynamicChannels.visibility) {
         throw new Error(
             `[DEPRECATED] Use of the config field dynamicChannels.visibility
@@ -31,7 +20,7 @@ var _toServer = function(domain, serverConfig) {
             and dynamicChannels.createAlias instead.`
         );
     }
-    return new IrcServer(domain, extend(true, defaultServerConfig, serverConfig));
+    return new IrcServer(domain, extend(true, IrcServer.DEFAULT_CONFIG, serverConfig));
 };
 
 module.exports.defaultConfig = function() {
@@ -49,56 +38,6 @@ module.exports.defaultConfig = function() {
         }
     };
 };
-
-module.exports.defaultServerConfig = function() {
-    return {
-        botConfig: {
-            nick: "appservicebot",
-            joinChannelsIfNoUsers: true,
-            enabled: true
-        },
-        privateMessages: {
-            enabled: true,
-            exclude: []
-        },
-        dynamicChannels: {
-            enabled: false,
-            published: true,
-            createAlias: true,
-            joinRule: "public",
-            federate: true,
-            aliasTemplate: "#irc_$SERVER_$CHANNEL",
-            whitelist: [],
-            exclude: []
-        },
-        mappings: {},
-        matrixClients: {
-            userTemplate: "@$SERVER_$NICK",
-            displayName: "$NICK (IRC)"
-        },
-        ircClients: {
-            nickTemplate: "M-$DISPLAY",
-            maxClients: 30,
-            idleTimeout: 172800,
-            allowNickChanges: false
-        },
-        membershipLists: {
-            enabled: false,
-            global: {
-                ircToMatrix: {
-                    initial: false,
-                    incremental: false
-                },
-                matrixToIrc: {
-                    initial: false,
-                    incremental: false
-                }
-            },
-            channels: [],
-            rooms: []
-        }
-    };
-}
 
 module.exports.generateRegistration = Promise.coroutine(function*(reg, config) {
     var asToken;
@@ -130,9 +69,8 @@ module.exports.generateRegistration = Promise.coroutine(function*(reg, config) {
     }
 
     if (!reg.getSenderLocalpart()) {
-        reg.setSenderLocalpart(DEFAULT_LOCALPART);
+        reg.setSenderLocalpart(IrcBridge.DEFAULT_LOCALPART);
     }
-
 
     reg.setHomeserverToken(AppServiceRegistration.generateToken());
     reg.setAppServiceToken(asToken || AppServiceRegistration.generateToken());
@@ -154,6 +92,7 @@ module.exports.generateRegistration = Promise.coroutine(function*(reg, config) {
 });
 
 module.exports.runBridge = Promise.coroutine(function*(port, config, reg) {
+    // configure global stuff for the process
     if (config.ircService.logging) {
         logging.configure(config.ircService.logging);
         logging.setUncaughtExceptionLogger(log);
@@ -166,101 +105,11 @@ module.exports.runBridge = Promise.coroutine(function*(port, config, reg) {
         ident.run();
     }
 
-    yield store.connectToDatabase(config.ircService.databaseUri);
-    // blow away all the previous configuration mappings, we're setting new ones now.
-    yield store.rooms.removeConfigMappings();
-
-    let servers = [];
-    let serverDomains = Object.keys(config.ircService.servers);
-    for (var i = 0; i < serverDomains.length; i++) {
-        let domain = serverDomains[i];
-        let server = _toServer(domain, config.ircService.servers[domain]);
-        yield store.setServerFromConfig(server, config.ircService.servers[domain]);
-        servers.push(server);
+    if (config.appService && !config.homeserver) {
+        config.homeserver = config.appService.homeserver;
     }
 
-    if (servers.length === 0) {
-        throw new Error("No servers specified.");
-    }
-
-
-    // configure IRC side
-    ircLib.registerHooks({
-        onMessage: ircToMatrix.onMessage,
-        onPrivateMessage: ircToMatrix.onPrivateMessage,
-        onJoin: ircToMatrix.onJoin,
-        onPart: ircToMatrix.onPart,
-        onMode: ircToMatrix.onMode
-    });
-    ircLib.setServers(servers);
-    names.initQueue();
-
-
-    // configure Matrix side
-    var appService = new AppService({
-        homeserverToken: reg.getHomeserverToken()
-    });
-    appService.on("http-log", function(logLine) {
-        log.info(logLine.replace(/\n/g, " "));
-    });
-    appService.on("type:m.room.message", matrixToIrc.onMessage);
-    appService.on("type:m.room.topic", matrixToIrc.onMessage);
-    appService.on("type:m.room.member", function(event) {
-        if (!event.content || !event.content.membership) {
-            return Promise.resolve();
-        }
-        var target = new MatrixUser(event.state_key, null, null);
-        var sender = new MatrixUser(event.user_id, null, null);
-        if (event.content.membership === "invite") {
-            return matrixToIrc.onInvite(event, sender, target);
-        }
-        else if (event.content.membership === "join") {
-            return matrixToIrc.onJoin(event, target);
-        }
-        else if (["ban", "leave"].indexOf(event.content.membership) !== -1) {
-            return matrixToIrc.onLeave(event, target);
-        }
-    });
-    appService.onUserQuery = matrixToIrc.onUserQuery;
-    appService.onAliasQuery = matrixToIrc.onAliasQuery;
-
-    if (config.appService) {
-        console.warn(
-            `[DEPRECATED] Use of config field 'appService' is deprecated. Remove this
-            field from the config file to remove this warning.
-
-            This release will use values from this config file. This will produce
-            a fatal error in a later release.`
-        );
-        matrixLib.setMatrixClientConfig({
-            baseUrl: config.appService.homeserver.url,
-            accessToken: config.appService.appservice.token,
-            domain: config.appService.homeserver.domain,
-            localpart: config.appService.localpart || DEFAULT_LOCALPART
-        });
-    }
-    else {
-        if (!reg.getSenderLocalpart() || !reg.getAppServiceToken()) {
-            throw new Error(
-                "FATAL: Registration file is missing a sender_localpart and/or AS token."
-            );
-        }
-        matrixLib.setMatrixClientConfig({
-            baseUrl: config.homeserver.url,
-            accessToken: reg.getAppServiceToken(),
-            domain: config.homeserver.domain,
-            localpart: reg.getSenderLocalpart()
-        });
-    }
-
-    // Start things
-    log.info("Joining mapped Matrix rooms...");
-    yield matrixLib.joinMappedRooms();
-    log.info("Connecting to IRC networks...");
-    yield ircLib.connect();
-    log.info("Syncing relevant membership lists...");
-    servers.forEach(function(server) {
-        membershiplists.sync(server);
-    });
-    appService.listen(port);
+    // run the bridge
+    var ircBridge = new IrcBridge(config, reg);
+    yield ircBridge.run(port);
 });

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "jayschema": "^0.3.1",
     "js-yaml": "^3.2.7",
     "matrix-appservice": "^0.2.3",
-    "matrix-appservice-bridge": "^0.1.3",
+    "matrix-appservice-bridge": "^0.1.4",
     "matrix-js-sdk": "0.3.0",
     "nedb": "^1.1.2",
     "nopt": "^3.0.1",

--- a/spec/integ/dynamic-channels.spec.js
+++ b/spec/integ/dynamic-channels.spec.js
@@ -306,7 +306,7 @@ describe("Dynamic channels (disabled)", function() {
             return Promise.resolve({});
         });
 
-        env.mockAppService._queryAlias(tAlias).catch(function() {
+        env.mockAppService._queryAlias(tAlias).done(function() {
             expect(joinedIrcChannel).toBe(false, "Joined channel by alias");
             done();
         });

--- a/spec/util/app-service-mock.js
+++ b/spec/util/app-service-mock.js
@@ -17,6 +17,11 @@ MockAppService.prototype._trigger = function(eventType, content) {
     var promises = listeners.map(function(l) {
         return l(content);
     });
+
+    if (eventType.indexOf("type:") === 0) {
+        promises = promises.concat(this._trigger("event", content));
+    }
+
     if (promises.length === 1) {
         return promises[0];
     }
@@ -27,14 +32,18 @@ MockAppService.prototype._queryAlias = function(alias) {
     if (!this.onAliasQuery) {
         throw new Error("IRC AS hasn't hooked into onAliasQuery yet.");
     }
-    return this.onAliasQuery(alias);
+    return this.onAliasQuery(alias).catch(function(err) {
+        console.error("onAliasQuery threw => %s", err);
+    });
 };
 
 MockAppService.prototype._queryUser = function(user) {
     if (!this.onUserQuery) {
         throw new Error("IRC AS hasn't hooked into onUserQuery yet.");
     }
-    return this.onUserQuery(user);
+    return this.onUserQuery(user).catch(function(err) {
+        console.error("onUserQuery threw => %s", err);
+    });
 };
 
 function MockAppServiceProxy() {

--- a/spec/util/test.js
+++ b/spec/util/test.js
@@ -73,7 +73,8 @@ module.exports.beforeEach = function(testCase, env) {
         env.clientMock._reset();
         env.main = proxyquire("../../lib/main.js", {
             "matrix-appservice": {
-                AppService: MockAppService
+                AppService: MockAppService,
+                "@global": true
             },
             "matrix-js-sdk": env.clientMock,
             "irc": env.ircMock


### PR DESCRIPTION
This PR basically takes a bunch of code from `main.js` and shoves it in a new file which can be instanced(ish). There's still a lot wrong with it, but this is a good stopping point to prevent the diff getting too bad.

Notably, it finally makes a `Bridge` from `matrix-appservice-bridge`. This is then injected via proxyquire for tests (so it's actually also executing `matrix-appservice-bridge` code, which has subtly different semantics wrt return values, hence functional changes on tests).

The roadmap for finishing this off:
 - Remove `models/requests.js` - We can use the bridge implementation now.
 - Remove `mxlib` entirely - We can use `Intent` and `ClientFactory` from the bridge lib now.
 - Remove `models/users.js` and `models.rooms.js` - We can replace them with bridge-classes for users and rooms respectively.
 - Finally, replace `store.js` and point the bridge impl at the real thing (we currently have 2 stores side-by-side as of this PR, the bridge one is unused).

Once that is done, the IRC AS will "officially" be using `matrix-appservice-bridge` in its entirety. At this point we could possibly do a release to `master` since the churn will have stopped. We can then:
 - Persist nicks
 - Persist IPv6 addresses
 - Fix error semantics (`throw`ing actual `Error` objects)
 - etc...