### PR TITLE
Escape HTML entities when sending IRC -> Matrix

### DIFF
--- a/lib/irclib/formatting.js
+++ b/lib/irclib/formatting.js
@@ -33,6 +33,22 @@ var STYLE_UNDERLINE = '\u001f';
 var STYLE_CODES = [STYLE_BOLD, STYLE_ITALICS, STYLE_UNDERLINE];
 var RESET_CODE = '\u000f';
 
+function escapeHtmlChars(text) {
+    return text
+         .replace(/&/g, "&amp;")
+         .replace(/</g, "&lt;")
+         .replace(/>/g, "&gt;")
+         .replace(/"/g, "&quot;")
+         .replace(/'/g, "&#39;"); // to work on HTML4 (&apos; is HTML5 only)
+}
+
+module.exports.stripIrcFormatting = function(text) {
+    // strip colors
+    return text.replace(/(\x03\d{0,2}(,\d{0,2})?|\u200B)/g, '').replace(
+        /[\x0F\x02\x16\x1F]/g, '' // styles too
+    );
+};
+
 module.exports.htmlToIrc = function(html) {
     if (!html) {
         return html;
@@ -121,6 +137,8 @@ module.exports.htmlToIrc = function(html) {
 };
 
 module.exports.ircToHtml = function(text) {
+    text = escapeHtmlChars(text);
+
     // Color codes look like 003xx or 003xx,yy (xx=foreground, yy=background)
     // We want to match until it hits another color (starting 003) or hits the
     // reset code 000f. That is the 'end tag', represented as a non-greedy match

--- a/lib/irclib/formatting.js
+++ b/lib/irclib/formatting.js
@@ -43,10 +43,9 @@ function escapeHtmlChars(text) {
 }
 
 module.exports.stripIrcFormatting = function(text) {
-    // strip colors
-    return text.replace(/(\x03\d{0,2}(,\d{0,2})?|\u200B)/g, '').replace(
-        /[\x0F\x02\x16\x1F]/g, '' // styles too
-    );
+    return text
+        .replace(/(\x03\d{0,2}(,\d{0,2})?|\u200B)/g, '') // strip colors
+        .replace(/[\x0F\x02\x16\x1F]/g, ''); // styles too
 };
 
 module.exports.htmlToIrc = function(html) {

--- a/lib/models/actions.js
+++ b/lib/models/actions.js
@@ -122,7 +122,10 @@ module.exports.toMatrix = function(action) {
             opts = {
                 body: action.text
             };
+            // TODO: This does mean anything with < > ' " will be sent as HTML
+            // which isn't ideal.
             if (fmtText !== action.text) {
+                opts.body = ircFormatting.stripIrcFormatting(action.text);
                 opts.htmlBody = fmtText;
             }
             break;

--- a/lib/mxlib/matrix.js
+++ b/lib/mxlib/matrix.js
@@ -221,7 +221,7 @@ MatrixLib.prototype.sendAction = function(room, from, action) {
     if (actionToMsgtypes[action.action]) {
         var msgtype = actionToMsgtypes[action.action];
         if (action.htmlBody) {
-            return sendHtml(this, room, from, msgtype, action.htmlBody);
+            return sendHtml(this, room, from, msgtype, action.htmlBody, action.body);
         }
         return sendMessage(this, room, from, msgtype, action.body);
     }
@@ -367,9 +367,9 @@ function sendMessage(lib, room, from, msgtype, text) {
     return sendMessageEvent(lib, room, from, content);
 }
 
-function sendHtml(lib, room, from, msgtype, html) {
+function sendHtml(lib, room, from, msgtype, html, fallback) {
     msgtype = msgtype || "m.text";
-    var fallback = html.replace(stripHtmlTags, "");
+    fallback = fallback || html.replace(stripHtmlTags, "");
     var content = {
         msgtype: msgtype,
         body: fallback,


### PR DESCRIPTION
This prevents munging occurring between IRC formatting and textual < element >
references, whereby if you sent a tag and some colour codes from IRC it would
not escape the tag and therefore send invalid HTML to Matrix.

Added integration test for this case.