### PR TITLE
Make membershiplists.js not be a singleton

### DIFF
--- a/lib/bridge/instance.js
+++ b/lib/bridge/instance.js
@@ -6,7 +6,7 @@ var extend = require("extend");
 var store = require("../store");
 var ircToMatrix = require("./irc-to-matrix.js");
 var matrixToIrc = require("./matrix-to-irc.js");
-var membershiplists = require("./membershiplists.js");
+var MemberListSyncer = require("./membershiplists.js");
 var ircLib = require("../irclib/irc.js");
 var names = require("../irclib/names.js");
 var IrcServer = require("../irclib/server.js").IrcServer;
@@ -27,6 +27,9 @@ function IrcBridge(config, registration) {
     this.registration = registration;
     this.ircServers = [];
     this.bridge = null; // Bridge
+    this.memberListSyncers = {
+    //  domain: MemberListSyncer
+    };
 }
 
 IrcBridge.prototype.run = Promise.coroutine(function*(port) {
@@ -80,11 +83,11 @@ IrcBridge.prototype.run = Promise.coroutine(function*(port) {
     yield this.bridge.run(port);
     this.bridge.getRequestFactory().addDefaultTimeoutCallback((req) => {
         this.onLog("[" + req.getId() + "] DELAYED (" + req.getDuration() + "ms)");
-        stats.request(req.isFromIrc, "delay", delta);
+        stats.request(req.isFromIrc, "delay", req.getDuration());
     }, DELAY_TIME_MS);
     this.bridge.getRequestFactory().addDefaultTimeoutCallback((req) => {
         this.onLog("[" + req.getId() + "] DEAD (" + req.getDuration() + "ms)");
-        stats.request(req.isFromIrc, "fail", delta);
+        stats.request(req.isFromIrc, "fail", req.getDuration());
     }, DEAD_TIME_MS);
     this.bridge.getRequestFactory().addDefaultResolveCallback((req) => {
         stats.request(req.isFromIrc, "success", req.getDuration());
@@ -133,8 +136,31 @@ IrcBridge.prototype.run = Promise.coroutine(function*(port) {
     log.info("Connecting to IRC networks...");
     yield ircLib.connect();
     log.info("Syncing relevant membership lists...");
-    this.ircServers.forEach(function(server) {
-        membershiplists.sync(server);
+    let appServiceUserId = (
+        "@" + this.registration.getSenderLocalpart() + ":" +
+        this.config.homeserver.domain
+    );
+    this.ircServers.forEach((server) => {
+        this.memberListSyncers[server.domain] = new MemberListSyncer(
+            server, appServiceUserId, matrixLib.getMatrixLibFor(),
+            (roomId, joiningUserId) => {
+                var req = new BridgeRequest(
+                    this.bridge.getRequestFactory().newRequest(), false
+                );
+                var target = new MatrixUser(joiningUserId, null, null);
+                return matrixToIrc.onJoin.bind(this)(req, {
+                    event_id: "$fake:membershiplist",
+                    room_id: roomId,
+                    state_key: joiningUserId,
+                    user_id: joiningUserId,
+                    content: {
+                        membership: "join"
+                    },
+                    _injected: true
+                }, target);
+            }
+        );
+        this.memberListSyncers[server.domain].sync();
     });
 });
 
@@ -146,7 +172,7 @@ IrcBridge.prototype._onEvent = Promise.coroutine(function*(baseRequest, context)
     var event = baseRequest.getData();
     var request = new BridgeRequest(baseRequest, false);
     if (event.type === "m.room.message" || event.type === "m.room.topic") {
-        yield matrixToIrc.onMessage(request, event)
+        yield matrixToIrc.onMessage.bind(this)(request, event)
     }
     else if (event.type === "m.room.member") {
         if (!event.content || !event.content.membership) {
@@ -156,13 +182,13 @@ IrcBridge.prototype._onEvent = Promise.coroutine(function*(baseRequest, context)
         var target = new MatrixUser(event.state_key, null, null);
         var sender = new MatrixUser(event.user_id, null, null);
         if (event.content.membership === "invite") {
-            yield matrixToIrc.onInvite(request, event, sender, target);
+            yield matrixToIrc.onInvite.bind(this)(request, event, sender, target);
         }
         else if (event.content.membership === "join") {
-            yield matrixToIrc.onJoin(request, event, target);
+            yield matrixToIrc.onJoin.bind(this)(request, event, target);
         }
         else if (["ban", "leave"].indexOf(event.content.membership) !== -1) {
-            yield matrixToIrc.onLeave(request, event, target);
+            yield matrixToIrc.onLeave.bind(this)(request, event, target);
         }
     }
 });
@@ -170,14 +196,14 @@ IrcBridge.prototype._onEvent = Promise.coroutine(function*(baseRequest, context)
 IrcBridge.prototype.onUserQuery = Promise.coroutine(function*(matrixUser) {
     var baseRequest = this.bridge.getRequestFactory().newRequest();
     var request = new BridgeRequest(baseRequest, false);
-    yield matrixToIrc.onUserQuery(request, matrixUser.userId);
+    yield matrixToIrc.onUserQuery.bind(this)(request, matrixUser.userId);
     return null; // don't provision, we already do atm
 });
 
 IrcBridge.prototype.onAliasQuery = Promise.coroutine(function*(alias, aliasLocalpart) {
     var baseRequest = this.bridge.getRequestFactory().newRequest();
     var request = new BridgeRequest(baseRequest, false);
-    yield matrixToIrc.onAliasQuery(request, alias);
+    yield matrixToIrc.onAliasQuery.bind(this)(request, alias);
     return null; // don't provision, we already do atm
 });
 

--- a/lib/bridge/instance.js
+++ b/lib/bridge/instance.js
@@ -148,6 +148,8 @@ IrcBridge.prototype.run = Promise.coroutine(function*(port) {
                     this.bridge.getRequestFactory().newRequest(), false
                 );
                 var target = new MatrixUser(joiningUserId, null, null);
+                // inject a fake join event which will do M->I connections and
+                // therefore sync the member list
                 return matrixToIrc.onJoin.bind(this)(req, {
                     event_id: "$fake:membershiplist",
                     room_id: roomId,

--- a/lib/bridge/matrix-to-irc.js
+++ b/lib/bridge/matrix-to-irc.js
@@ -1,3 +1,4 @@
+/*eslint no-invalid-this: 0*/
 "use strict";
 
 var Promise = require("bluebird");
@@ -5,7 +6,6 @@ var promiseutil = require("../promiseutil");
 
 var matrixLib = require("../mxlib/matrix");
 var ircLib = require("../irclib/irc");
-var membershiplists = require("./membershiplists");
 var store = require("../store");
 
 var roomModels = require("../models/rooms");
@@ -428,9 +428,14 @@ var _onLeave = Promise.coroutine(function*(req, event, user) {
 
     // =========== Bridge Bot Parting ===========
     // For membership list syncing only
-    ircRooms.forEach(function(ircRoom) {
+    ircRooms.forEach((ircRoom) => {
         if (!ircRoom.server.shouldJoinChannelsIfNoUsers()) {
-            membershiplists.checkBotPartRoom(ircRoom, req);
+            if (ircRoom.server.domain) {
+                // this = IrcBridge
+                this.memberListSyncers[ircRoom.server.domain].checkBotPartRoom(
+                    ircRoom, req
+                );
+            }
         }
     });
 

--- a/lib/bridge/membershiplists.js
+++ b/lib/bridge/membershiplists.js
@@ -1,17 +1,24 @@
+/*eslint no-invalid-this: 0*/ // eslint doesn't understand Promise.coroutine wrapping
+
 // Controls the logic for determining which membership lists should be synced and
 // handles the sequence of events until the lists are in sync.
 "use strict";
 
 var Promise = require("bluebird");
 var promiseutil = require("../promiseutil");
-var matrixToIrc = require("./matrix-to-irc.js");
-var ircLib = require("../irclib/irc.js");
-var matrixLib = require("../mxlib/matrix");
-var MatrixUser = require("../models/users").MatrixUser;
 var store = require("../store");
-var log = require("../logging").get("membershiplists");
+var log = require("../logging").get("MemberListSyncer");
 
-module.exports.sync = function(server) {
+
+function MemberListSyncer(server, appServiceUserId, appServiceMxLib, injectJoinFn) {
+    this.server = server;
+    this.appServiceUserId = appServiceUserId;
+    this.appServiceMxLib = appServiceMxLib;
+    this.injectJoinFn = injectJoinFn;
+}
+
+MemberListSyncer.prototype.sync = Promise.coroutine(function*() {
+    let server = this.server;
     if (!server.isMembershipListsEnabled()) {
         log.info("%s does not have membership list syncing enabled.", server.domain);
         return;
@@ -21,133 +28,112 @@ module.exports.sync = function(server) {
         return;
     }
     log.info("Checking membership lists for syncing on %s", server.domain);
-    var start = Date.now();
-    var rooms;
-    getSyncableRooms(server).then(function(syncRooms) {
-        rooms = syncRooms;
-        log.info("Found %s syncable rooms (%sms)", rooms.length, Date.now() - start);
-        start = Date.now();
-        log.info("Joining Matrix users to IRC channels...");
-        return joinMatrixUsersToChannels(rooms, server);
-    }).then(function() {
-        log.info("Joined Matrix users to IRC channels. (%sms)", Date.now() - start);
-        // NB: We do not need to explicitly join IRC users to Matrix rooms
-        // because we get all of the NAMEs/JOINs as events when we connect to
-        // the IRC server. This effectively "injects" the list for us.
-        start = Date.now();
-        log.info("Leaving IRC users from Matrix rooms (cleanup)...");
-        return leaveIrcUsersFromRooms(rooms, server);
-    }).done(function() {
-        log.info("Left IRC users from Matrix rooms. (%sms)", Date.now() - start);
-    }, function(err) {
-        log.error("Failed to sync membership lists: %s", err);
-    });
-};
+    let start = Date.now();
+    let rooms = yield this._getSyncableRooms(server);
+    log.info("Found %s syncable rooms (%sms)", rooms.length, Date.now() - start);
+    start = Date.now();
+    log.info("Joining Matrix users to IRC channels...");
+    yield joinMatrixUsersToChannels(rooms, server, this.injectJoinFn);
+    log.info("Joined Matrix users to IRC channels. (%sms)", Date.now() - start);
+    // NB: We do not need to explicitly join IRC users to Matrix rooms
+    // because we get all of the NAMEs/JOINs as events when we connect to
+    // the IRC server. This effectively "injects" the list for us.
+    start = Date.now();
+    log.info("Leaving IRC users from Matrix rooms (cleanup)...");
+    yield leaveIrcUsersFromRooms(rooms, server);
+    log.info("Left IRC users from Matrix rooms. (%sms)", Date.now() - start);
+});
 
-module.exports.getChannelsToJoin = function(server) {
+MemberListSyncer.prototype.getChannelsToJoin = Promise.coroutine(function*() {
+    let server = this.server;
     log.debug("getChannelsToJoin => %s", server.domain);
-    var defer = promiseutil.defer();
+    let rooms = yield this._getSyncableRooms(server);
+
     // map room IDs to channels on this server.
-    getSyncableRooms(server).then(function(rooms) {
-        var promises = [];
-        var channels = {}; // object for set-like semantics.
-        rooms.forEach(function(room) {
-            promises.push(store.rooms.getIrcChannelsForRoomId(room.roomId).then(
-            function(ircRooms) {
-                ircRooms = ircRooms.filter(function(ircRoom) {
-                    return ircRoom.server.domain === server.domain;
-                });
-                ircRooms.forEach(function(ircRoom) {
-                    channels[ircRoom.channel] = true;
-                    log.debug(
-                        "%s should be joined because %s real Matrix users are in room %s",
-                        ircRoom.channel, room.reals.length, room.roomId
-                    );
-                    if (room.reals.length < 5) {
-                        log.debug("These are: %s", JSON.stringify(room.reals));
-                    }
-                });
-            }));
-        });
-        promiseutil.allSettled(promises).then(function() {
-            var chans = Object.keys(channels);
-            log.debug(
-                "getChannelsToJoin => %s should be synced: %s",
-                chans.length, JSON.stringify(chans)
-            );
-            defer.resolve(chans);
+    let channels = new Set();
+    let promises = rooms.map(function(room) {
+        return store.rooms.getIrcChannelsForRoomId(room.roomId).then(function(ircRooms) {
+            ircRooms = ircRooms.filter(function(ircRoom) {
+                return ircRoom.server.domain === server.domain;
+            });
+            ircRooms.forEach(function(ircRoom) {
+                channels.add(ircRoom.channel);
+                log.debug(
+                    "%s should be joined because %s real Matrix users are in room %s",
+                    ircRoom.channel, room.reals.length, room.roomId
+                );
+                if (room.reals.length < 5) {
+                    log.debug("These are: %s", JSON.stringify(room.reals));
+                }
+            });
         });
     });
 
-    return defer.promise;
-};
+    yield promiseutil.allSettled(promises);
 
+    let channelsArray = Array.from(channels);
+    log.debug(
+        "getChannelsToJoin => %s should be synced: %s",
+        channelsArray.length, JSON.stringify(channelsArray)
+    );
+    return channelsArray;
+});
 
 // map irc channel to a list of room IDs. If all of those
 // room IDs have no real users in them, then part the bridge bot too.
-module.exports.checkBotPartRoom = function(ircRoom, req) {
+MemberListSyncer.prototype.checkBotPartRoom = Promise.coroutine(function*(ircRoom, req) {
     if (ircRoom.channel.indexOf("#") !== 0) {
         return; // don't leave PM rooms
     }
-    var irc = ircLib.getIrcLibFor(req);
-    store.rooms.getMatrixRoomsForChannel(ircRoom.server, ircRoom.channel).done(
-    function(matrixRooms) {
-        if (matrixRooms.length === 0) {
-            // no mapped rooms, leave the channel.
-            irc.partBot(ircRoom);
+    let self = this;
+    let ircLib = req.ircLib;
+    let mxLib = req.mxLib;
+    let matrixRooms = yield store.rooms.getMatrixRoomsForChannel(
+        ircRoom.server, ircRoom.channel
+    );
+
+    if (matrixRooms.length === 0) {
+        // no mapped rooms, leave the channel.
+        ircLib.partBot(ircRoom);
+    }
+    else if (matrixRooms.length === 1) {
+        // common case, just hit /state rather than slow /initialSync
+        let roomId = matrixRooms[0].roomId;
+        let res = yield mxLib.roomState(roomId);
+        let data = getRoomMemberData(ircRoom.server, roomId, res, self.appServiceUserId);
+        req.log.debug("%s Matrix users are in room %s", data.reals.length, roomId);
+        if (data.reals.length === 0) {
+            ircLib.partBot(ircRoom);
         }
-        else if (matrixRooms.length === 1) {
-            // common case, just hit /state rather than slow /initialSync
-            var roomId = matrixRooms[0].roomId;
-            var mxLib = matrixLib.getMatrixLibFor(req);
-            mxLib.roomState(roomId).done(function(res) {
-                var data = getRoomMemberData(ircRoom.server, roomId, res);
-                log.debug(
-                    "%s Matrix users are in room %s", data.reals.length, roomId
-                );
-                if (data.reals.length === 0) {
-                    irc.partBot(ircRoom);
+    }
+    else {
+        // hit initial sync to get list
+        let syncableRooms = yield this._getSyncableRooms(ircRoom.server);
+        matrixRooms.forEach(function(matrixRoom) {
+            // if the room isn't in the syncable rooms list, then we part.
+            var shouldPart = true;
+            for (var i = 0; i < syncableRooms.length; i++) {
+                if (syncableRooms[i].roomId === matrixRoom.roomId) {
+                    shouldPart = false;
+                    break;
                 }
-            }, function(err) {
-                log.error("Failed to hit /state for %s", roomId);
-            });
-        }
-        else {
-            // hit initial sync to get list
-            getSyncableRooms(ircRoom.server).done(function(syncableRooms) {
-                matrixRooms.forEach(function(matrixRoom) {
-                    // if the room isn't in the syncable rooms list, then we part.
-                    var shouldPart = true;
-                    for (var i = 0; i < syncableRooms.length; i++) {
-                        if (syncableRooms[i].roomId === matrixRoom.roomId) {
-                            shouldPart = false;
-                            break;
-                        }
-                    }
-                    if (shouldPart) {
-                        irc.partBot(ircRoom);
-                    }
-                });
-            }, function(err) {
-                log.error("Failed to hit /initialSync : %s", err);
-            });
-        }
-    }, function(err) {
-        log.error(
-            "Cannot get matrix rooms for channel %s: %s", ircRoom.channel, err
-        );
-    });
-};
+            }
+            if (shouldPart) {
+                ircLib.partBot(ircRoom);
+            }
+        });
+    }
+});
 
 // grab all rooms the bot knows about which have at least 1 real user in them.
-function getSyncableRooms(server) {
-    var mxLib = matrixLib.getMatrixLibFor();
+MemberListSyncer.prototype._getSyncableRooms = function(server) {
+    let self = this;
     var defer = promiseutil.defer();
     // hit /initialSync on the bot to pull in room state for all rooms.
-    mxLib.initialSync().done(function(res) {
+    this.appServiceMxLib.initialSync().done(function(res) {
         var rooms = res.rooms || [];
         rooms = rooms.map(function(room) {
-            return getRoomMemberData(server, room.room_id, room.state);
+            return getRoomMemberData(server, room.room_id, room.state, self.appServiceUserId);
         });
         // filter out rooms with no real matrix users in them.
         rooms = rooms.filter(function(room) {
@@ -155,11 +141,10 @@ function getSyncableRooms(server) {
         });
         defer.resolve(rooms);
     });
-
     return defer.promise;
-}
+};
 
-function joinMatrixUsersToChannels(rooms, server) {
+function joinMatrixUsersToChannels(rooms, server, injectJoinFn) {
     var d = promiseutil.defer();
 
     // filter out rooms listed in the rules
@@ -215,7 +200,7 @@ function joinMatrixUsersToChannels(rooms, server) {
             "Injecting join event for %s in %s (%s left) is_frontier=%s",
             entry.userId, entry.roomId, entries.length, entry.frontier
         );
-        injectJoinEvent(entry.roomId, entry.userId).finally(function() {
+        injectJoinFn(entry.roomId, entry.userId).finally(function() {
             joinNextUser();
         });
     }
@@ -229,7 +214,7 @@ function leaveIrcUsersFromRooms(rooms, server) {
     return Promise.resolve();
 }
 
-function getRoomMemberData(server, roomId, stateEvents) {
+function getRoomMemberData(server, roomId, stateEvents, appServiceUserId) {
     stateEvents = stateEvents || [];
     var data = {
         roomId: roomId,
@@ -241,7 +226,7 @@ function getRoomMemberData(server, roomId, stateEvents) {
             return;
         }
         var userId = event.state_key;
-        if (userId === matrixLib.getAppServiceUserId()) {
+        if (userId === appServiceUserId) {
             return;
         }
         if (server.claimsUserId(userId)) {
@@ -254,16 +239,4 @@ function getRoomMemberData(server, roomId, stateEvents) {
     return data;
 }
 
-function injectJoinEvent(roomId, userId) {
-    var target = new MatrixUser(userId, null, null);
-    return matrixToIrc.onJoin({
-        event_id: "$fake:membershiplist",
-        room_id: roomId,
-        state_key: userId,
-        user_id: userId,
-        content: {
-            membership: "join"
-        },
-        _injected: true
-    }, target);
-}
+module.exports = MemberListSyncer;

--- a/lib/irclib/irc.js
+++ b/lib/irclib/irc.js
@@ -7,7 +7,6 @@ var Promise = require("bluebird");
 var promiseutil = require("../promiseutil");
 var log = require("../logging").get("irc");
 
-var membershiplists = require("../bridge/membershiplists.js");
 var pool = require("./client-pool");
 var IrcUser = require("../models/users").IrcUser;
 var MatrixUser = require("../models/users").MatrixUser;
@@ -130,7 +129,7 @@ var getChannelsToJoin = function(server) {
     if (server.shouldJoinChannelsIfNoUsers()) {
         return store.rooms.getTrackedChannelsForServer(server.domain);
     }
-    return membershiplists.getChannelsToJoin(server);
+    return globalBridge.memberListSyncers[server.domain].getChannelsToJoin();
 };
 
 var loginToServer = function(server) {


### PR DESCRIPTION
Now it represents a `MemberListSyncer` class. There's a bunch of ming to bind
matrix-to-irc callbacks 'this' value to the `IrcBridge`. This will be much nicer
when matrix-to-irc is de-singleton'd.