### PR TITLE
 Add the `!whois` command for the bridge

### DIFF
--- a/lib/bridge/MatrixHandler.js
+++ b/lib/bridge/MatrixHandler.js
@@ -328,7 +328,7 @@ MatrixHandler.prototype._onAdminMessage = Promise.coroutine(function*(req, event
             whoisNick, ircServer.domain);
         let bridgedClient = yield this.ircBridge.getBridgedClient(ircServer, event.user_id);
         try {
-            let response = yield bridgedClient.whois(whoisNick);
+            let response = yield bridgedClient.whois(whoisNick).msg;
             let noticeRes = new MatrixAction("notice", response);
             yield this.ircBridge.sendMatrixAction(adminRoom, botUser, noticeRes, req);
             return;

--- a/lib/bridge/MatrixHandler.js
+++ b/lib/bridge/MatrixHandler.js
@@ -317,12 +317,9 @@ MatrixHandler.prototype._onAdminMessage = Promise.coroutine(function*(req, event
         let whoisNick = args.length === 1 ? args[0] : null; // ensure 1 arg
         let errText = null;
         if (!whoisNick) {
-            errText = "Format: '!whois nick'";
-        }
-
-        if (errText) {
             yield this.ircBridge.sendMatrixAction(
-                adminRoom, botUser, new MatrixAction("notice", errText), req
+              adminRoom, botUser,
+              new MatrixAction("notice", "Format: '!whois nick'"), req
             );
             return;
         }

--- a/lib/bridge/MatrixHandler.js
+++ b/lib/bridge/MatrixHandler.js
@@ -318,8 +318,8 @@ MatrixHandler.prototype._onAdminMessage = Promise.coroutine(function*(req, event
         let errText = null;
         if (!whoisNick) {
             yield this.ircBridge.sendMatrixAction(
-              adminRoom, botUser,
-              new MatrixAction("notice", "Format: '!whois nick'"), req
+                adminRoom, botUser,
+                new MatrixAction("notice", "Format: '!whois nick'"), req
             );
             return;
         }

--- a/lib/bridge/MatrixHandler.js
+++ b/lib/bridge/MatrixHandler.js
@@ -311,6 +311,40 @@ MatrixHandler.prototype._onAdminMessage = Promise.coroutine(function*(req, event
 
         yield Promise.all(invitePromises);
     }
+    else if (cmd === "!whois") {
+        // Format is: "!whois <nick>"
+
+        let whoisNick = args.length === 1 ? args[0] : null; // ensure 1 arg
+        let errText = null;
+        if (!whoisNick) {
+            errText = "Format: '!whois nick'";
+        }
+
+        if (errText) {
+            yield this.ircBridge.sendMatrixAction(
+                adminRoom, botUser, new MatrixAction("notice", errText), req
+            );
+            return;
+        }
+
+        req.log.info("%s wants whois info on %s on %s", event.user_id,
+            whoisNick, ircServer.domain);
+        let bridgedClient = yield this.ircBridge.getBridgedClient(ircServer, event.user_id);
+        try {
+            let response = yield bridgedClient.whois(whoisNick);
+            let noticeRes = new MatrixAction("notice", response);
+            yield this.ircBridge.sendMatrixAction(adminRoom, botUser, noticeRes, req);
+            return;
+        }
+        catch (err) {
+            if (err.stack) {
+                req.log.error(err);
+            }
+            let noticeErr = new MatrixAction("notice", JSON.stringify(err));
+            yield this.ircBridge.sendMatrixAction(adminRoom, botUser, noticeErr, req);
+            return;
+        }
+    }
     else if (cmd === "!help") {
         let notice = new MatrixAction("notice",
             `Valid commands:

--- a/lib/irc/BridgedClient.js
+++ b/lib/irc/BridgedClient.js
@@ -280,7 +280,6 @@ BridgedClient.prototype.sendAction = function(room, action) {
 /**
  * Get the whois info for an IRC user
  * @param {string} nick : The nick to call /whois on
- * @return {Promise<String>} Which resolves to a message to be sent to the user.
  */
 BridgedClient.prototype.whois = function(nick) {
     if (this.disabled) {

--- a/lib/irc/BridgedClient.js
+++ b/lib/irc/BridgedClient.js
@@ -277,6 +277,11 @@ BridgedClient.prototype.sendAction = function(room, action) {
     return Promise.reject(new Error("Unknown action type: " + action.type));
 };
 
+/**
+ * Get the whois info for an IRC user
+ * @param {string} nick : The nick to call /whois on
+ * @return {Promise<String>} Which resolves to a message to be sent to the user.
+ */
 BridgedClient.prototype.whois = function(nick) {
     if (this.disabled) {
         return Promise.resolve({
@@ -293,7 +298,8 @@ BridgedClient.prototype.whois = function(nick) {
         }
         defer.resolve({
             server: self.server,
-            nick: nick
+            nick: nick,
+            msg: "Whois info for '" + nick + "': " + whois
         });
     });
     return defer.promise;


### PR DESCRIPTION
This adds a new command - `!whois` for retrieving whois information
about a user in the same way an IRC user would use `/whois <nick>`

(this time based on `develop` instead of master)

This is a continuation of #90, addressing the feedback there.