### PR TITLE
Mirror kicks if there are sufficient permissions

### DIFF
--- a/lib/bridge/IrcBridge.js
+++ b/lib/bridge/IrcBridge.js
@@ -347,7 +347,16 @@ IrcBridge.prototype._onEvent = Promise.coroutine(function*(baseRequest, context)
             yield this.matrixHandler.onJoin(request, event, target);
         }
         else if (["ban", "leave"].indexOf(event.content.membership) !== -1) {
-            yield this.matrixHandler.onLeave(request, event, target, sender);
+            // Given a "self-kick" is a leave, and you can't ban yourself,
+            // if the 2 IDs are different then we know it is either a kick
+            // or a ban (or a rescinded invite)
+            var isKickOrBan = target.getId() !== sender.getId();
+            if (isKickOrBan) {
+                yield this.matrixHandler.onKick(request, event, sender, target);
+            }
+            else {
+                yield this.matrixHandler.onLeave(request, event, target, sender);
+            }
         }
     }
 });

--- a/lib/bridge/IrcBridge.js
+++ b/lib/bridge/IrcBridge.js
@@ -347,7 +347,7 @@ IrcBridge.prototype._onEvent = Promise.coroutine(function*(baseRequest, context)
             yield this.matrixHandler.onJoin(request, event, target);
         }
         else if (["ban", "leave"].indexOf(event.content.membership) !== -1) {
-            yield this.matrixHandler.onLeave(request, event, target);
+            yield this.matrixHandler.onLeave(request, event, target, sender);
         }
     }
 });

--- a/lib/bridge/IrcHandler.js
+++ b/lib/bridge/IrcHandler.js
@@ -256,7 +256,8 @@ IrcHandler.prototype.onJoin = Promise.coroutine(function*(req, server, joiningUs
     yield Promise.all(promises);
 });
 
