### PR TITLE
Fix config being broken with multiple irc servers

### DIFF
--- a/lib/bridge/IrcBridge.js
+++ b/lib/bridge/IrcBridge.js
@@ -120,7 +120,7 @@ IrcBridge.prototype.run = Promise.coroutine(function*(port) {
     for (var i = 0; i < serverDomains.length; i++) {
         let domain = serverDomains[i];
         let completeConfig = extend(
-            true, IrcServer.DEFAULT_CONFIG, this.config.ircService.servers[domain]
+            true, {}, IrcServer.DEFAULT_CONFIG, this.config.ircService.servers[domain]
         );
         let server = new IrcServer(domain, completeConfig);
         // store the config mappings in the DB to keep everything in one place.


### PR DESCRIPTION
The extend module works by doing an in-place replacement on its first argument.

Fixes #26 