### PR TITLE
Reject !nick change for some IRC error codes

### DIFF
--- a/lib/bridge/MatrixHandler.js
+++ b/lib/bridge/MatrixHandler.js
@@ -211,7 +211,7 @@ MatrixHandler.prototype._onAdminMessage = Promise.coroutine(function*(req, event
             if (err.stack) {
                 req.log.error(err);
             }
-            let noticeErr = new MatrixAction("notice", JSON.stringify(err));
+            let noticeErr = new MatrixAction("notice", err.message);
             yield this.ircBridge.sendMatrixAction(adminRoom, botUser, noticeErr, req);
             return;
         }

--- a/lib/irc/BridgedClient.js
+++ b/lib/irc/BridgedClient.js
@@ -189,7 +189,7 @@ BridgedClient.prototype.changeNick = function(newNick) {
     // TODO: This is dupe logic with server.js
     // strip illegal chars according to RFC 1459 Sect 2.3.1
     // but allow _ because most IRC servers allow that.
-    var nick = newNick.replace(/[^A-Za-z0-9\]\[\^\\\{\}\-`_]/g, "");
+    var nick = newNick.replace(/[^A-Za-z0-9\]\[\^\\\{\}\-`_\|]/g, "");
     // nicks must start with a letter
     if (!/^[A-Za-z]/.test(nick)) {
         return Promise.reject(

--- a/lib/irc/BridgedClient.js
+++ b/lib/irc/BridgedClient.js
@@ -210,12 +210,29 @@ BridgedClient.prototype.changeNick = function(newNick) {
         return Promise.resolve("Your nick is already '" + nick + "'.");
     }
 
-    var d = promiseutil.defer();
-    this.unsafeClient.once("nick", function(old, n) {
-        d.resolve("Nick changed from '" + old + "' to '" + n + "'.");
+    return new Promise((resolve, reject) => {
+        var nickListener, nickErrListener;
+        nickListener = (old, n) => {
+            this.unsafeClient.removeListener("error", nickErrListener);
+            resolve("Nick changed from '" + old + "' to '" + n + "'.");
+        };
+        nickErrListener = (err) => {
+            if (!err || !err.command) { return; }
+            var failCodes = [
+                "err_banonchan", "err_nickcollision", "err_nicknameinuse",
+                "err_erroneusnickname", "err_nonicknamegiven", "err_eventnickchange",
+                "err_nicktoofast"
+            ];
+            if (failCodes.indexOf(err.command) !== -1) {
+                this.log.error("Nick change error : %s", err.command);
+                this.unsafeClient.removeListener("nick", nickListener);
+                reject(new Error("Failed to change nick: " + err.command));
+            }
+        };
+        this.unsafeClient.once("nick", nickListener);
+        this.unsafeClient.once("error", nickErrListener);
+        this.unsafeClient.send("NICK", nick);
     });
-    this.unsafeClient.send("NICK", nick);
-    return d.promise;
 };
 
 BridgedClient.prototype.joinChannel = function(channel) {

--- a/lib/irc/BridgedClient.js
+++ b/lib/irc/BridgedClient.js
@@ -12,6 +12,7 @@ var log = require("../logging").get("BridgedClient");
 
 // The length of time to wait before trying to join the channel again
 const JOIN_TIMEOUT_MS = 15 * 1000; // 15s
+const NICK_DELAY_TIMER_MS = 10 * 1000; // 10s
 
 /**
  * Create a new bridged IRC client.
@@ -212,7 +213,14 @@ BridgedClient.prototype.changeNick = function(newNick) {
 
     return new Promise((resolve, reject) => {
         var nickListener, nickErrListener;
+        var timeoutId = setTimeout(() => {
+            this.log.error("Timed out trying to change nick to %s", nick);
+            this.unsafeClient.removeListener("nick", nickListener);
+            this.unsafeClient.removeListener("error", nickErrListener);
+            reject(new Error("Timed out waiting for a response to change nick."));
+        }, NICK_DELAY_TIMER_MS);
         nickListener = (old, n) => {
+            clearTimeout(timeoutId);
             this.unsafeClient.removeListener("error", nickErrListener);
             resolve("Nick changed from '" + old + "' to '" + n + "'.");
         };
@@ -225,6 +233,7 @@ BridgedClient.prototype.changeNick = function(newNick) {
             ];
             if (failCodes.indexOf(err.command) !== -1) {
                 this.log.error("Nick change error : %s", err.command);
+                clearTimeout(timeoutId);
                 this.unsafeClient.removeListener("nick", nickListener);
                 reject(new Error("Failed to change nick: " + err.command));
             }

--- a/lib/irc/ConnectionInstance.js
+++ b/lib/irc/ConnectionInstance.js
@@ -124,7 +124,10 @@ ConnectionInstance.prototype._listenForErrors = function() {
             "err_needreggednick", "err_nosuchnick", "err_cannotsendtochan",
             "err_toomanychannels", "err_erroneusnickname", "err_usernotinchannel",
             "err_notonchannel", "err_useronchannel", "err_notregistered",
-            "err_alreadyregistred", "err_noprivileges", "err_chanoprivsneeded"
+            "err_alreadyregistred", "err_noprivileges", "err_chanoprivsneeded",
+            "err_banonchan", "err_nickcollision", "err_nicknameinuse",
+            "err_erroneusnickname", "err_nonicknamegiven", "err_eventnickchange",
+            "err_nicktoofast"
         ];
         if (err && err.command) {
             if (failCodes.indexOf(err.command) !== -1) {

--- a/spec/integ/admin-rooms.spec.js
+++ b/spec/integ/admin-rooms.spec.js
@@ -330,7 +330,6 @@ describe("Admin rooms", function() {
     it("should timeout !nick changes after 10 seconds", function(done) {
         jasmine.Clock.useMock();
         var newNick = "Blurple";
-        var testText = "I don't know what colour I am.";
 
         // make sure that the NICK command is sent
         var sentNickCommand = false;


### PR DESCRIPTION
- Fixes #69 because of - https://github.com/matrix-org/node-irc/commit/e35e49e8f1bd996287c3bd2b1c5f932820691ad3

- Fixes #76

- Fixes #45 as we now handle most (all?) IRC error responses and time out the nick listener after 10s.