-IrcHandler.prototype.onKick = Promise.coroutine(function*(req, server, kicker, kickee, chan, reason) {
+IrcHandler.prototype.onKick = Promise.coroutine(function*(req, server,
+                                                kicker, kickee, chan, reason) {
     req.log.info(
         "onKick(%s) %s is kicking %s from %s",
         server.domain, kicker.nick, kickee.nick, chan

--- a/lib/bridge/IrcHandler.js
+++ b/lib/bridge/IrcHandler.js
@@ -316,6 +316,20 @@ IrcHandler.prototype.onKick = Promise.coroutine(function*(req, server,
         // will NOT send a PART command. We equally cannot make a fake PART command and
         // reuse the same code path as we want to force this to go through, regardless of
         // whether incremental join/leave syncing is turned on.
+        let matrixUser = yield this.ircBridge.getMatrixUser(kickee);
+        req.log.info("Mapped kickee nick %s to %s", kickee.nick, JSON.stringify(matrixUser));
+        let matrixRooms = yield this.ircBridge.getStore().getMatrixRoomsForChannel(server, chan);
+        if (matrixRooms.length === 0) {
+            req.log.info("No mapped matrix rooms for IRC channel %s", chan);
+            return;
+        }
+        let promises = matrixRooms.map((room) => {
+            req.log.info("Leaving (due to kick) room %s", room.getId());
+            return this.ircBridge.getAppServiceBridge().getIntent(
+                matrixUser.getId()
+            ).leave(room.getId());
+        });
+        yield Promise.all(promises);
     }
 });
 

--- a/lib/bridge/IrcHandler.js
+++ b/lib/bridge/IrcHandler.js
@@ -262,9 +262,34 @@ IrcHandler.prototype.onKick = Promise.coroutine(function*(req, server,
         "onKick(%s) %s is kicking %s from %s",
         server.domain, kicker.nick, kickee.nick, chan
     );
+
+    /*
+    We know this is an IRC client kicking someone.
+    There are 2 scenarios to consider here:
+     - IRC on IRC kicking
+     - IRC on Matrix kicking
+
+    IRC-IRC
+    =======
+      __USER A____            ____USER B___
+     |            |          |             |
+    IRC       vMatrix1       IRC      vMatrix2 |     Effect
+    -----------------------------------------------------------------------
+    Kicker                 Kickee              |  vMatrix2 leaves room.
+
+    IRC-Matrix
+    ==========
+      __USER A____            ____USER B___
+     |            |          |             |
+    Matrix      vIRC        IRC       vMatrix  |     Effect
+    -----------------------------------------------------------------------
+               Kickee      Kicker              |  Bot tries to kick Matrix user via /kick.
+    */
+
     if (!kickee.isVirtual) {
         return; // nothing to mirror to Matrix
     }
+
     let matrixRooms = yield this.ircBridge.getStore().getMatrixRoomsForChannel(server, chan);
     if (matrixRooms.length === 0) {
         req.log.info("No mapped matrix rooms for IRC channel %s", chan);

--- a/lib/bridge/IrcHandler.js
+++ b/lib/bridge/IrcHandler.js
@@ -276,6 +276,9 @@ IrcHandler.prototype.onKick = Promise.coroutine(function*(req, server,
     IRC       vMatrix1       IRC      vMatrix2 |     Effect
     -----------------------------------------------------------------------
     Kicker                 Kickee              |  vMatrix2 leaves room.
+                                                  This avoid potential permission issues
+                                                  in case vMatrix1 cannot kick vMatrix2
+                                                  on Matrix.
 
     IRC-Matrix
     ==========
@@ -286,29 +289,34 @@ IrcHandler.prototype.onKick = Promise.coroutine(function*(req, server,
                Kickee      Kicker              |  Bot tries to kick Matrix user via /kick.
     */
 
-    if (!kickee.isVirtual) {
-        return; // nothing to mirror to Matrix
-    }
-
-    let matrixRooms = yield this.ircBridge.getStore().getMatrixRoomsForChannel(server, chan);
-    if (matrixRooms.length === 0) {
-        req.log.info("No mapped matrix rooms for IRC channel %s", chan);
-        return;
-    }
-    let bridgedIrcClient = this.ircBridge.getClientPool().getBridgedClientByNick(
-        server, kickee.nick
-    );
-    if (!bridgedIrcClient) {
-        return; // unexpected given isVirtual == true, but meh, bail.
-    }
-    let promises = matrixRooms.map((room) => {
-        req.log.info("Kicking %s from room %s", bridgedIrcClient.userId, room.getId());
-        return this.ircBridge.getAppServiceBridge().getIntent().kick(
-            room.getId(), bridgedIrcClient.userId,
-            `${kicker.nick} has kicked ${bridgedIrcClient.userId} from ${chan} (${reason})`
+    if (kickee.isVirtual) {
+        // A real IRC user is kicking one of us - this is IRC on Matrix kicking.
+        let matrixRooms = yield this.ircBridge.getStore().getMatrixRoomsForChannel(server, chan);
+        if (matrixRooms.length === 0) {
+            req.log.info("No mapped matrix rooms for IRC channel %s", chan);
+            return;
+        }
+        let bridgedIrcClient = this.ircBridge.getClientPool().getBridgedClientByNick(
+            server, kickee.nick
         );
-    });
-    yield Promise.all(promises);
+        if (!bridgedIrcClient) {
+            return; // unexpected given isVirtual == true, but meh, bail.
+        }
+        let promises = matrixRooms.map((room) => {
+            req.log.info("Kicking %s from room %s", bridgedIrcClient.userId, room.getId());
+            return this.ircBridge.getAppServiceBridge().getIntent().kick(
+                room.getId(), bridgedIrcClient.userId,
+                `${kicker.nick} has kicked ${bridgedIrcClient.userId} from ${chan} (${reason})`
+            );
+        });
+        yield Promise.all(promises);
+    }
+    else {
+        // the kickee is just some random IRC user, but we still need to bridge this as IRC
+        // will NOT send a PART command. We equally cannot make a fake PART command and
+        // reuse the same code path as we want to force this to go through, regardless of
+        // whether incremental join/leave syncing is turned on.
+    }
 });
 
 /**

--- a/lib/bridge/IrcHandler.js
+++ b/lib/bridge/IrcHandler.js
@@ -256,6 +256,35 @@ IrcHandler.prototype.onJoin = Promise.coroutine(function*(req, server, joiningUs
     yield Promise.all(promises);
 });
 
+IrcHandler.prototype.onKick = Promise.coroutine(function*(req, server, kicker, kickee, chan, reason) {
+    req.log.info(
+        "onKick(%s) %s is kicking %s from %s",
+        server.domain, kicker.nick, kickee.nick, chan
+    );
+    if (!kickee.isVirtual) {
+        return; // nothing to mirror to Matrix
+    }
+    let matrixRooms = yield this.ircBridge.getStore().getMatrixRoomsForChannel(server, chan);
+    if (matrixRooms.length === 0) {
+        req.log.info("No mapped matrix rooms for IRC channel %s", chan);
+        return;
+    }
+    let bridgedIrcClient = this.ircBridge.getClientPool().getBridgedClientByNick(
+        server, kickee.nick
+    );
+    if (!bridgedIrcClient) {
+        return; // unexpected given isVirtual == true, but meh, bail.
+    }
+    let promises = matrixRooms.map((room) => {
+        req.log.info("Kicking %s from room %s", bridgedIrcClient.userId, room.getId());
+        return this.ircBridge.getAppServiceBridge().getIntent().kick(
+            room.getId(), bridgedIrcClient.userId,
+            `${kicker.nick} has kicked ${bridgedIrcClient.userId} from ${chan} (${reason})`
+        );
+    });
+    yield Promise.all(promises);
+});
+
 /**
  * Called when the AS receives an IRC part event.
  * @param {IrcServer} server : The sending IRC server.
@@ -273,6 +302,7 @@ IrcHandler.prototype.onPart = Promise.coroutine(function*(req, server, leavingUs
     }
     let nick = leavingUser.nick;
     req.log.info("onPart(%s) %s to %s", kind, nick, chan);
+
     // if the person leaving is a virtual IRC user, do nothing.
     if (leavingUser.isVirtual) {
         return BridgeRequest.ERR_VIRTUAL_USER;
@@ -292,7 +322,7 @@ IrcHandler.prototype.onPart = Promise.coroutine(function*(req, server, leavingUs
         ).leave(room.getId());
     });
     stats.membership(true, "part");
-    yield Promise.all(promises)
+    yield Promise.all(promises);
 });
 
 IrcHandler.prototype.onMode = Promise.coroutine(function*(req, server, channel, by,

--- a/lib/bridge/MatrixHandler.js
+++ b/lib/bridge/MatrixHandler.js
@@ -476,6 +476,36 @@ MatrixHandler.prototype._onJoin = Promise.coroutine(function*(req, event, user) 
     yield Promise.all(promises);
 });
 
+MatrixHandler.prototype._onKick = Promise.coroutine(function*(req, event, kicker, kickee) {
+    req.log.info(
+        "onKick %s is kicking %s from %s",
+        kicker.getId(), kickee.getId(), event.room_id
+    );
+
+    /*
+    We know this is a Matrix client kicking someone.
+    There are 2 scenarios to consider here:
+      - Matrix on Matrix kicking
+      - Matrix on IRC kicking
+
+    Matrix-Matrix
+    =============
+      __USER A____            ____USER B___
+     |            |          |             |
+    Matrix     vIRC1       Matrix        vIRC2 |     Effect
+    -----------------------------------------------------------------------
+    Kicker                 Kickee              |  vIRC2 parts channel.
+
+    Matrix-IRC
+    ==========
+      __USER A____            ____USER B___
+     |            |          |             |
+    Matrix      vIRC        IRC       vMatrix  |     Effect
+    -----------------------------------------------------------------------
+    Kicker                            Kickee   |  vIRC tries to kick IRC via KICK command.
+    */
+});
+
 MatrixHandler.prototype._onLeave = Promise.coroutine(function*(req, event, user, sender) {
     req.log.info("onLeave: %s", JSON.stringify(event));
     // membershiplists injects leave events when syncing initial membership

--- a/lib/bridge/MatrixHandler.js
+++ b/lib/bridge/MatrixHandler.js
@@ -513,7 +513,42 @@ MatrixHandler.prototype._onKick = Promise.coroutine(function*(req, event, kicker
     let kickeeClients = this.ircBridge.getBridgedClientsForUserId(kickee.getId());
 
     if (kickeeClients.length === 0) {
-        // Matrix on IRC kicking
+        // Matrix on IRC kicking, work out which IRC user to kick.
+        let server = null;
+        for (let i = 0; i < ircRooms.length; i++) {
+            if (ircRooms[i].server.claimsUserId(kickee.getId())) {
+                server = ircRooms[i].server;
+                break;
+            }
+        }
+        if (!server) {
+            return; // kicking a bogus user
+        }
+        let kickeeNick = server.getNickFromUserId(kickee.getId());
+        if (!kickeeNick) {
+            return; // bogus virtual user ID
+        }
+        // work out which client will do the kicking
+        let kickerClient = this.ircBridge.getIrcUserFromCache(server, kicker.getId());
+        if (!kickerClient) {
+            // well this is awkward.. whine about it and bail.
+            req.log.error(
+                "%s has no client instance to send kick from. Cannot kick.",
+                kicker.getId()
+            );
+            return;
+        }
+        // we may be bridging this matrix room into many different IRC channels, and we want
+        // to kick this user from all of them.
+        for (let i = 0; i < ircRooms.length; i++) {
+            if (ircRooms[i].server.domain !== server.domain) {
+                return;
+            }
+            kickerClient.kick(
+                kickeeNick, ircRooms[i].channel,
+                `${kicker.getId()} kicked ${kickeeNick}`
+            );
+        }
     }
     else {
         // Matrix on Matrix kicking: part the channel.

--- a/lib/bridge/MatrixHandler.js
+++ b/lib/bridge/MatrixHandler.js
@@ -564,7 +564,8 @@ MatrixHandler.prototype._onKick = Promise.coroutine(function*(req, event, kicker
             }
             kickerClient.kick(
                 kickeeNick, ircRooms[i].channel,
-                `${kicker.getId()} kicked ${kickeeNick}`
+                `Kicked by ${kicker.getId()}` +
+                (event.content.reason ? ` : ${event.content.reason}` : "")
             );
         }
     }

--- a/lib/bridge/MatrixHandler.js
+++ b/lib/bridge/MatrixHandler.js
@@ -478,7 +478,7 @@ MatrixHandler.prototype._onJoin = Promise.coroutine(function*(req, event, user) 
 
 MatrixHandler.prototype._onKick = Promise.coroutine(function*(req, event, kicker, kickee) {
     req.log.info(
-        "onKick %s is kicking %s from %s",
+        "onKick %s is kicking/banning %s from %s",
         kicker.getId(), kickee.getId(), event.room_id
     );
 
@@ -495,6 +495,8 @@ MatrixHandler.prototype._onKick = Promise.coroutine(function*(req, event, kicker
     Matrix     vIRC1       Matrix        vIRC2 |     Effect
     -----------------------------------------------------------------------
     Kicker                 Kickee              |  vIRC2 parts channel.
+                                                  This avoids potential permission issues
+                                                  in case vIRC1 cannot kick vIRC2 on IRC.
 
     Matrix-IRC
     ==========
@@ -504,6 +506,35 @@ MatrixHandler.prototype._onKick = Promise.coroutine(function*(req, event, kicker
     -----------------------------------------------------------------------
     Kicker                            Kickee   |  vIRC tries to kick IRC via KICK command.
     */
+
+    let ircRooms = yield this.ircBridge.getStore().getIrcChannelsForRoomId(event.room_id);
+    // do we have an active connection for the kickee? This tells us if they are real
+    // or virtual.
+    let kickeeClients = this.ircBridge.getBridgedClientsForUserId(kickee.getId());
+
+    if (kickeeClients.length === 0) {
+        // Matrix on IRC kicking
+    }
+    else {
+        // Matrix on Matrix kicking: part the channel.
+        let kickeeServerLookup = {};
+        kickeeClients.forEach(function(ircClient) {
+            kickeeServerLookup[ircClient.server.domain] = ircClient;
+        });
+        let promises = []; // one for each leave
+        ircRooms.forEach(function(ircRoom) {
+            // Make the connected IRC client leave the channel.
+            let client = kickeeServerLookup[ircRoom.server.domain];
+            if (!client) {
+                return; // not connected to this server
+            }
+            // If we aren't joined this will no-op.
+            promises.push(client.leaveChannel(
+                ircRoom.channel, `Kicked by ${kicker.getId()}`
+            ));
+        });
+        yield Promise.all(promises);
+    }
 });
 
 MatrixHandler.prototype._onLeave = Promise.coroutine(function*(req, event, user, sender) {
@@ -517,16 +548,14 @@ MatrixHandler.prototype._onLeave = Promise.coroutine(function*(req, event, user,
         return BridgeRequest.ERR_VIRTUAL_USER;
     }
 
-    var isKick = user.getId() !== sender.getId() && event.content.membership === "leave";
-
     // do we have an active connection for this user?
     let clientList = this.ircBridge.getBridgedClientsForUserId(user.getId());
     // filter out servers which don't mirror matrix join parts (unless it's a kick)
     clientList = clientList.filter(function(client) {
-        return isKick || (
-                    client.server.shouldSyncMembershipToIrc(syncKind, event.room_id) &&
-                    !client.server.claimsUserId(user.getId())
-                ); // not a virtual user
+        return (
+            client.server.shouldSyncMembershipToIrc(syncKind, event.room_id) &&
+            !client.server.claimsUserId(user.getId())
+        ); // not a virtual user
     });
 
     let serverLookup = {};
@@ -548,8 +577,7 @@ MatrixHandler.prototype._onLeave = Promise.coroutine(function*(req, event, user,
             return; // not connected to this server
         }
         // leave it; if we aren't joined this will no-op.
-        let reason = isKick ? `Kicked by ${sender.getId()}` : undefined;
-        promises.push(client.leaveChannel(ircRoom.channel, reason));
+        promises.push(client.leaveChannel(ircRoom.channel));
     });
 
     if (promises.length === 0) { // no connected clients
@@ -819,6 +847,10 @@ MatrixHandler.prototype.onJoin = function(req, event, user) {
 
 MatrixHandler.prototype.onLeave = function(req, event, user, sender) {
     return reqHandler(req, this._onLeave(req, event, user, sender));
+};
+
+MatrixHandler.prototype.onKick = function(req, event, kicker, kickee) {
+    return reqHandler(req, this._onKick(req, event, kicker, kickee));
 };
 
 MatrixHandler.prototype.onMessage = function(req, event) {

--- a/lib/bridge/MatrixHandler.js
+++ b/lib/bridge/MatrixHandler.js
@@ -476,7 +476,7 @@ MatrixHandler.prototype._onJoin = Promise.coroutine(function*(req, event, user) 
     yield Promise.all(promises);
 });
 
-MatrixHandler.prototype._onLeave = Promise.coroutine(function*(req, event, user) {
+MatrixHandler.prototype._onLeave = Promise.coroutine(function*(req, event, user, sender) {
     req.log.info("onLeave: %s", JSON.stringify(event));
     // membershiplists injects leave events when syncing initial membership
     // lists. We know if this event is injected because this flag is set.
@@ -487,12 +487,16 @@ MatrixHandler.prototype._onLeave = Promise.coroutine(function*(req, event, user)
         return BridgeRequest.ERR_VIRTUAL_USER;
     }
 
+    var isKick = user.getId() !== sender.getId() && event.content.membership === "leave";
+
     // do we have an active connection for this user?
     let clientList = this.ircBridge.getBridgedClientsForUserId(user.getId());
-    // filter out servers which don't mirror matrix join parts
+    // filter out servers which don't mirror matrix join parts (unless it's a kick)
     clientList = clientList.filter(function(client) {
-        return client.server.shouldSyncMembershipToIrc(syncKind, event.room_id) &&
-            !client.server.claimsUserId(user.getId()); // not a virtual user
+        return isKick || (
+                    client.server.shouldSyncMembershipToIrc(syncKind, event.room_id) &&
+                    !client.server.claimsUserId(user.getId())
+                ); // not a virtual user
     });
 
     let serverLookup = {};
@@ -514,7 +518,8 @@ MatrixHandler.prototype._onLeave = Promise.coroutine(function*(req, event, user)
             return; // not connected to this server
         }
         // leave it; if we aren't joined this will no-op.
-        promises.push(client.leaveChannel(ircRoom.channel));
+        let reason = isKick ? `Kicked by ${sender.getId()}` : undefined;
+        promises.push(client.leaveChannel(ircRoom.channel, reason));
     });
 
     if (promises.length === 0) { // no connected clients
@@ -782,8 +787,8 @@ MatrixHandler.prototype.onJoin = function(req, event, user) {
     return reqHandler(req, this._onJoin(req, event, user));
 };
 
-MatrixHandler.prototype.onLeave = function(req, event, user) {
-    return reqHandler(req, this._onLeave(req, event, user));
+MatrixHandler.prototype.onLeave = function(req, event, user, sender) {
+    return reqHandler(req, this._onLeave(req, event, user, sender));
 };
 
 MatrixHandler.prototype.onMessage = function(req, event) {

--- a/lib/irc/BridgedClient.js
+++ b/lib/irc/BridgedClient.js
@@ -231,7 +231,8 @@ BridgedClient.prototype.joinChannel = function(channel, key) {
     return this._joinChannel(channel, key);
 };
 
-BridgedClient.prototype.leaveChannel = function(channel) {
+BridgedClient.prototype.leaveChannel = function(channel, reason) {
+    reason = reason || "User left";
     if (this.disabled) { return Promise.resolve("disabled"); }
     if (!this.inst || this.inst.dead) {
         return Promise.resolve(); // we were never connected to the network.
@@ -246,7 +247,7 @@ BridgedClient.prototype.leaveChannel = function(channel) {
     var defer = promiseutil.defer();
     this._removeChannel(channel);
     self.log.debug("Leaving channel %s", channel);
-    this.unsafeClient.part(channel, "User left", function() {
+    this.unsafeClient.part(channel, reason, function() {
         self.log.debug("Left channel %s", channel);
         defer.resolve();
     });

--- a/lib/irc/BridgedClient.js
+++ b/lib/irc/BridgedClient.js
@@ -255,6 +255,27 @@ BridgedClient.prototype.leaveChannel = function(channel, reason) {
     return defer.promise;
 };
 
+BridgedClient.prototype.kick = function(nick, channel, reason) {
+    reason = reason || "User kicked";
+    if (this.disabled) { return Promise.resolve("disabled"); }
+    if (!this.inst || this.inst.dead) {
+        return Promise.resolve(); // we were never connected to the network.
+    }
+    if (Object.keys(this.unsafeClient.chans).indexOf(channel) === -1) {
+        // we were never joined to it. We need to be joined to it to kick people.
+        return Promise.resolve();
+    }
+    if (channel.indexOf("#") !== 0) {
+        return Promise.resolve(); // PM room
+    }
+
+    return new Promise((resolve, reject) => {
+        this.log.debug("Kicking %s from channel %s", nick, channel);
+        this.unsafeClient.send("KICK", channel, nick, reason);
+        resolve(); // wait for some response? Is there even one?
+    });
+};
+
 BridgedClient.prototype.sendAction = function(room, action) {
     if (this.disabled) { return Promise.resolve("disabled"); }
     this._keepAlive();

--- a/lib/irc/ConnectionInstance.js
+++ b/lib/irc/ConnectionInstance.js
@@ -231,7 +231,7 @@ ConnectionInstance.create = function(server, opts, onCreatedCallback) {
         password: opts.password,
         localAddress: opts.localAddress,
         autoConnect: false,
-        autoRejoin: true,
+        autoRejoin: false,
         floodProtection: true,
         floodProtectionDelay: FLOOD_PROTECTION_DELAY_MS,
         port: server.getPort(),

--- a/lib/irc/IrcEventBroker.js
+++ b/lib/irc/IrcEventBroker.js
@@ -323,8 +323,8 @@ IrcEventBroker.prototype.addHooks = function(client, connInst) {
     });
     this._hookIfClaimed(client, connInst, "kick", function(chan, nick, by, reason, msg) {
         var req = createRequest();
-        complete(req, ircHandler.onPart(
-            req, server, createUser(nick), chan, "kick"
+        complete(req, ircHandler.onKick(
+            req, server, createUser(by), createUser(nick), chan, reason
         ));
     });
     this._hookIfClaimed(client, connInst, "join", function(chan, nick, msg) {

--- a/spec/integ/kicking.spec.js
+++ b/spec/integ/kicking.spec.js
@@ -1,0 +1,131 @@
+"use strict";
+var Promise = require("bluebird");
+var test = require("../util/test");
+var env = test.mkEnv();
+var config = env.config;
+
+describe("Kicking", function() {
+    var mxUser = {
+        id: "@flibble:wibble",
+        nick: "M-flibble"
+    };
+
+    var ircUser = {
+        nick: "bob",
+        localpart: config._server + "_bob",
+        id: "@" + config._server + "_bob:" + config.homeserver.domain
+    };
+
+    beforeEach(function(done) {
+        test.beforeEach(this, env); // eslint-disable-line no-invalid-this
+
+        // accept connection requests from eeeeeeeeveryone!
+        env.ircMock._autoConnectNetworks(
+            config._server, mxUser.nick, config._server
+        );
+        env.ircMock._autoConnectNetworks(
+            config._server, ircUser.nick, config._server
+        );
+        env.ircMock._autoConnectNetworks(
+            config._server, config._botnick, config._server
+        );
+        // accept join requests from eeeeeeeeveryone!
+        env.ircMock._autoJoinChannels(
+            config._server, mxUser.nick, config._chan
+        );
+        env.ircMock._autoJoinChannels(
+            config._server, ircUser.nick, config._chan
+        );
+        env.ircMock._autoJoinChannels(
+            config._server, config._botnick, config._chan
+        );
+
+        // we also don't care about registration requests for the irc user
+        env.clientMock._client(ircUser.id)._onHttpRegister({
+            expectLocalpart: ircUser.localpart,
+            returnUserId: ircUser.id
+        });
+
+        // do the init
+        test.initEnv(env).then(function() {
+            // make the matrix user be on IRC
+            return env.mockAppService._trigger("type:m.room.message", {
+                content: {
+                    body: "let me in",
+                    msgtype: "m.text"
+                },
+                user_id: mxUser.id,
+                room_id: config._roomid,
+                type: "m.room.message"
+            })
+        }).then(function() {
+            return env.ircMock._findClientAsync(config._server, config._botnick);
+        }).then(function(botIrcClient) {
+            // make the IRC user be on Matrix
+            botIrcClient.emit("message", ircUser.nick, config._chan, "let me in");
+            done();
+        })
+    });
+
+    describe("IRC users on IRC", function() {
+
+    });
+
+    describe("Matrix users on Matrix", function() {
+        it("should make the kickee part the IRC channel", function(done) {
+            var parted = false;
+            env.ircMock._whenClient(config._server, mxUser.nick, "part",
+            function(client, channel, msg, cb) {
+                expect(client.nick).toEqual(mxUser.nick);
+                expect(client.addr).toEqual(config._server);
+                expect(channel).toEqual(config._chan);
+                expect(msg.indexOf("@the_kicker:localhost")).not.toEqual(-1,
+                    "Part message doesn't contain kicker's user ID");
+                parted = true;
+                client._invokeCallback(cb);
+            });
+
+            env.mockAppService._trigger("type:m.room.member", {
+                content: {
+                    membership: "leave"
+                },
+                user_id: "@the_kicker:localhost",
+                state_key: mxUser.id,
+                room_id: config._roomid,
+                type: "m.room.member"
+            }).done(function() {
+                expect(parted).toBe(true, "Didn't part");
+                done();
+            });
+        });
+    });
+
+    describe("Matrix users on IRC", function() {
+        it("should make the AS bot kick the Matrix user from the Matrix room",
+        test.coroutine(function*() {
+            var userKickedPromise = new Promise(function(resolve, reject) {
+                // assert function call when the bot attempts to kick
+                var botSdk = env.clientMock._client(config._botUserId);
+                botSdk.kick.andCallFake(function(roomId, userId, reason) {
+                    expect(roomId).toEqual(config._roomid);
+                    expect(userId).toEqual(mxUser.id);
+                    expect(reason.indexOf("KickerNick")).not.toEqual(-1,
+                        "Reason doesn't contain the kicker's nick");
+                    resolve();
+                    return Promise.resolve();
+                });
+            });
+
+            // send the KICK command
+            var botCli = yield env.ircMock._findClientAsync(
+                config._server, config._botnick
+            );
+            botCli.emit("kick", config._chan, mxUser.nick, "KickerNick", "Reasons");
+            yield userKickedPromise;
+        }));
+    });
+
+    describe("IRC users on Matrix", function() {
+
+    });
+});

--- a/spec/integ/mirroring.spec.js
+++ b/spec/integ/mirroring.spec.js
@@ -113,47 +113,6 @@ describe("Mirroring", function() {
             });
         });
 
-        it("should part the IRC channel if the kicker and kickee are both on Matrix",
-        function(done) {
-            var parted = false;
-            env.ircMock._autoJoinChannels(
-                roomMapping.server, testUser.nick, roomMapping.channel
-            );
-            env.ircMock._whenClient(roomMapping.server, testUser.nick, "part",
-            function(client, channel, msg, cb) {
-                expect(client.nick).toEqual(testUser.nick);
-                expect(client.addr).toEqual(roomMapping.server);
-                expect(channel).toEqual(roomMapping.channel);
-                expect(msg.indexOf("@the_kicker:localhost")).not.toEqual(-1,
-                    "Part message doesn't contain kicker's user ID");
-                parted = true;
-                client._invokeCallback(cb);
-            });
-
-            env.mockAppService._trigger("type:m.room.message", {
-                content: {
-                    body: "dummy text to get it to join",
-                    msgtype: "m.text"
-                },
-                user_id: testUser.id,
-                room_id: roomMapping.roomId,
-                type: "m.room.message"
-            }).then(function() {
-                return env.mockAppService._trigger("type:m.room.member", {
-                    content: {
-                        membership: "leave"
-                    },
-                    user_id: "@the_kicker:localhost",
-                    state_key: testUser.id,
-                    room_id: roomMapping.roomId,
-                    type: "m.room.member"
-                });
-            }).done(function() {
-                expect(parted).toBe(true, "Didn't part");
-                done();
-            });
-        });
-
         it("should no-op if a Matrix user joins a room not being tracked",
         function(done) {
             env.ircMock._whenClient(roomMapping.server, testUser.nick, "join",
@@ -245,42 +204,5 @@ describe("Mirroring", function() {
                 client.emit("part", roomMapping.channel, ircUser.nick);
             });
         });
-
-        it("should be kicked from the matrix room when the IRC user is kicked",
-        test.coroutine(function*() {
-            // join the room so they can be kicked
-            env.ircMock._autoJoinChannels(
-                roomMapping.server, testUser.nick, roomMapping.channel
-            );
-            yield env.mockAppService._trigger("type:m.room.member", {
-                content: {
-                    membership: "join"
-                },
-                user_id: testUser.id,
-                state_key: testUser.id,
-                room_id: roomMapping.roomId,
-                type: "m.room.member"
-            })
-
-            var userKickedPromise = new Promise(function(resolve, reject) {
-                // assert function call when the bot attempts to kick
-                var botSdk = env.clientMock._client(config._botUserId);
-                botSdk.kick.andCallFake(function(roomId, userId, reason) {
-                    expect(roomId).toEqual(roomMapping.roomId);
-                    expect(userId).toEqual(testUser.id);
-                    expect(reason.indexOf("KickerNick")).not.toEqual(-1,
-                        "Reason doesn't contain the kicker's nick");
-                    resolve();
-                    return Promise.resolve();
-                });
-            });
-
-            // send the KICK command
-            var botCli = yield env.ircMock._findClientAsync(
-                roomMapping.server, roomMapping.botNick
-            );
-            botCli.emit("kick", roomMapping.channel, testUser.nick, "KickerNick", "Reasons");
-            yield userKickedPromise;
-        }));
     });
 });

--- a/spec/integ/mirroring.spec.js
+++ b/spec/integ/mirroring.spec.js
@@ -113,7 +113,8 @@ describe("Mirroring", function() {
             });
         });
 
-        it("should part the IRC channel when the Matrix user is kicked", function(done) {
+        it("should part the IRC channel if the kicker and kickee are both on Matrix",
+        function(done) {
             var parted = false;
             env.ircMock._autoJoinChannels(
                 roomMapping.server, testUser.nick, roomMapping.channel

--- a/spec/util/client-sdk-mock.js
+++ b/spec/util/client-sdk-mock.js
@@ -25,6 +25,7 @@ function MockClient(config) {
     this.sendEvent = jasmine.createSpy("sdk.sendEvent(roomId,type,content)");
     this.invite = jasmine.createSpy("sdk.invite(roomId, userId)");
     this.leave = jasmine.createSpy("sdk.leave(roomId)");
+    this.kick = jasmine.createSpy("sdk.kick(roomId, target)");
     this.createAlias = jasmine.createSpy("sdk.createAlias(alias, roomId)");
     this.mxcUrlToHttp = jasmine.createSpy("sdk.mxcUrlToHttp(mxc, w, h, method)");
 


### PR DESCRIPTION
There are a number of kicking scenarios to be considered.

Matrix - IRC
```
  __USER A____            ____USER B___
 |            |          |             |
Matrix      vIRC        IRC       vMatrix  |     Effect
-----------------------------------------------------------------------
Kicker                            Kickee   |  vIRC tries to kick IRC via KICK command.
           Kickee      Kicker              |  Bot tries to kick Matrix user via /kick. (DONE)
```

Matrix - Matrix: (DONE)
```
  __USER A____            ____USER B___
 |            |          |             |
Matrix     vIRC1       Matrix        vIRC2 |     Effect
-----------------------------------------------------------------------
Kicker                 Kickee              |  vIRC2 parts channel.
```

IRC - IRC:
```
  __USER A____            ____USER B___
 |            |          |             |
IRC       vMatrix1       IRC      vMatrix2 |     Effect
-----------------------------------------------------------------------
Kicker                 Kickee              |  vMatrix2 leaves room.
```

This PR handles all of these scenarios.