### PR TITLE
Add !whois command to help output

### DIFF
--- a/lib/bridge/MatrixHandler.js
+++ b/lib/bridge/MatrixHandler.js
@@ -344,7 +344,8 @@ MatrixHandler.prototype._onAdminMessage = Promise.coroutine(function*(req, event
         let notice = new MatrixAction("notice",
             `Valid commands:
             !join irc.example.com #channel [key]
-            !nick irc.example.com DesiredNick`
+            !nick irc.example.com DesiredNick
+            !whois nick`
         );
         yield this.ircBridge.sendMatrixAction(adminRoom, botUser, notice, req);
         return;


### PR DESCRIPTION
Relates to #96 

Very simple change to add it to the `!help` output. I left off adding it to the CHANGELOG.md since I wasn't sure what format it should be in there.