### PR TITLE
Improve performance of room store

### DIFF
--- a/lib/DataStore.js
+++ b/lib/DataStore.js
@@ -121,23 +121,21 @@ DataStore.prototype.setPmRoom = function(ircRoom, matrixRoom, userId, virtualUse
 DataStore.prototype.getMatrixPmRoom = function(realUserId, virtualUserId) {
     log.debug("getMatrixPmRoom " + realUserId);
     var linkKey = createPmLinkKey(realUserId, virtualUserId);
-    return this._roomStore.getLinksByKey(linkKey).then(function(links) {
-        if (links.length > 1) {
-            log.error("getMatrixPmRoom found >1 PM rooms for %s", realUserId);
-        }
-        var link = links[0];
-        if (!link) {
+    return this._roomStore.getEntryById(linkKey).then(function(entry) {
+        if (!entry) {
             return null;
         }
-        return new MatrixRoom(link.matrix);
+        return entry.matrix;
     });
 };
 
 DataStore.prototype.getTrackedChannelsForServer = function(ircAddr) {
     log.debug("getTrackedChannelsForServer " + ircAddr);
-    return this._roomStore.getRemoteRooms({ domain: ircAddr }).then((rooms) => {
+    return this._roomStore.getEntriesByRemoteRoomData({ domain: ircAddr }).then(
+    (entries) => {
         var channels = [];
-        rooms.forEach((r) => {
+        entries.forEach((e) => {
+            let r = e.remote;
             let server = this._serverMappings[r.get("domain")];
             if (!server) {
                 return;
@@ -153,18 +151,18 @@ DataStore.prototype.getTrackedChannelsForServer = function(ircAddr) {
 
 DataStore.prototype.getRoomIdsFromConfig = function() {
     log.debug("getRoomIdsFromConfig ");
-    return this._roomStore.getLinksByData({
+    return this._roomStore.getEntriesByMatrixRoomData({
         from_config: true
-    }).then(function(links) {
-        return links.map((link) => {
-            return link.matrix;
+    }).then(function(entries) {
+        return entries.map((e) => {
+            return e.matrix.getId();
         });
     });
 };
 
 DataStore.prototype.removeConfigMappings = function() {
     log.debug("removeConfigMappings ");
-    return this._roomStore.unlinkByData({
+    return this._roomStore.removeEntriesByMatrixRoomData({
         from_config: true
     });
 };
@@ -197,7 +195,18 @@ DataStore.prototype.setIpv6Counter = Promise.coroutine(function*(counter) {
  */
 DataStore.prototype.getAdminRoomById = function(roomId) {
     log.debug("getAdminRoomById " + roomId);
-    return this._roomStore.getMatrixRoom(roomId);
+    return this._roomStore.getEntriesByMatrixId(roomId).then(function(entries) {
+        if (entries.length == 0) {
+            return null;
+        }
+        if (entries.length > 1) {
+            log.error("getAdminRoomById(" + roomId + ") has " + entries.length + " entries");
+        }
+        if (entries[0].matrix.get("admin_id")) {
+            return entries[0].matrix;
+        }
+        return null;
+    });
 };
 
 /**
@@ -209,16 +218,15 @@ DataStore.prototype.getAdminRoomById = function(roomId) {
 DataStore.prototype.storeAdminRoom = function(room, userId) {
     log.info("storeAdminRoom (id=%s, user_id=%s)", room.getId(), userId);
     room.set("admin_id", userId);
-    return this._roomStore.setMatrixRoom(room, {
-        "extras.admin_id": userId
-    })
+    return this._roomStore.upsertEntry({
+        id: "ADMIN_" + userId,
+        matrix: room,
+    });
 };
 
 DataStore.prototype.getAdminRoomByUserId = function(userId) {
     log.debug("getAdminRoomByUserId " + userId);
-    return this._roomStore.getMatrixRoom({
-        "extras.admin_id": userId
-    });
+    return this._roomStore.getEntryById("ADMIN_" + userId);
 };
 
 DataStore.prototype.storeMatrixUser = function(matrixUser) {

--- a/lib/DataStore.js
+++ b/lib/DataStore.js
@@ -43,7 +43,7 @@ function DataStore(userStore, roomStore) {
     }, errLog("remote_id"));
     this._userStore.db.ensureIndex({
         fieldName: "data.localpart",
-        unique: true,
+        unique: false,
         sparse: true
     }, errLog("localpart"))
 }

--- a/lib/DataStore.js
+++ b/lib/DataStore.js
@@ -46,7 +46,7 @@ DataStore.prototype.storeRoom = function(ircRoom, matrixRoom, fromConfig) {
         matrixRoom.getId(), ircRoom.get("domain"), ircRoom.channel, fromConfig);
     return this._roomStore.linkRooms(matrixRoom, ircRoom, {
         from_config: fromConfig
-    });
+    }, createMappingId(matrixRoom.getId(), ircRoom.get("domain"), ircRoom.channel));
 };
 
 /**
@@ -110,12 +110,10 @@ DataStore.prototype.setPmRoom = function(ircRoom, matrixRoom, userId, virtualUse
         matrixRoom.getId(), ircRoom.server.domain, ircRoom.channel, userId,
         virtualUserId);
 
-    var id = createPmId(userId, virtualUserId);
-
     return this._roomStore.linkRooms(matrixRoom, ircRoom, {
         real_user_id: userId,
         virtual_user_id: virtualUserId
-    }, id);
+    }, createPmId(userId, virtualUserId));
 };
 
 DataStore.prototype.getMatrixPmRoom = function(realUserId, virtualUserId) {
@@ -296,11 +294,17 @@ function*(domain, username) {
 });
 
 function createPmId(userId, virtualUserId) {
+    // space as delimiter as none of these IDs allow spaces.
     return "PM_" + userId + " " + virtualUserId; // clobber based on this.
 }
 
 function createAdminId(userId) {
     return "ADMIN_" + userId; // clobber based on this.
+}
+
+function createMappingId(roomId, ircDomain, ircChannel) {
+    // space as delimiter as none of these IDs allow spaces.
+    return roomId + " " + ircDomain + " " + ircChannel; // clobber based on this
 }
 
 module.exports = DataStore;

--- a/lib/DataStore.js
+++ b/lib/DataStore.js
@@ -37,7 +37,6 @@ function DataStore(userStore, roomStore) {
             return;
         }
         log.info("Indexes set on user store");
-        log.info("Indexes: " + require("util").inspect(userStore.db.indexes))
     });
     this._serverMappings = {}; // { domain: IrcServer }
 }

--- a/lib/DataStore.js
+++ b/lib/DataStore.js
@@ -110,18 +110,18 @@ DataStore.prototype.setPmRoom = function(ircRoom, matrixRoom, userId, virtualUse
         matrixRoom.getId(), ircRoom.server.domain, ircRoom.channel, userId,
         virtualUserId);
 
-    var linkKey = createPmLinkKey(userId, virtualUserId);
+    var id = createPmId(userId, virtualUserId);
 
     return this._roomStore.linkRooms(matrixRoom, ircRoom, {
         real_user_id: userId,
         virtual_user_id: virtualUserId
-    }, linkKey);
+    }, id);
 };
 
 DataStore.prototype.getMatrixPmRoom = function(realUserId, virtualUserId) {
     log.debug("getMatrixPmRoom " + realUserId);
-    var linkKey = createPmLinkKey(realUserId, virtualUserId);
-    return this._roomStore.getEntryById(linkKey).then(function(entry) {
+    var id = createPmId(realUserId, virtualUserId);
+    return this._roomStore.getEntryById(id).then(function(entry) {
         if (!entry) {
             return null;
         }
@@ -219,14 +219,14 @@ DataStore.prototype.storeAdminRoom = function(room, userId) {
     log.info("storeAdminRoom (id=%s, user_id=%s)", room.getId(), userId);
     room.set("admin_id", userId);
     return this._roomStore.upsertEntry({
-        id: "ADMIN_" + userId,
+        id: createAdminId(userId),
         matrix: room,
     });
 };
 
 DataStore.prototype.getAdminRoomByUserId = function(userId) {
     log.debug("getAdminRoomByUserId " + userId);
-    return this._roomStore.getEntryById("ADMIN_" + userId);
+    return this._roomStore.getEntryById(createAdminId(userId));
 };
 
 DataStore.prototype.storeMatrixUser = function(matrixUser) {
@@ -295,8 +295,12 @@ function*(domain, username) {
     return matrixUsers[0];
 });
 
-function createPmLinkKey(userId, virtualUserId) {
-    return "PM " + userId + " " + virtualUserId; // clobber based on this.
+function createPmId(userId, virtualUserId) {
+    return "PM_" + userId + " " + virtualUserId; // clobber based on this.
+}
+
+function createAdminId(userId) {
+    return "ADMIN_" + userId; // clobber based on this.
 }
 
 module.exports = DataStore;

--- a/lib/DataStore.js
+++ b/lib/DataStore.js
@@ -14,6 +14,38 @@ function DataStore(userStore, roomStore) {
     this._roomStore = roomStore;
     this._userStore = userStore;
     this._serverMappings = {}; // { domain: IrcServer }
+
+    var errLog = function(fieldName) {
+        return function(err) {
+            if (err) {
+                log.error("Failed to ensure '%s' index on store: " + err, fieldName);
+                return;
+            }
+            log.info("Indexes checked on '%s' for store.", fieldName);
+        };
+    };
+
+    // add some indexes
+    this._roomStore.db.ensureIndex({
+        fieldName: "id",
+        unique: true,
+        sparse: false
+    }, errLog("id"));
+    this._roomStore.db.ensureIndex({
+        fieldName: "matrix_id",
+        unique: false,
+        sparse: true
+    }, errLog("matrix_id"));
+    this._roomStore.db.ensureIndex({
+        fieldName: "remote_id",
+        unique: false,
+        sparse: true
+    }, errLog("remote_id"));
+    this._userStore.db.ensureIndex({
+        fieldName: "data.localpart",
+        unique: true,
+        sparse: true
+    }, errLog("localpart"))
 }
 
 DataStore.prototype.setServerFromConfig = Promise.coroutine(function*(server, serverConfig) {

--- a/lib/DataStore.js
+++ b/lib/DataStore.js
@@ -123,6 +123,7 @@ DataStore.prototype.getIrcChannelsForRoomId = function(roomId) {
  * room ID to an array of IRC rooms.
  */
 DataStore.prototype.getIrcChannelsForRoomIds = function(roomIds) {
+    log.debug("getIrcChannelsForRoomIds " + JSON.stringify(roomIds));
     return this._roomStore.batchGetLinkedRemoteRooms(roomIds).then((roomIdToRemoteRooms) => {
         Object.keys(roomIdToRemoteRooms).forEach((roomId) => {
             // filter out rooms with unknown IRC servers and

--- a/lib/DataStore.js
+++ b/lib/DataStore.js
@@ -13,54 +13,6 @@ var log = require("./logging").get("DataStore");
 function DataStore(userStore, roomStore) {
     this._roomStore = roomStore;
     this._userStore = userStore;
-    // Make indexes - slightly hacky because we're indexing on a shared ID namespace
-    // (IRC/Matrix) AND enforcing uniqueness, whereas technically uniqueness is a tuple
-    // of (type, id) - but we happen to know that this is safe to do.
-    this._roomStore.db.ensureIndex({
-        fieldName: "id",
-        unique: true,
-        sparse: true // don't index documents for which the field is not defined (e.g. union types)
-    }, function(err) {
-        if (err) {
-            log.error("Failed to ensure index on room store: ", err);
-            return;
-        }
-        log.info("Indexes set on room store");
-    });
-    this._userStore.db.ensureIndex({
-        fieldName: "id",
-        unique: true,
-        sparse: true // don't index documents for which the field is not defined (e.g. union types)
-    }, function(err) {
-        if (err) {
-            log.error("Failed to ensure index on user store: ", err);
-            return;
-        }
-        log.info("Indexes set on user store");
-    });
-    // also index the link key for union types
-    this._roomStore.db.ensureIndex({
-        fieldName: "link_key",
-        unique: true,
-        sparse: true // don't index documents for which the field is undefined (matrix/remote types)
-    }, function(err) {
-        if (err) {
-            log.error("Failed to ensure link_key index on room store: ", err);
-            return;
-        }
-        log.info("link_key Indexes set on room store");
-    });
-    this._userStore.db.ensureIndex({
-        fieldName: "link_key",
-        unique: true,
-        sparse: true // don't index documents for which the field is undefined (matrix/remote types)
-    }, function(err) {
-        if (err) {
-            log.error("Failed to ensure link_key index on user store: ", err);
-            return;
-        }
-        log.info("link_key Indexes set on user store");
-    });
     this._serverMappings = {}; // { domain: IrcServer }
 }
 

--- a/lib/DataStore.js
+++ b/lib/DataStore.js
@@ -256,7 +256,12 @@ DataStore.prototype.storeAdminRoom = function(room, userId) {
 
 DataStore.prototype.getAdminRoomByUserId = function(userId) {
     log.debug("getAdminRoomByUserId " + userId);
-    return this._roomStore.getEntryById(createAdminId(userId));
+    return this._roomStore.getEntryById(createAdminId(userId)).then(function(entry) {
+        if (!entry) {
+            return null;
+        }
+        return entry.matrix;
+    });
 };
 
 DataStore.prototype.storeMatrixUser = function(matrixUser) {

--- a/lib/DataStore.js
+++ b/lib/DataStore.js
@@ -45,7 +45,12 @@ function DataStore(userStore, roomStore) {
         fieldName: "data.localpart",
         unique: false,
         sparse: true
-    }, errLog("localpart"))
+    }, errLog("localpart"));
+    this._userStore.db.ensureIndex({
+        fieldName: "id",
+        unique: true,
+        sparse: false
+    }, errLog("user id"));
 }
 
 DataStore.prototype.setServerFromConfig = Promise.coroutine(function*(server, serverConfig) {

--- a/lib/DataStore.js
+++ b/lib/DataStore.js
@@ -13,6 +13,32 @@ var log = require("./logging").get("DataStore");
 function DataStore(userStore, roomStore) {
     this._roomStore = roomStore;
     this._userStore = userStore;
+    // Make indexes - slightly hacky because we're indexing on a shared ID namespace (IRC/Matrix) AND enforcing
+    // uniqueness, whereas technically uniqueness is a tuple of (type, id) - but we happen to know that this is
+    // safe to do.
+    this._roomStore.db.ensureIndex({
+        fieldName: "id",
+        unique: true,
+        sparse: true // don't index documents for which the field is not defined (e.g. union types)
+    }, function(err) {
+        if (err) {
+            log.error("Failed to ensure index on room store: ", err);
+            return;
+        }
+        log.info("Indexes set on room store");
+    });
+    this._userStore.db.ensureIndex({
+        fieldName: "id",
+        unique: true,
+        sparse: true // don't index documents for which the field is not defined (e.g. union types)
+    }, function(err) {
+        if (err) {
+            log.error("Failed to ensure index on user store: ", err);
+            return;
+        }
+        log.info("Indexes set on user store");
+        log.info("Indexes: " + require("util").inspect(userStore.db.indexes))
+    });
     this._serverMappings = {}; // { domain: IrcServer }
 }
 

--- a/lib/DataStore.js
+++ b/lib/DataStore.js
@@ -38,6 +38,29 @@ function DataStore(userStore, roomStore) {
         }
         log.info("Indexes set on user store");
     });
+    // also index the link key for union types
+    this._roomStore.db.ensureIndex({
+        fieldName: "link_key",
+        unique: true,
+        sparse: true // don't index documents for which the field is not defined (e.g. matrix/remote types)
+    }, function(err) {
+        if (err) {
+            log.error("Failed to ensure link_key index on room store: ", err);
+            return;
+        }
+        log.info("link_key Indexes set on room store");
+    });
+    this._userStore.db.ensureIndex({
+        fieldName: "link_key",
+        unique: true,
+        sparse: true // don't index documents for which the field is not defined (e.g. matrix/remote types)
+    }, function(err) {
+        if (err) {
+            log.error("Failed to ensure link_key index on user store: ", err);
+            return;
+        }
+        log.info("link_key Indexes set on user store");
+    });
     this._serverMappings = {}; // { domain: IrcServer }
 }
 

--- a/lib/DataStore.js
+++ b/lib/DataStore.js
@@ -42,7 +42,7 @@ function DataStore(userStore, roomStore) {
     this._roomStore.db.ensureIndex({
         fieldName: "link_key",
         unique: true,
-        sparse: true // don't index documents for which the field is not defined (e.g. matrix/remote types)
+        sparse: true // don't index documents for which the field is undefined (matrix/remote types)
     }, function(err) {
         if (err) {
             log.error("Failed to ensure link_key index on room store: ", err);
@@ -53,7 +53,7 @@ function DataStore(userStore, roomStore) {
     this._userStore.db.ensureIndex({
         fieldName: "link_key",
         unique: true,
-        sparse: true // don't index documents for which the field is not defined (e.g. matrix/remote types)
+        sparse: true // don't index documents for which the field is undefined (matrix/remote types)
     }, function(err) {
         if (err) {
             log.error("Failed to ensure link_key index on user store: ", err);
@@ -110,6 +110,29 @@ DataStore.prototype.getIrcChannelsForRoomId = function(roomId) {
             let server = this._serverMappings[remoteRoom.get("domain")];
             return IrcRoom.fromRemoteRoom(server, remoteRoom);
         });
+    });
+};
+
+/**
+ * Retrieve a list of IRC rooms for a given list of room IDs. This is significantly
+ * faster than calling getIrcChannelsForRoomId for each room ID.
+ * @param {string[]} roomIds : The room IDs to get mapped IRC channels.
+ * @return {Promise<Map<string, IrcRoom[]>>} A promise which resolves to a map of
+ * room ID to an array of IRC rooms.
+ */
+DataStore.prototype.getIrcChannelsForRoomIds = function(roomIds) {
+    return this._roomStore.batchGetLinkedRemoteRooms(roomIds).then((roomIdToRemoteRooms) => {
+        Object.keys(roomIdToRemoteRooms).forEach((roomId) => {
+            // filter out rooms with unknown IRC servers and
+            // map RemoteRooms to IrcRooms
+            roomIdToRemoteRooms[roomId] = roomIdToRemoteRooms[roomId].filter((remoteRoom) => {
+                return Boolean(this._serverMappings[remoteRoom.get("domain")]);
+            }).map((remoteRoom) => {
+                let server = this._serverMappings[remoteRoom.get("domain")];
+                return IrcRoom.fromRemoteRoom(server, remoteRoom);
+            });
+        });
+        return roomIdToRemoteRooms;
     });
 };
 

--- a/lib/DataStore.js
+++ b/lib/DataStore.js
@@ -13,9 +13,9 @@ var log = require("./logging").get("DataStore");
 function DataStore(userStore, roomStore) {
     this._roomStore = roomStore;
     this._userStore = userStore;
-    // Make indexes - slightly hacky because we're indexing on a shared ID namespace (IRC/Matrix) AND enforcing
-    // uniqueness, whereas technically uniqueness is a tuple of (type, id) - but we happen to know that this is
-    // safe to do.
+    // Make indexes - slightly hacky because we're indexing on a shared ID namespace
+    // (IRC/Matrix) AND enforcing uniqueness, whereas technically uniqueness is a tuple
+    // of (type, id) - but we happen to know that this is safe to do.
     this._roomStore.db.ensureIndex({
         fieldName: "id",
         unique: true,

--- a/lib/bridge/IrcBridge.js
+++ b/lib/bridge/IrcBridge.js
@@ -136,11 +136,13 @@ IrcBridge.prototype.run = Promise.coroutine(function*(port) {
     yield this._bridge.run(port);
     this._bridge.getRequestFactory().addDefaultTimeoutCallback((req) => {
         this.onLog("[" + req.getId() + "] DELAYED (" + req.getDuration() + "ms)");
-        stats.request(req.isFromIrc, "delay", req.getDuration());
+        var isFromIrc = Boolean((req.getData() || {}).isFromIrc);
+        stats.request(isFromIrc, "delay", req.getDuration());
     }, DELAY_TIME_MS);
     this._bridge.getRequestFactory().addDefaultTimeoutCallback((req) => {
         this.onLog("[" + req.getId() + "] DEAD (" + req.getDuration() + "ms)");
-        stats.request(req.isFromIrc, "fail", req.getDuration());
+        var isFromIrc = Boolean((req.getData() || {}).isFromIrc);
+        stats.request(isFromIrc, "fail", req.getDuration());
     }, DEAD_TIME_MS);
     this._bridge.getRequestFactory().addDefaultResolveCallback((req, res) => {
         if (res === BridgeRequest.ERR_VIRTUAL_USER) {
@@ -151,10 +153,12 @@ IrcBridge.prototype.run = Promise.coroutine(function*(port) {
             log.debug("[" + req.getId() + "] IGNORE not mapped");
             return; // these aren't true successes so don't skew graphs
         }
-        stats.request(req.isFromIrc, "success", req.getDuration());
+        var isFromIrc = Boolean((req.getData() || {}).isFromIrc);
+        stats.request(isFromIrc, "success", req.getDuration());
     });
     this._bridge.getRequestFactory().addDefaultRejectCallback((req) => {
-        stats.request(req.isFromIrc, "fail", req.getDuration());
+        var isFromIrc = Boolean((req.getData() || {}).isFromIrc);
+        stats.request(isFromIrc, "fail", req.getDuration());
     });
 
     if (this.config.appService) {

--- a/lib/bridge/IrcBridge.js
+++ b/lib/bridge/IrcBridge.js
@@ -147,6 +147,10 @@ IrcBridge.prototype.run = Promise.coroutine(function*(port) {
             log.debug("[" + req.getId() + "] IGNORE virtual user");
             return; // these aren't true successes so don't skew graphs
         }
+        else if (res === BridgeRequest.ERR_NOT_MAPPED) {
+            log.debug("[" + req.getId() + "] IGNORE not mapped");
+            return; // these aren't true successes so don't skew graphs
+        }
         stats.request(req.isFromIrc, "success", req.getDuration());
     });
     this._bridge.getRequestFactory().addDefaultRejectCallback((req) => {

--- a/lib/bridge/IrcBridge.js
+++ b/lib/bridge/IrcBridge.js
@@ -454,7 +454,13 @@ IrcBridge.prototype._loginToServer = Promise.coroutine(function*(server) {
         // join a channel every 500ms. We stagger them like this to
         // avoid thundering herds
         setTimeout(function() {
-            bridgedClient.joinChannel(c);
+            // catch this as if this rejects it will hard-crash
+            // since this is a new stack frame which will bubble
+            // up as an uncaught exception.
+            bridgedClient.joinChannel(c).catch((e) => {
+                log.error("Failed to join channel:: %s", c);
+                log.error(e);
+            });
         }, 500 * num);
         num += 1;
     });

--- a/lib/bridge/IrcHandler.js
+++ b/lib/bridge/IrcHandler.js
@@ -147,7 +147,7 @@ IrcHandler.prototype.onJoin = Promise.coroutine(function*(req, server, joiningUs
     let syncType = kind === "names" ? "initial" : "incremental";
     if (!server.shouldSyncMembershipToMatrix(syncType, chan)) {
         req.log.info("IRC onJoin(%s) %s to %s - not syncing.", kind, nick, chan);
-        throw new Error("Server doesn't mirror joins.");
+        return BridgeRequest.ERR_NOT_MAPPED;
     }
 
     req.log.info("onJoin(%s) %s to %s", kind, nick, chan);

--- a/lib/bridge/IrcHandler.js
+++ b/lib/bridge/IrcHandler.js
@@ -204,15 +204,13 @@ IrcHandler.prototype.onPart = Promise.coroutine(function*(req, server, leavingUs
         req.log.info("No mapped matrix rooms for IRC channel %s", chan);
         return;
     }
-    else {
-        stats.membership(true, "part");
-    }
     let promises = matrixRooms.map((room) => {
         req.log.info("Leaving room %s", room.getId());
         return this.ircBridge.getAppServiceBridge().getIntent(
             matrixUser.getId()
         ).leave(room.getId());
     });
+    stats.membership(true, "part");
     yield Promise.all(promises)
 });
 

--- a/lib/bridge/IrcHandler.js
+++ b/lib/bridge/IrcHandler.js
@@ -2,6 +2,7 @@
 "use strict";
 var Promise = require("bluebird");
 
+var stats = require("../config/stats");
 var BridgeRequest = require("../models/BridgeRequest");
 var IrcRoom = require("../models/IrcRoom");
 var MatrixRoom = require("matrix-appservice-bridge").MatrixRoom;
@@ -168,6 +169,9 @@ IrcHandler.prototype.onJoin = Promise.coroutine(function*(req, server, joiningUs
     if (matrixRooms.length === 0) {
         req.log.info("No mapped matrix rooms for IRC channel %s", chan);
     }
+    else {
+        stats.membership(true, "join");
+    }
     yield Promise.all(promises);
 });
 
@@ -199,6 +203,9 @@ IrcHandler.prototype.onPart = Promise.coroutine(function*(req, server, leavingUs
     if (matrixRooms.length === 0) {
         req.log.info("No mapped matrix rooms for IRC channel %s", chan);
         return;
+    }
+    else {
+        stats.membership(true, "part");
     }
     let promises = matrixRooms.map((room) => {
         req.log.info("Leaving room %s", room.getId());

--- a/lib/bridge/MatrixHandler.js
+++ b/lib/bridge/MatrixHandler.js
@@ -2,6 +2,7 @@
 "use strict";
 var Promise = require("bluebird");
 
+var stats = require("../config/stats");
 var MatrixRoom = require("matrix-appservice-bridge").MatrixRoom;
 var IrcRoom = require("../models/IrcRoom");
 var MatrixAction = require("../models/MatrixAction");
@@ -396,6 +397,11 @@ MatrixHandler.prototype._onJoin = Promise.coroutine(function*(req, event, user) 
             yield bridgedClient.joinChannel(room.channel); // join each channel
         })());
     });
+
+    if (promises.length > 0) {
+        stats.membership(false, "join");
+    }
+
     yield Promise.all(promises);
 });
 
@@ -439,6 +445,10 @@ MatrixHandler.prototype._onLeave = Promise.coroutine(function*(req, event, user)
         // leave it; if we aren't joined this will no-op.
         promises.push(client.leaveChannel(ircRoom.channel));
     });
+
+    if (promises.length > 0) {
+        stats.membership(false, "part");
+    }
 
     // =========== Bridge Bot Parting ===========
     // For membership list syncing only

--- a/lib/bridge/MatrixHandler.js
+++ b/lib/bridge/MatrixHandler.js
@@ -381,7 +381,7 @@ MatrixHandler.prototype._onJoin = Promise.coroutine(function*(req, event, user) 
         req.log.info(
             "No tracked channels which mirror joins for this room."
         );
-        return;
+        return BridgeRequest.ERR_NOT_MAPPED;
     }
 
     // for each room (which may be on different servers)
@@ -398,10 +398,13 @@ MatrixHandler.prototype._onJoin = Promise.coroutine(function*(req, event, user) 
         })());
     });
 
-    if (promises.length > 0) {
-        stats.membership(false, "join");
+    // We know ircRooms.length > 1. The only time when this isn't mapped into a Promise
+    // is when there is a virtual user: TODO: clean this up! Control flow is hard.
+    if (promises.length === 0) {
+        return BridgeRequest.ERR_VIRTUAL_USER;
     }
 
+    stats.membership(false, "join");
     yield Promise.all(promises);
 });
 
@@ -446,8 +449,8 @@ MatrixHandler.prototype._onLeave = Promise.coroutine(function*(req, event, user)
         promises.push(client.leaveChannel(ircRoom.channel));
     });
 
-    if (promises.length > 0) {
-        stats.membership(false, "part");
+    if (promises.length === 0) { // no connected clients
+        return BridgeRequest.ERR_VIRTUAL_USER;
     }
 
     // =========== Bridge Bot Parting ===========
@@ -466,7 +469,7 @@ MatrixHandler.prototype._onLeave = Promise.coroutine(function*(req, event, user)
             }
         }
     });
-
+    stats.membership(false, "part");
     yield Promise.all(promises);
 });
 
@@ -572,6 +575,12 @@ MatrixHandler.prototype._onMessage = Promise.coroutine(function*(req, event) {
             })());
         }
     });
+
+    // We know ircRooms.length > 1, and the only time when a promise is NOT made
+    // is when it's a virtual user. TODO: Tidy up control flow here.
+    if (promises.length === 0) {
+        return BridgeRequest.ERR_VIRTUAL_USER;
+    }
 
     yield Promise.all(promises);
 });

--- a/lib/bridge/MatrixHandler.js
+++ b/lib/bridge/MatrixHandler.js
@@ -443,6 +443,10 @@ MatrixHandler.prototype._onLeave = Promise.coroutine(function*(req, event, user)
     // =========== Bridge Bot Parting ===========
     // For membership list syncing only
     ircRooms.forEach((ircRoom) => {
+        let client = serverLookup[ircRoom.server.domain];
+        if (!client) {
+            return; // no client left the room, so no need to recheck part room.
+        }
         if (!ircRoom.server.shouldJoinChannelsIfNoUsers()) {
             if (ircRoom.server.domain) {
                 // this = IrcBridge

--- a/lib/bridge/MatrixHandler.js
+++ b/lib/bridge/MatrixHandler.js
@@ -393,7 +393,9 @@ MatrixHandler.prototype._onJoin = Promise.coroutine(function*(req, event, user) 
         }
         // get the virtual IRC user for this user
         promises.push(Promise.coroutine(function*() {
-            let bridgedClient = yield self.ircBridge.getBridgedClient(room.server, user.getId());
+            let bridgedClient = yield self.ircBridge.getBridgedClient(
+                room.server, user.getId(), (event.content || {}).displayname
+            );
             yield bridgedClient.joinChannel(room.channel); // join each channel
         })());
     });

--- a/lib/bridge/MemberListSyncer.js
+++ b/lib/bridge/MemberListSyncer.js
@@ -17,6 +17,7 @@ function MemberListSyncer(ircBridge, appServiceBot, server, appServiceUserId, in
     this.server = server;
     this.appServiceUserId = appServiceUserId;
     this.injectJoinFn = injectJoinFn;
+    this._syncableRoomsPromise = null;
 }
 
 MemberListSyncer.prototype.sync = Promise.coroutine(function*() {
@@ -108,7 +109,7 @@ MemberListSyncer.prototype.checkBotPartRoom = Promise.coroutine(function*(ircRoo
     }
     else {
         // hit initial sync to get list
-        let syncableRooms = yield this._getSyncableRooms(ircRoom.server);
+        let syncableRooms = yield this._getSyncableRooms(ircRoom.server, true);
         matrixRooms.forEach(function(matrixRoom) {
             // if the room isn't in the syncable rooms list, then we part.
             var shouldPart = true;
@@ -126,9 +127,17 @@ MemberListSyncer.prototype.checkBotPartRoom = Promise.coroutine(function*(ircRoo
 });
 
 // grab all rooms the bot knows about which have at least 1 real user in them.
-MemberListSyncer.prototype._getSyncableRooms = function(server) {
+// ignoreCache exists because this function hammers /initialSync and that is expeeeensive,
+// so we don't do it unless they need absolutely fresh data. On startup, this can be called
+// multiple times, so we cache the first request's promise and return that instead of making
+// double hits.
+MemberListSyncer.prototype._getSyncableRooms = function(server, ignoreCache) {
+    if (!ignoreCache && this._syncableRoomsPromise) {
+        log.debug("Returning existing _getSyncableRooms Promise");
+        return this._syncableRoomsPromise;
+    }
     // hit /initialSync on the bot to pull in room state for all rooms.
-    return this.appServiceBot.getMemberLists().then(function(roomDict) {
+    this._syncableRoomsPromise = this.appServiceBot.getMemberLists().then(function(roomDict) {
         // roomDict = { room_id: RoomInfo }
         return Object.keys(roomDict).map(function(roomId) {
             return roomDict[roomId];
@@ -137,6 +146,7 @@ MemberListSyncer.prototype._getSyncableRooms = function(server) {
             return roomInfo.realJoinedUsers.length > 0;
         });
     });
+    return this._syncableRoomsPromise;
 };
 
 function joinMatrixUsersToChannels(rooms, server, injectJoinFn) {

--- a/lib/bridge/MemberListSyncer.js
+++ b/lib/bridge/MemberListSyncer.js
@@ -54,26 +54,29 @@ MemberListSyncer.prototype.getChannelsToJoin = Promise.coroutine(function*() {
 
     // map room IDs to channels on this server.
     let channels = new Set();
-    let promises = rooms.map((roomInfo) => {
-        return this.ircBridge.getStore().getIrcChannelsForRoomId(roomInfo.id).then(
-        function(ircRooms) {
-            ircRooms = ircRooms.filter(function(ircRoom) {
+    let roomInfoMap = {};
+    let roomIds = rooms.map((roomInfo) => {
+        roomInfoMap[roomInfo.id] = roomInfo;
+        return roomInfo.id;
+    });
+    yield this.ircBridge.getStore().getIrcChannelsForRoomIds(roomIds).then((roomIdToIrcRoom) => {
+        Object.keys(roomIdToIrcRoom).forEach((roomId) => {
+            // only interested in rooms for this server
+            let ircRooms = roomIdToIrcRoom[roomId].filter((ircRoom) => {
                 return ircRoom.server.domain === server.domain;
             });
-            ircRooms.forEach(function(ircRoom) {
+            ircRooms.forEach((ircRoom) => {
                 channels.add(ircRoom.channel);
                 log.debug(
                     "%s should be joined because %s real Matrix users are in room %s",
-                    ircRoom.channel, roomInfo.realJoinedUsers.length, roomInfo.id
+                    ircRoom.channel, roomInfoMap[roomId].realJoinedUsers.length, roomId
                 );
-                if (roomInfo.realJoinedUsers.length < 5) {
-                    log.debug("These are: %s", JSON.stringify(roomInfo.realJoinedUsers));
+                if (roomInfoMap[roomId].realJoinedUsers.length < 5) {
+                    log.debug("These are: %s", JSON.stringify(roomInfoMap[roomId].realJoinedUsers));
                 }
             });
-        });
+        })
     });
-
-    yield promiseutil.allSettled(promises);
 
     let channelsArray = Array.from(channels);
     log.debug(

--- a/lib/config/stats.js
+++ b/lib/config/stats.js
@@ -67,3 +67,14 @@ module.exports.request = function(isFromIrc, outcome, durationMs) {
         "ms"
     );
 };
+
+module.exports.membership = function(isFromIrc, state) {
+    // ircas.<job_name>.membership.<protocol>.<state>
+    // e.g. ircas.1234.membership.matrix.join
+    var protocol = isFromIrc ? "irc" : "matrix";
+    sendStat(
+        "ircas." + jobName + ".membership." + protocol + "." + state,
+        1,
+        "c"
+    );
+};

--- a/lib/irc/IrcEventBroker.js
+++ b/lib/irc/IrcEventBroker.js
@@ -229,7 +229,11 @@ IrcEventBroker.prototype.sendMetadata = function(client, msg) {
         return;
     }
     var req = new BridgeRequest(
-        this._appServiceBridge.getRequestFactory().newRequest(), true
+        this._appServiceBridge.getRequestFactory().newRequest({
+            data: {
+                isFromIrc: true
+            }
+        })
     );
     complete(req, this._ircHandler.onMetadata(req, client, msg));
 };
@@ -247,7 +251,11 @@ IrcEventBroker.prototype.addHooks = function(client, connInst) {
 
     var createRequest = () => {
         return new BridgeRequest(
-            this._appServiceBridge.getRequestFactory().newRequest(), true
+            this._appServiceBridge.getRequestFactory().newRequest({
+                data: {
+                    isFromIrc: true
+                }
+            })
         );
     };
 

--- a/lib/models/BridgeRequest.js
+++ b/lib/models/BridgeRequest.js
@@ -22,5 +22,6 @@ class BridgeRequest {
     }
 }
 BridgeRequest.ERR_VIRTUAL_USER = "virtual-user";
+BridgeRequest.ERR_NOT_MAPPED = "not-mapped";
 
 module.exports = BridgeRequest;

--- a/lib/models/BridgeRequest.js
+++ b/lib/models/BridgeRequest.js
@@ -3,9 +3,9 @@ var logging = require("../logging");
 var log = logging.get("req");
 
 class BridgeRequest {
-    constructor(req, isFromIrc) {
-        this.isFromIrc = isFromIrc;
+    constructor(req) {
         this.req = req;
+        var isFromIrc = req.getData() ? Boolean(req.getData().isFromIrc) : false;
         this.log = logging.newRequestLogger(log, req.getId(), isFromIrc);
     }
 

--- a/lib/models/IrcRoom.js
+++ b/lib/models/IrcRoom.js
@@ -45,9 +45,10 @@ IrcRoom.fromRemoteRoom = function(server, remoteRoom) {
 };
 
 // An IRC room is uniquely identified by a combination of the channel name and the
-// IRC network the channel resides on.
+// IRC network the channel resides on. Space is the delimiter because neither the
+// domain nor the channel allows spaces.
 IrcRoom.createId = function(server, channel) {
-    return server.domain + "_@_" + channel;
+    return server.domain + " " + channel;
 };
 
 module.exports = IrcRoom;

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "irc": "matrix-org/node-irc",
     "jayschema": "^0.3.1",
     "js-yaml": "^3.2.7",
-    "matrix-appservice-bridge": "^0.3.7",
+    "matrix-appservice-bridge": "^1.0.0",
     "nedb": "^1.1.2",
     "nopt": "^3.0.1",
     "request": "^2.54.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "irc": "matrix-org/node-irc",
     "jayschema": "^0.3.1",
     "js-yaml": "^3.2.7",
-    "matrix-appservice-bridge": "^0.3.6",
+    "matrix-appservice-bridge": "^0.3.7",
     "nedb": "^1.1.2",
     "nopt": "^3.0.1",
     "request": "^2.54.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "irc": "matrix-org/node-irc",
     "jayschema": "^0.3.1",
     "js-yaml": "^3.2.7",
-    "matrix-appservice-bridge": "^0.3.5",
+    "matrix-appservice-bridge": "^0.3.6",
     "nedb": "^1.1.2",
     "nopt": "^3.0.1",
     "request": "^2.54.0",

--- a/scripts/upgrade-db-0.2-to-0.3.js
+++ b/scripts/upgrade-db-0.2-to-0.3.js
@@ -1,0 +1,220 @@
+#!/usr/bin/env node
+"use strict";
+
+var Promise = require("bluebird");
+var Datastore = require("nedb");
+Promise.promisifyAll(Datastore.prototype);
+var nopt = require("nopt");
+var path = require("path");
+var fs = require("fs");
+
+const ROOM_DB = "0.3-db/rooms.db";
+const USER_DB = "0.3-db/users.db"
+
+var opts = nopt({
+    "help": Boolean,
+    rooms: path,
+    users: path,
+}, {
+    "h": "--help"
+});
+
+if (!opts.help && (!opts.rooms || !opts.users)) {
+    console.log("--rooms and --users are required.");
+    opts.help = true;
+}
+
+if (opts.help) {
+    console.log(
+`Database Upgrade script (v0.2 => v0.3)
+--------------------------------------
+If you have an existing database from the develop branch (unreleased onto master),
+it will not work with v0.3. To upgrade the database, run this script.
+v0.3-ready database files will be dumped to a directory called "0.3-db" in the
+current working directory.
+
+ Usage:
+   --rooms   The path to rooms.db. Required.
+   --users   The path to users.db. Required.`
+);
+process.exit(0);
+}
+
+
+var upgradeUsers = Promise.coroutine(function*(usersDb) {
+    console.log("Upgrading users database"); // TODO
+});
+
+var upgradeRooms = Promise.coroutine(function*(db) {
+    console.log("Upgrading rooms database");
+    // 0.2 rooms.db =>
+    // CHANNELS
+    // type=matrix, id=<room_id>  data={extras:{}}  -- UNIQUE(id)
+    // type=remote, id=<domain_@_chan> data={domain,channel,type(channel)}  -- UNIQUE(id)
+    // type=union, link_key=<room_id remote_id>, remote_id, matrix_id, data:{from_config}
+    //
+    // ADMIN
+    // type=matrix, id=<room_id> data={extras:{admin_id:<user_id>}}
+    //
+    // PM
+    // type=matrix, id=<room_id>  data={extras:{}}
+    // type=remote, id=<domain_@_nick> data={domain,channel,type(pm)}
+    // type=union, link_key="PM real_user_id virt_user_id", remote_id, matrix_id,
+    //                                                      data={real_user_id, virtual_user_id}
+    //
+    //
+    // 0.3 rooms.db =>
+    // CHANNELS
+    // id=<room_id> <domain> <chan>, remote_id=<domain> <chan>, matrix_id=<room_id>
+    //     remote={domain=<domain>, channel=<channel>, type="channel"}
+    //     matrix={extras={}}
+    //     data={from_config=true|false}
+    //
+    // ADMIN
+    // id=ADMIN_<user_id>, matrix_id=<room_id>, matrix={extras={admin_id=<user_id>}}
+    //
+    // PM
+    // id=PM_<user_id> <virt_user_id>, remote_id=<domain> <nick>, matrix_id=<room_id>
+    //     remote={domain=<domain>, channel=<nick>, type="pm"}
+    //     matrix={extras={}}
+    //     data={real_user_id=<user_id>, virtual_user_id=<virt_user_id>}
+
+    var entries = yield db.findAsync({});
+    var newRoomStore = new Datastore({
+        filename: ROOM_DB,
+        autoload: true
+    });
+    var insertions = {}; // unique based on ID
+    var matrixRooms = {
+        // room_id: {data fields}
+    };
+    var ircChannels = {
+        // domain_@_chan: {data fields}
+    };
+
+    // populate irc/matrix rooms for union types later
+    entries.forEach(function(e) {
+        switch (e.type) {
+            case "matrix":
+                if (matrixRooms[e.id]) {
+                    throw new Error("Duplicate matrix id: " + e.id);
+                }
+                matrixRooms[e.id] = e.data;
+                var data = e.data.extras || {};
+                if (data.admin_id) {
+                    // admin room
+                    var id = "ADMIN_" + data.admin_id;
+                    insertions[id] = {
+                        id: "ADMIN_" + data.admin_id,
+                        matrix_id: e.id,
+                        matrix: e.data
+                    };
+                }
+                break;
+            case "remote":
+                if (ircChannels[e.id]) {
+                    throw new Error("Duplicate remote id: " + e.id);
+                }
+                ircChannels[e.id] = e.data;
+                break;
+        }
+    });
+
+    entries.forEach(function(e) {
+        if (e.type !== "union") {
+            return;
+        }
+        var roomId = e.matrix_id;
+        var matrixData = matrixRooms[roomId];
+        var remoteData = ircChannels[e.remote_id];
+        if (!matrixData || !remoteData) {
+            throw new Error("Missing matrix/remote data for union type: " + JSON.stringify(e));
+        }
+
+        if (e.link_key.indexOf("PM ") === 0) {
+            if (remoteData.type !== "pm") {
+                console.error("Expected remote data type to be 'pm' but was: " + remoteData.type + " entry: " + JSON.stringify(e));
+                return;
+            }
+            var userId = e.data.real_user_id;
+            var virtUserId = e.data.virtual_user_id;
+            var domain = remoteData.domain;
+            var nick = remoteData.channel;
+            var id = "PM_" + userId + " " + virtUserId;
+            insertions[id] = {
+                id: id,
+                remote_id: domain + " " + nick,
+                matrix_id: roomId,
+                remote: remoteData,
+                matrix: matrixData,
+                data: e.data
+            };
+        } else if (e.link_key.indexOf("!") === 0) { // normal channel
+            var domain = remoteData.domain;
+            var channel = remoteData.channel;
+            var id = roomId + " " + domain + " " + channel;
+            var splat = false;
+            insertions[id] = {
+                id: id,
+                remote_id: domain + " " + channel,
+                matrix_id: roomId,
+                remote: remoteData,
+                matrix: matrixData,
+                data: e.data
+            };
+        } else {
+            throw new Error("Unexpected link_key value for union type: " + e.link_key);
+        }
+    });
+
+    var insertList = [];
+    Object.keys(insertions).forEach(function(k) {
+        insertList.push(insertions[k]);
+    });
+
+    yield newRoomStore.insertAsync(insertList);
+
+    // if everything worked we should have globally unique 'id' values and sparse
+    // non-unique matrix_id and remote_id
+    try {
+        yield newRoomStore.ensureIndexAsync({
+            fieldName: "id",
+            unique: true,
+            sparse: false
+        });
+        yield newRoomStore.ensureIndexAsync({
+            fieldName: "matrix_id",
+            unique: false,
+            sparse: true
+        });
+        yield newRoomStore.ensureIndexAsync({
+            fieldName: "remote_id",
+            unique: false,
+            sparse: true
+        });
+    } catch (err) {
+        console.error(JSON.stringify(err));
+    }
+});
+
+Promise.coroutine(function*() {
+    try {
+        fs.mkdirSync("0.3-db");
+    }
+    catch (err) {
+        if (err.code !== "EEXIST") { throw err; }
+        try { fs.unlinkSync(ROOM_DB); } catch (e) {}
+        try { fs.unlinkSync(USER_DB); } catch (e) {}
+    }
+    var userStore = new Datastore({
+        filename: opts.users,
+        autoload: true
+    });
+    yield upgradeUsers(userStore);
+    var roomStore = new Datastore({
+        filename: opts.rooms,
+        autoload: true
+    });
+    yield upgradeRooms(roomStore);
+    console.log("Upgrade complete.");
+})();

--- a/scripts/upgrade-db-0.2-to-0.3.js
+++ b/scripts/upgrade-db-0.2-to-0.3.js
@@ -9,18 +9,16 @@ var path = require("path");
 var fs = require("fs");
 
 const ROOM_DB = "0.3-db/rooms.db";
-const USER_DB = "0.3-db/users.db"
 
 var opts = nopt({
     "help": Boolean,
     rooms: path,
-    users: path,
 }, {
     "h": "--help"
 });
 
-if (!opts.help && (!opts.rooms || !opts.users)) {
-    console.log("--rooms and --users are required.");
+if (!opts.help && !opts.rooms) {
+    console.log("--rooms is required.");
     opts.help = true;
 }
 
@@ -34,16 +32,10 @@ v0.3-ready database files will be dumped to a directory called "0.3-db" in the
 current working directory.
 
  Usage:
-   --rooms   The path to rooms.db. Required.
-   --users   The path to users.db. Required.`
+   --rooms   The path to rooms.db. Required.`
 );
 process.exit(0);
 }
-
-
-var upgradeUsers = Promise.coroutine(function*(usersDb) {
-    console.log("Upgrading users database"); // TODO
-});
 
 var upgradeRooms = Promise.coroutine(function*(db) {
     console.log("Upgrading rooms database");
@@ -204,13 +196,7 @@ Promise.coroutine(function*() {
     catch (err) {
         if (err.code !== "EEXIST") { throw err; }
         try { fs.unlinkSync(ROOM_DB); } catch (e) {}
-        try { fs.unlinkSync(USER_DB); } catch (e) {}
     }
-    var userStore = new Datastore({
-        filename: opts.users,
-        autoload: true
-    });
-    yield upgradeUsers(userStore);
     var roomStore = new Datastore({
         filename: opts.rooms,
         autoload: true

--- a/spec/util/client-sdk-mock.js
+++ b/spec/util/client-sdk-mock.js
@@ -45,15 +45,6 @@ function MockClient(config) {
         return Promise.resolve({});
     });
 
-    // TEMPORARY: FIXME TODO XXX Shim authedRequestWithPrefix calls to /register to register()
-    this._http.authedRequestWithPrefix = jasmine.createSpy("authedRequestWithPrefix");
-    this._http.authedRequestWithPrefix.andCallFake(function(a, method, path, d, data) {
-        if (method === "POST" && path === "/register") {
-            return self.register(data.user);
-        }
-    });
-
-
     // Helper to succeed sdk registration calls.
     this._onHttpRegister = function(params) {
         self.register.andCallFake(function(username, password) {


### PR DESCRIPTION
This is the culmination of https://github.com/matrix-org/matrix-appservice-irc/issues/68 - the following changes have been made:
 - Make the IRC bridge rely on `matrix-appservice-bridge@1.0.0` to pull in the new database format.
 - Add an upgrade script `scripts/upgrade-db-0.2-to-0.3.js` to port over to the new format.
 - Add a batch version of `getLinkedRemoteRooms` to reduce the number of queries at startup.
 - Add indexes on Room Store's `matrix_id`, `remote_id` and User Store's `localpart` to hasten lookups as they are called frequently.
 - Cache the promise for `_getSyncableRooms` to prevent 2x `/initialSync`s being triggered on startup (one to get the list of channels to join, one to inject join events).


This PR also tidies up a lot of metrics and adds a few more:
 - Join/Part metrics for IRC/Matrix are now sent as counters.
 - If a server doesn't mirror joins/parts, it will not treat the joining/parting request as `FAILED`, but instead ignore it (so as to avoid skewing error metrics).
 - Fix a problem where metrics I->M would not be sent.