### PR TITLE
Unify nick validation and handle more edge cases

### DIFF
--- a/lib/bridge/IrcBridge.js
+++ b/lib/bridge/IrcBridge.js
@@ -523,30 +523,39 @@ IrcBridge.prototype.partBot = function(ircRoom) {
 
 IrcBridge.prototype.getBridgedClient = Promise.coroutine(function*(server, userId,
                                                          displayName) {
-    var bridgedClient = this.getIrcUserFromCache(server, userId);
+    let bridgedClient = this.getIrcUserFromCache(server, userId);
     if (bridgedClient) {
         log.debug("Returning cached bridged client %s", userId);
         return bridgedClient;
     }
 
-    var nick = server.getNick(userId, displayName);
-    var mxUser = new MatrixUser(userId);
+    let mxUser = new MatrixUser(userId);
     mxUser.setDisplayName(displayName);
-    var ircClientConfig = IrcClientConfig.newConfig(mxUser, server.domain, nick);
-
-    log.debug(
-        "Creating virtual irc user with nick %s for %s (display name %s)",
-        nick, userId, displayName
-    );
-    bridgedClient = this._clientPool.createIrcClient(ircClientConfig, mxUser, false);
 
     // check the database for stored config information for this irc client
     // including username, custom nick, nickserv password, etc.
+    let ircClientConfig = IrcClientConfig.newConfig(
+        mxUser, server.domain, server.getNick(userId, displayName)
+    );
     let storedConfig = yield this.getStore().getIrcClientConfig(userId, server.domain);
     if (storedConfig) {
         log.debug("Configuring IRC user from store => " + storedConfig);
-        bridgedClient.setClientConfig(storedConfig);
+        ircClientConfig = storedConfig;
     }
+
+    // recheck the cache: We just yield'ed to check the client config. We may
+    // be racing with another request to getBridgedClient.
+    bridgedClient = this.getIrcUserFromCache(server, userId);
+    if (bridgedClient) {
+        log.debug("Returning cached bridged client %s", userId);
+        return bridgedClient;
+    }
+
+    log.debug(
+        "Creating virtual irc user with nick %s for %s (display name %s)",
+        ircClientConfig.getDesiredNick(), userId, displayName
+    );
+    bridgedClient = this._clientPool.createIrcClient(ircClientConfig, mxUser, false);
 
     try {
         yield bridgedClient.connect();
@@ -557,7 +566,7 @@ IrcBridge.prototype.getBridgedClient = Promise.coroutine(function*(server, userI
     }
     catch (err) {
         log.error("Couldn't connect virtual user %s to %s : %s",
-                nick, server.domain, JSON.stringify(err));
+                ircClientConfig.getDesiredNick(), server.domain, JSON.stringify(err));
         throw err;
     }
 });

--- a/lib/irc/BridgedClient.js
+++ b/lib/irc/BridgedClient.js
@@ -312,6 +312,60 @@ BridgedClient.prototype.whois = function(nick) {
     return defer.promise;
 };
 
+/**
+ * Convert the given nick into a valid nick. This involves length and character
+ * checks on the provided nick. If the client is connected to an IRCd then the
+ * cmds received (e.g. NICKLEN) will be used in the calculations.
+ *
+ * This function may modify the nick in interesting ways in order to coerce the
+ * given nick into a valid nick. If throwOnInvalid is true, this function will
+ * throw a human-readable error instead of coercing the nick on invalid nicks.
+ *
+ * @param {string} nick The nick to convert into a valid nick.
+ * @param {boolean} throwOnInvalid True to throw an error on invalid nicks
+ * instead of coercing them.
+ * @return {string} A valid nick.
+ * @throws Only if throwOnInvalid is true and the nick is not a valid nick.
+ * The error message will contain a human-readable message which can be sent
+ * back to a user.
+ */
+BridgedClient.prototype._getValidNick = function(nick, throwOnInvalid) {
+    // Apply a series of transformations to the nick, and check after each
+    // stage for mismatches to the input (and throw if appropriate).
+
+
+    // strip illegal chars according to RFC 2812 Sect 2.3.1
+    let n = nick.replace(/[^A-Za-z0-9\]\[\^\\\{\}\-`_\|]/g, "");
+    if (throwOnInvalid && n !== nick) {
+        throw new Error(`Nick '${n}' contains illegal characters.`);
+    }
+
+    // nicks must start with a letter
+    if (!/^[A-Za-z]/.test(n)) {
+        if (throwOnInvalid) {
+            throw new Error(`Nick '${n}' must start with a letter.`);
+        }
+        // Add arbitrary letter prefix. This is important for guest user
+        // IDs which are all numbers.
+        n = "M" + n;
+    }
+
+    // nicks can't be too long
+    let maxNickLen = 9; // RFC 1459 default
+    if (this.unsafeClient.supported &&
+            typeof this.unsafeClient.supported.nicklength == "number") {
+        maxNickLen = this.unsafeClient.supported.nicklength;
+    }
+    if (n.length > maxNickLen) {
+        if (throwOnInvalid) {
+            throw new Error(`Nick '${n}' is too long. (Max: ${maxNickLen})`);
+        }
+        n = n.substr(0, maxNickLen);
+    }
+
+    return n;
+}
+
 BridgedClient.prototype._keepAlive = function() {
     this.lastActionTs = Date.now();
     var idleTimeout = this.server.getIdleTimeoutMs();

--- a/lib/irc/BridgedClient.js
+++ b/lib/irc/BridgedClient.js
@@ -34,7 +34,7 @@ function BridgedClient(server, ircClientConfig, matrixUser, isBot, eventBroker, 
     this.matrixUser = matrixUser;
 
     this.server = server;
-    this.nick = ircClientConfig.getDesiredNick();
+    this.nick = this._getValidNick(ircClientConfig.getDesiredNick(), false);
     this.password = (
         ircClientConfig.getPassword() ? ircClientConfig.getPassword() : server.config.password
     );
@@ -108,10 +108,10 @@ BridgedClient.prototype.connect = Promise.coroutine(function*() {
         }
         this.log.info(
             "Connecting to IRC server %s as %s (user=%s)",
-            server.domain, nameInfo.nick, nameInfo.username
+            server.domain, this.nick, nameInfo.username
         );
         let connInst = yield ConnectionInstance.create(server, {
-            nick: nameInfo.nick,
+            nick: this.nick,
             username: nameInfo.username,
             realname: nameInfo.realname,
             password: this.password,
@@ -187,34 +187,21 @@ BridgedClient.prototype.disconnect = function(reason) {
  * @return {Promise<String>} Which resolves to a message to be sent to the user.
  */
 BridgedClient.prototype.changeNick = function(newNick) {
-    // TODO: This is dupe logic with server.js
-    // strip illegal chars according to RFC 1459 Sect 2.3.1
-    // but allow _ because most IRC servers allow that.
-    var nick = newNick.replace(/[^A-Za-z0-9\]\[\^\\\{\}\-`_\|]/g, "");
-    // nicks must start with a letter
-    if (!/^[A-Za-z]/.test(nick)) {
-        return Promise.reject(
-            new Error("Nick '" + nick + "' must start with a letter.")
-        );
+    let validNick = newNick;
+    try {
+        validNick = this._getValidNick(newNick, true);
+        if (validNick === this.nick) {
+            return Promise.resolve(`Your nick is already '${validNick}'.`);
+        }
     }
-    var maxNickLen = 9; // RFC 1459 default
-    if (this.unsafeClient.supported &&
-            typeof this.unsafeClient.supported.nicklength == "number") {
-        maxNickLen = this.unsafeClient.supported.nicklength;
-    }
-    if (nick.length > maxNickLen) {
-        return Promise.reject(
-            new Error("Nick '" + nick + "' is too long. (Max: " + maxNickLen + ")")
-        );
-    }
-    if (nick === this.nick) {
-        return Promise.resolve("Your nick is already '" + nick + "'.");
+    catch (err) {
+        return Promise.reject(err);
     }
 
     return new Promise((resolve, reject) => {
         var nickListener, nickErrListener;
         var timeoutId = setTimeout(() => {
-            this.log.error("Timed out trying to change nick to %s", nick);
+            this.log.error("Timed out trying to change nick to %s", validNick);
             this.unsafeClient.removeListener("nick", nickListener);
             this.unsafeClient.removeListener("error", nickErrListener);
             reject(new Error("Timed out waiting for a response to change nick."));
@@ -240,7 +227,7 @@ BridgedClient.prototype.changeNick = function(newNick) {
         };
         this.unsafeClient.once("nick", nickListener);
         this.unsafeClient.once("error", nickErrListener);
-        this.unsafeClient.send("NICK", nick);
+        this.unsafeClient.send("NICK", validNick);
     });
 };
 
@@ -315,7 +302,12 @@ BridgedClient.prototype.whois = function(nick) {
 /**
  * Convert the given nick into a valid nick. This involves length and character
  * checks on the provided nick. If the client is connected to an IRCd then the
- * cmds received (e.g. NICKLEN) will be used in the calculations.
+ * cmds received (e.g. NICKLEN) will be used in the calculations. If the client
+ * is NOT connected to an IRCd then this function will NOT take length checks
+ * into account. This means this function will optimistically allow long nicks
+ * in the hopes that it will succeed, rather than use the RFC stated maximum of
+ * 9 characters which is far too small. In testing, IRCds coerce long
+ * nicks up to the limit rather than preventing the connection entirely.
  *
  * This function may modify the nick in interesting ways in order to coerce the
  * given nick into a valid nick. If throwOnInvalid is true, this function will
@@ -337,30 +329,32 @@ BridgedClient.prototype._getValidNick = function(nick, throwOnInvalid) {
     // strip illegal chars according to RFC 2812 Sect 2.3.1
     let n = nick.replace(/[^A-Za-z0-9\]\[\^\\\{\}\-`_\|]/g, "");
     if (throwOnInvalid && n !== nick) {
-        throw new Error(`Nick '${n}' contains illegal characters.`);
+        throw new Error(`Nick '${nick}' contains illegal characters.`);
     }
 
     // nicks must start with a letter
     if (!/^[A-Za-z]/.test(n)) {
         if (throwOnInvalid) {
-            throw new Error(`Nick '${n}' must start with a letter.`);
+            throw new Error(`Nick '${nick}' must start with a letter.`);
         }
         // Add arbitrary letter prefix. This is important for guest user
         // IDs which are all numbers.
         n = "M" + n;
     }
 
-    // nicks can't be too long
-    let maxNickLen = 9; // RFC 1459 default
-    if (this.unsafeClient.supported &&
-            typeof this.unsafeClient.supported.nicklength == "number") {
-        maxNickLen = this.unsafeClient.supported.nicklength;
-    }
-    if (n.length > maxNickLen) {
-        if (throwOnInvalid) {
-            throw new Error(`Nick '${n}' is too long. (Max: ${maxNickLen})`);
+    if (this.unsafeClient) {
+        // nicks can't be too long
+        let maxNickLen = 9; // RFC 1459 default
+        if (this.unsafeClient.supported &&
+                typeof this.unsafeClient.supported.nicklength == "number") {
+            maxNickLen = this.unsafeClient.supported.nicklength;
         }
-        n = n.substr(0, maxNickLen);
+        if (n.length > maxNickLen) {
+            if (throwOnInvalid) {
+                throw new Error(`Nick '${nick}' is too long. (Max: ${maxNickLen})`);
+            }
+            n = n.substr(0, maxNickLen);
+        }
     }
 
     return n;

--- a/lib/irc/ClientPool.js
+++ b/lib/irc/ClientPool.js
@@ -23,9 +23,6 @@ function ClientPool(ircBridge) {
         //    },
         //    userIds: {
         //      <user_id>: BridgedClient
-        //    },
-        //    desiredNicks: {
-        //      <nickname>: BridgedClient
         //    }
         // }
     };
@@ -55,8 +52,7 @@ ClientPool.prototype.createIrcClient = function(ircClientConfig, matrixUser, isB
     if (this._virtualClients[server.domain] === undefined) {
         this._virtualClients[server.domain] = {
             nicks: {},
-            userIds: {},
-            desiredNicks: {}
+            userIds: {}
         };
     }
 
@@ -69,7 +65,6 @@ ClientPool.prototype.createIrcClient = function(ircClientConfig, matrixUser, isB
     // connected yet, else we could spawn 2 clients for a single user if this
     // function is called quickly.
     this._virtualClients[server.domain].userIds[bridgedClient.userId] = bridgedClient;
-    this._virtualClients[server.domain].desiredNicks[bridgedClient.nick] = bridgedClient;
 
     // Does this server have a max clients limit? If so, check if the limit is
     // reached and start cycling based on oldest time.
@@ -177,17 +172,12 @@ ClientPool.prototype._getNumberOfConnections = function(server) {
     if (!server || !this._virtualClients[server.domain]) { return 0; }
 
     var connectedNickMap = this._virtualClients[server.domain].nicks;
-    var connectingNickMap = this._virtualClients[server.domain].desiredNicks;
 
     var numConnectedNicks = Object.keys(connectedNickMap).filter(function(nick) {
         return Boolean(connectedNickMap[nick]); // remove 'undefined' values
     }).length;
 
-    var numConnectingNicks = Object.keys(connectingNickMap).filter(function(nick) {
-        return Boolean(connectingNickMap[nick]); // remove 'undefined' values
-    }).length;
-
-    return numConnectedNicks + numConnectingNicks;
+    return numConnectedNicks;
 };
 
 ClientPool.prototype._sendConnectionMetric = function(server) {
@@ -205,8 +195,7 @@ ClientPool.prototype._onClientConnected = function(bridgedClient) {
     var oldNick = bridgedClient.nick;
     var actualNick = bridgedClient.unsafeClient.nick;
 
-    // move from desired to actual.
-    this._virtualClients[server.domain].desiredNicks[oldNick] = undefined;
+    // assign a nick to this client
     this._virtualClients[server.domain].nicks[actualNick] = bridgedClient;
 
     // informative logging

--- a/lib/irc/IdentGenerator.js
+++ b/lib/irc/IdentGenerator.js
@@ -25,18 +25,12 @@ IdentGenerator.prototype.inspect = function(depth) {
  * @param {IrcClientConfig} clientConfig IRC client configuration info.
  * @param {MatrixUser} matrixUser Optional. The matrix user.
  * @return {Promise} Resolves to {
- *   nick: 'nick_to_use',
  *   username: 'username_to_use',
  *   realname: 'realname_to_use'
  * }
  */
 IdentGenerator.prototype.getIrcNames = Promise.coroutine(function*(ircClientConfig, matrixUser) {
     var info = {
-        // strip illegal chars according to RFC 1459 Sect 2.3.1
-        // but allow _ because most IRC servers allow that.
-        nick: ircClientConfig.getDesiredNick().replace(
-            /[^A-Za-z0-9\]\[\^\\\{\}\-`_]/g, ""
-        ),
         username: null,
         realname: (matrixUser ?
                     sanitiseRealname(matrixUser.getId()) :


### PR DESCRIPTION
- Fixes #12.
- Fixes a few warts from #87.

Details:

- Add a single function to handle nick validation and coercion: `BridgedClient._getValidNick`.

- Removed `desiredNicks` from the ClientPool. It wasn't used for anything.
  Duplicate detection is keyed off the user ID, not the nick.

- Make `changeNick()` (via `!nick`) use `_getValidNick`.

- Make nick DB entries use`_getValidNick`.

- Ignore the default RFC stated max length in `_getValidNick` if there is
  no IRC connection.

- Removed nick mangling logic from `IdentGenerator`.