### PR TITLE
Implement +k support

### DIFF
--- a/lib/bridge/IrcBridge.js
+++ b/lib/bridge/IrcBridge.js
@@ -441,9 +441,9 @@ IrcBridge.prototype.matrixToIrcUser = function(user) {
     return Promise.resolve(new IrcUser(ircInfo.server, ircInfo.nick, true));
 };
 
-IrcBridge.prototype.trackChannel = function(server, channel) {
+IrcBridge.prototype.trackChannel = function(server, channel, key) {
     return this.getBotClient(server).then(function(client) {
-        return client.joinChannel(channel);
+        return client.joinChannel(channel, key);
     }).catch(log.logErr);
 };
 

--- a/lib/bridge/MatrixHandler.js
+++ b/lib/bridge/MatrixHandler.js
@@ -218,13 +218,14 @@ MatrixHandler.prototype._onAdminMessage = Promise.coroutine(function*(req, event
     }
     else if (cmd === "!join") {
         // TODO: Code dupe from !nick
-        // Format is: "!join irc.example.com #channel"
+        // Format is: "!join irc.example.com #channel key"
 
         // check that the server exists and that the user_id is on the whitelist
-        let ircChannel = args.length === 1 ? args[0] : null; // ensure 1 arg
+        let ircChannel = args[0];
+        let key = args[1]; // keys can't have spaces in them, so we can just do this.
         let errText = null;
         if (!ircChannel || ircChannel.indexOf("#") !== 0) {
-            errText = "Format: '!join irc.example.com #channel'";
+            errText = "Format: '!join irc.example.com #channel [key]'";
         }
         else if (ircServer.hasInviteRooms() && !ircServer.isInWhitelist(event.user_id)) {
             errText = "You are not authorised to join channels on this server.";
@@ -259,7 +260,7 @@ MatrixHandler.prototype._onAdminMessage = Promise.coroutine(function*(req, event
         }
         // track the channel then invite them.
         // TODO: Dupes onAliasQuery a lot
-        let ircRoom = yield this.ircBridge.trackChannel(ircServer, ircChannel);
+        let ircRoom = yield this.ircBridge.trackChannel(ircServer, ircChannel, key);
         let response = yield this.ircBridge.getAppServiceBridge().getIntent(
             event.user_id
         ).createRoom({

--- a/lib/bridge/MatrixHandler.js
+++ b/lib/bridge/MatrixHandler.js
@@ -168,7 +168,7 @@ MatrixHandler.prototype._onAdminMessage = Promise.coroutine(function*(req, event
             }
             else {
                 connectedNetworksStr = "Currently connected to IRC networks:\n";
-                for (var i = 0; i < clientList.length; i++) {
+                for (let i = 0; i < clientList.length; i++) {
                     connectedNetworksStr += clientList[i].server.domain +
                         " as " + clientList[i].nick + "\n";
                 }
@@ -218,7 +218,7 @@ MatrixHandler.prototype._onAdminMessage = Promise.coroutine(function*(req, event
     }
     else if (cmd === "!join") {
         // TODO: Code dupe from !nick
-        // Format is: "!join irc.example.com #channel key"
+        // Format is: "!join irc.example.com #channel [key]"
 
         // check that the server exists and that the user_id is on the whitelist
         let ircChannel = args[0];
@@ -237,49 +237,84 @@ MatrixHandler.prototype._onAdminMessage = Promise.coroutine(function*(req, event
             );
             return;
         }
-
         req.log.info("%s wants to join the channel %s on %s", event.user_id,
             ircChannel, ircServer.domain);
+
+        // There are 2 main flows here:
+        //   - The !join is instigated to make the BOT join a new channel.
+        //        * Bot MUST join and invite user
+        //   - The !join is instigated to make the USER join a new channel.
+        //        * IRC User MAY have to join (if bridging incr joins or using a chan key)
+        //        * Bot MAY invite user
+        //
+        // This means that in both cases:
+        //  1) Bot joins IRC side (NOP if bot is disabled)
+        //  2) Bot sends Matrix invite to bridged room. (ignore failures if already in room)
+        // And *sometimes* we will:
+        //  3) Force join the IRC user (if given key / bridging joins)
+
         // track the channel if we aren't already
         let matrixRooms = yield this.ircBridge.getStore().getMatrixRoomsForChannel(
             ircServer, ircChannel
         );
 
-        if (matrixRooms.length > 0) {
-            // already tracking channel, so just invite them.
-            let promises = matrixRooms.map((room) => {
-                req.log.info(
-                    "Inviting %s to room %s", event.user_id, room.getId()
-                );
-                return this.ircBridge.getAppServiceBridge().getIntent().invite(
-                    room.getId(), event.user_id
-                );
+        if (matrixRooms.length === 0) {
+            // track the channel then invite them.
+            // TODO: Dupes onAliasQuery a lot
+            let ircRoom = yield this.ircBridge.trackChannel(ircServer, ircChannel, key);
+            let response = yield this.ircBridge.getAppServiceBridge().getIntent(
+                event.user_id
+            ).createRoom({
+                options: {
+                    name: ircChannel,
+                    visibility: "private"
+                    // Intent will automatically invite the user
+                }
             });
-            yield Promise.all(promises);
-            return;
+            let mxRoom = new MatrixRoom(response.room_id);
+            yield this.ircBridge.getStore().storeRoom(
+                ircRoom, mxRoom
+            );
+            req.log.info(
+                "Created a room to track %s on %s and invited %s",
+                ircRoom.channel, ircServer.domain, event.user_id
+            );
+            matrixRooms.push(mxRoom);
         }
-        // track the channel then invite them.
-        // TODO: Dupes onAliasQuery a lot
-        let ircRoom = yield this.ircBridge.trackChannel(ircServer, ircChannel, key);
-        let response = yield this.ircBridge.getAppServiceBridge().getIntent(
-            event.user_id
-        ).createRoom({
-            options: {
-                name: ircChannel,
-                visibility: "private"
-                // Intent will automatically invite the user
-            }
+
+        // already tracking channel, so just invite them.
+        let invitePromises = matrixRooms.map((room) => {
+            req.log.info(
+                "Inviting %s to room %s", event.user_id, room.getId()
+            );
+            return this.ircBridge.getAppServiceBridge().getIntent().invite(
+                room.getId(), event.user_id
+            );
         });
-        yield this.ircBridge.getStore().storeRoom(ircRoom, new MatrixRoom(response.room_id));
-        req.log.info(
-            "Created a room to track %s on %s and invited %s",
-            ircRoom.channel, ircServer.domain, event.user_id
-        );
+
+        // check whether we should be force joining the IRC user
+        for (let i = 0; i < matrixRooms.length; i++) {
+            let m = matrixRooms[i];
+            let userMustJoin = (
+                key || ircServer.shouldSyncMembershipToIrc("incremental", m.getId())
+            );
+            if (userMustJoin) {
+                // force join then break out (we only ever join once no matter how many
+                // rooms the channel is bridged to)
+                let bc = yield this.ircBridge.getBridgedClient(
+                    ircServer, event.user_id
+                );
+                yield bc.joinChannel(ircChannel, key);
+                break;
+            }
+        }
+
+        yield Promise.all(invitePromises);
     }
     else if (cmd === "!help") {
         let notice = new MatrixAction("notice",
             `Valid commands:
-            !join irc.example.com #channel
+            !join irc.example.com #channel [key]
             !nick irc.example.com DesiredNick`
         );
         yield this.ircBridge.sendMatrixAction(adminRoom, botUser, notice, req);

--- a/lib/irc/BridgedClient.js
+++ b/lib/irc/BridgedClient.js
@@ -231,9 +231,9 @@ BridgedClient.prototype.changeNick = function(newNick) {
     });
 };
 
-BridgedClient.prototype.joinChannel = function(channel) {
+BridgedClient.prototype.joinChannel = function(channel, key) {
     if (this.disabled) { return Promise.resolve(new IrcRoom(this.server, channel)); }
-    return this._joinChannel(channel);
+    return this._joinChannel(channel, key);
 };
 
 BridgedClient.prototype.leaveChannel = function(channel) {
@@ -477,7 +477,7 @@ BridgedClient.prototype._sendMessage = function(room, msgType, text) {
     return defer.promise;
 }
 
-BridgedClient.prototype._joinChannel = function(channel, attemptCount) {
+BridgedClient.prototype._joinChannel = function(channel, key, attemptCount) {
     attemptCount = attemptCount || 1;
     if (!this.unsafeClient) {
         return Promise.reject(new Error("No client"));
@@ -536,7 +536,7 @@ BridgedClient.prototype._joinChannel = function(channel, attemptCount) {
             this.log.error("Timed out trying to join %s - trying again.", channel);
             // try joining again.
             attemptCount += 1;
-            this._joinChannel(channel, attemptCount).done(function(s) {
+            this._joinChannel(channel, key, attemptCount).done(function(s) {
                 defer.resolve(s);
             }, function(e) {
                 defer.reject(e);
@@ -544,7 +544,8 @@ BridgedClient.prototype._joinChannel = function(channel, attemptCount) {
         }
     }, JOIN_TIMEOUT_MS);
 
-    this.unsafeClient.join(channel, () => {
+    // send the JOIN with a key if it was specified.
+    this.unsafeClient.join(channel + (key ? " " + key : ""), () => {
         this.log.debug("Joined channel %s", channel);
         client.removeListener("error", failFn);
         var room = new IrcRoom(this.server, channel);

--- a/spec/integ/admin-rooms.spec.js
+++ b/spec/integ/admin-rooms.spec.js
@@ -33,7 +33,7 @@ describe("Creating admin rooms", function() {
     });
 
     it("should be possible by sending an invite to the bot's user ID",
-    function(done) {
+    test.coroutine(function*() {
         var botJoinedRoom = false;
         var sdk = env.clientMock._client(botUserId);
         sdk.joinRoom.andCallFake(function(roomId) {
@@ -42,7 +42,7 @@ describe("Creating admin rooms", function() {
             return Promise.resolve({});
         });
 
-        env.mockAppService._trigger("type:m.room.member", {
+        yield env.mockAppService._trigger("type:m.room.member", {
             content: {
                 membership: "invite",
             },
@@ -50,11 +50,9 @@ describe("Creating admin rooms", function() {
             user_id: "@someone:somewhere",
             room_id: "!adminroomid:here",
             type: "m.room.member"
-        }).done(function(e) {
-            expect(botJoinedRoom).toBe(true);
-            done();
         });
-    });
+        expect(botJoinedRoom).toBe(true);
+    }));
 });
 
 describe("Admin rooms", function() {
@@ -124,7 +122,7 @@ describe("Admin rooms", function() {
     });
 
     it("should respond to bad !nick commands with a help notice",
-    function(done) {
+    test.coroutine(function*() {
         var sentNotice = false;
         var sdk = env.clientMock._client(botUserId);
         sdk.sendEvent.andCallFake(function(roomId, type, content) {
@@ -134,7 +132,7 @@ describe("Admin rooms", function() {
             return Promise.resolve();
         });
 
-        env.mockAppService._trigger("type:m.room.message", {
+        yield env.mockAppService._trigger("type:m.room.message", {
             content: {
                 body: "!nick blargle wargle",
                 msgtype: "m.text"
@@ -142,14 +140,12 @@ describe("Admin rooms", function() {
             user_id: userId,
             room_id: adminRoomId,
             type: "m.room.message"
-        }).done(function() {
-            expect(sentNotice).toBe(true);
-            done();
         });
-    });
+        expect(sentNotice).toBe(true);
+    }));
 
     it("should respond to bad !join commands with a help notice",
-    function(done) {
+    test.coroutine(function*() {
         var sentNotice = false;
         var sdk = env.clientMock._client(botUserId);
         sdk.sendEvent.andCallFake(function(roomId, type, content) {
@@ -159,7 +155,7 @@ describe("Admin rooms", function() {
             return Promise.resolve();
         });
 
-        env.mockAppService._trigger("type:m.room.message", {
+        yield env.mockAppService._trigger("type:m.room.message", {
             content: {
                 body: "!join blargle",
                 msgtype: "m.text"
@@ -167,14 +163,12 @@ describe("Admin rooms", function() {
             user_id: userId,
             room_id: adminRoomId,
             type: "m.room.message"
-        }).done(function() {
-            expect(sentNotice).toBe(true);
-            done();
-        });
-    });
+        })
+        expect(sentNotice).toBe(true);
+    }));
 
-    it("should ignore messages sent by the bot", function(done) {
-        env.mockAppService._trigger("type:m.room.message", {
+    it("should ignore messages sent by the bot", test.coroutine(function*() {
+        yield env.mockAppService._trigger("type:m.room.message", {
             content: {
                 body: "!join blargle",
                 msgtype: "m.text"
@@ -182,12 +176,11 @@ describe("Admin rooms", function() {
             user_id: botUserId,
             room_id: adminRoomId,
             type: "m.room.message"
-        }).done(function(e) {
-            done();
         });
-    });
+    }));
 
-    it("should be able to change their nick using !nick", function(done) {
+    it("should be able to change their nick using !nick",
+    test.coroutine(function*() {
         var newNick = "Blurple";
         var testText = "I don't know what colour I am.";
 
@@ -227,7 +220,7 @@ describe("Admin rooms", function() {
         });
 
         // trigger the request to change the nick
-        env.mockAppService._trigger("type:m.room.message", {
+        yield env.mockAppService._trigger("type:m.room.message", {
             content: {
                 body: "!nick " + roomMapping.server + " " + newNick,
                 msgtype: "m.text"
@@ -235,27 +228,26 @@ describe("Admin rooms", function() {
             user_id: userId,
             room_id: adminRoomId,
             type: "m.room.message"
-        }).then(function() {
-            // trigger the message which should use the new nick
-            return env.mockAppService._trigger("type:m.room.message", {
-                content: {
-                    body: testText,
-                    msgtype: "m.text"
-                },
-                user_id: userId,
-                room_id: roomMapping.roomId,
-                type: "m.room.message"
-            });
-        }).done(function() {
-            // make sure everything was called
-            expect(sentNickCommand).toBe(true, "sent nick IRC command");
-            expect(sentAckNotice).toBe(true, "sent ACK m.notice");
-            expect(sentSay).toBe(true, "sent say IRC command");
-            done();
         });
-    });
+        // trigger the message which should use the new nick
+        yield env.mockAppService._trigger("type:m.room.message", {
+            content: {
+                body: testText,
+                msgtype: "m.text"
+            },
+            user_id: userId,
+            room_id: roomMapping.roomId,
+            type: "m.room.message"
+        });
 
-    it("should reject !nick changes for IRC errors", function(done) {
+        // make sure everything was called
+        expect(sentNickCommand).toBe(true, "sent nick IRC command");
+        expect(sentAckNotice).toBe(true, "sent ACK m.notice");
+        expect(sentSay).toBe(true, "sent say IRC command");
+    }));
+
+    it("should reject !nick changes for IRC errors",
+    test.coroutine(function*() {
         var newNick = "Blurple";
         var testText = "I don't know what colour I am.";
 
@@ -299,7 +291,7 @@ describe("Admin rooms", function() {
         });
 
         // trigger the request to change the nick
-        env.mockAppService._trigger("type:m.room.message", {
+        yield env.mockAppService._trigger("type:m.room.message", {
             content: {
                 body: "!nick " + roomMapping.server + " " + newNick,
                 msgtype: "m.text"
@@ -307,27 +299,25 @@ describe("Admin rooms", function() {
             user_id: userId,
             room_id: adminRoomId,
             type: "m.room.message"
-        }).then(function() {
-            // trigger the message which should use the OLD nick
-            return env.mockAppService._trigger("type:m.room.message", {
-                content: {
-                    body: testText,
-                    msgtype: "m.text"
-                },
-                user_id: userId,
-                room_id: roomMapping.roomId,
-                type: "m.room.message"
-            });
-        }).done(function() {
-            // make sure everything was called
-            expect(sentNickCommand).toBe(true, "sent nick IRC command");
-            expect(sentAckNotice).toBe(true, "sent ACK m.notice");
-            expect(sentSay).toBe(true, "sent say IRC command");
-            done();
         });
-    });
+        // trigger the message which should use the OLD nick
+        yield env.mockAppService._trigger("type:m.room.message", {
+            content: {
+                body: testText,
+                msgtype: "m.text"
+            },
+            user_id: userId,
+            room_id: roomMapping.roomId,
+            type: "m.room.message"
+        });
 
-    it("should timeout !nick changes after 10 seconds", function(done) {
+        // make sure everything was called
+        expect(sentNickCommand).toBe(true, "sent nick IRC command");
+        expect(sentAckNotice).toBe(true, "sent ACK m.notice");
+        expect(sentSay).toBe(true, "sent say IRC command");
+    }));
+
+    it("should timeout !nick changes after 10 seconds", test.coroutine(function*() {
         jasmine.Clock.useMock();
         var newNick = "Blurple";
 
@@ -360,7 +350,7 @@ describe("Admin rooms", function() {
         });
 
         // trigger the request to change the nick
-        env.mockAppService._trigger("type:m.room.message", {
+        yield env.mockAppService._trigger("type:m.room.message", {
             content: {
                 body: "!nick " + roomMapping.server + " " + newNick,
                 msgtype: "m.text"
@@ -368,16 +358,15 @@ describe("Admin rooms", function() {
             user_id: userId,
             room_id: adminRoomId,
             type: "m.room.message"
-        }).then(function() {
-            // make sure everything was called
-            expect(sentNickCommand).toBe(true, "sent nick IRC command");
-            expect(sentAckNotice).toBe(true, "sent ACK m.notice");
-            done();
         });
-    });
+
+        // make sure everything was called
+        expect(sentNickCommand).toBe(true, "sent nick IRC command");
+        expect(sentAckNotice).toBe(true, "sent ACK m.notice");
+    }));
 
     it("should be able to join a channel with !join if they are on the whitelist",
-    function(done) {
+    test.coroutine(function*() {
         var newChannel = "#awooga";
         var newRoomId = "!aasifuhawei:efjkwehfi";
 
@@ -404,7 +393,7 @@ describe("Admin rooms", function() {
         });
 
         // trigger the request to join a channel
-        env.mockAppService._trigger("type:m.room.message", {
+        yield env.mockAppService._trigger("type:m.room.message", {
             content: {
                 body: "!join " + roomMapping.server + " " + newChannel,
                 msgtype: "m.text"
@@ -412,11 +401,54 @@ describe("Admin rooms", function() {
             user_id: userId,
             room_id: adminRoomId,
             type: "m.room.message"
-        }).done(function() {
-            // make sure everything was called
-            expect(createdMatrixRoom).toBe(true, "Did not create matrix room");
-            expect(joinedChannel).toBe(true, "Bot didn't join channel");
-            done();
+        })
+
+        // make sure everything was called
+        expect(createdMatrixRoom).toBe(true, "Did not create matrix room");
+        expect(joinedChannel).toBe(true, "Bot didn't join channel");
+    }));
+
+    it("should be able to join a channel with !join and a key",
+    test.coroutine(function*() {
+        var newChannel = "#awooga";
+        var newRoomId = "!aasifuhawei:efjkwehfi";
+        var key = "secret";
+
+        // let the bot join the irc channel
+        var joinedChannel = false;
+        env.ircMock._whenClient(roomMapping.server, roomMapping.botNick, "join",
+        function(client, chan, cb) {
+            if (chan === (newChannel + " " + key)) {
+                joinedChannel = true;
+                if (cb) { cb(); }
+            }
         });
-    });
+
+        // make sure the AS creates a new PRIVATE matrix room.
+        var createdMatrixRoom = false;
+        var sdk = env.clientMock._client(botUserId);
+        sdk.createRoom.andCallFake(function(opts) {
+            expect(opts.visibility).toEqual("private");
+            expect(opts.invite).toEqual([userId]);
+            createdMatrixRoom = true;
+            return Promise.resolve({
+                room_id: newRoomId
+            });
+        });
+
+        // trigger the request to join a channel
+        yield env.mockAppService._trigger("type:m.room.message", {
+            content: {
+                body: "!join " + roomMapping.server + " " + newChannel + " " + key,
+                msgtype: "m.text"
+            },
+            user_id: userId,
+            room_id: adminRoomId,
+            type: "m.room.message"
+        })
+
+        // make sure everything was called
+        expect(createdMatrixRoom).toBe(true, "Did not create matrix room");
+        expect(joinedChannel).toBe(true, "Bot didn't join channel");
+    }));
 });

--- a/spec/integ/admin-rooms.spec.js
+++ b/spec/integ/admin-rooms.spec.js
@@ -424,6 +424,16 @@ describe("Admin rooms", function() {
             }
         });
 
+        // Because we gave a key, we expect the user to be joined (with the key)
+        // immediately.
+        env.ircMock._whenClient(roomMapping.server, userIdNick, "join",
+        function(client, chan, cb) {
+            if (chan === (newChannel + " " + key)) {
+                joinedChannel = true;
+                if (cb) { cb(); }
+            }
+        });
+
         // make sure the AS creates a new PRIVATE matrix room.
         var createdMatrixRoom = false;
         var sdk = env.clientMock._client(botUserId);

--- a/spec/util/test.js
+++ b/spec/util/test.js
@@ -112,6 +112,7 @@ module.exports.coroutine = function(generatorFn) {
             done();
         }, function(err) {
             expect(true).toBe(false, "Coroutine threw: " + err + "\n" + err.stack);
+            done();
         })
     };
 };


### PR DESCRIPTION
Fixes #33

- `!join` now accepts an optional `key` when joining a channel.
- Adjusted the behaviour of `!join` to send a `JOIN` if a key is specified or if incremental syncing M->I is turned on.