### PR TITLE
Regex in generated registration file restricted

### DIFF
--- a/lib/irc/IrcServer.js
+++ b/lib/irc/IrcServer.js
@@ -276,7 +276,7 @@ IrcServer.prototype.getAliasRegex = function(hsdomain) {
             "$CHANNEL": ".*"  // the nick is unknown, so replace with a wildcard
         },
         // Only match the domain of the HS
-        ":" + hsdomain
+        ":" + escapeRegExp(hsdomain)
     );
 };
 
@@ -290,7 +290,7 @@ IrcServer.prototype.getUserRegex = function(hsdomain) {
             "$NICK": ".*"  // the nick is unknown, so replace with a wildcard
         },
         // Only match the domain of the HS
-        ":" + hsdomain
+        ":" + escapeRegExp(hsdomain)
     );
 };
 

--- a/lib/irc/IrcServer.js
+++ b/lib/irc/IrcServer.js
@@ -275,9 +275,8 @@ IrcServer.prototype.getAliasRegex = function() {
         {
             "$CHANNEL": ".*"  // the nick is unknown, so replace with a wildcard
         },
-        // The regex applies to the entire alias, so add a wildcard after : to
-        // match all domains.
-        ":.*"
+        // Only match the domain of the server
+        ":" + this.domain
     );
 };
 
@@ -290,9 +289,8 @@ IrcServer.prototype.getUserRegex = function() {
         {
             "$NICK": ".*"  // the nick is unknown, so replace with a wildcard
         },
-        // The regex applies to the entire user ID, so add a wildcard after : to
-        // match all domains.
-        ":.*"
+        // Only match the domain of the server
+        ":" + this.domain
     );
 };
 

--- a/lib/irc/IrcServer.js
+++ b/lib/irc/IrcServer.js
@@ -266,7 +266,7 @@ IrcServer.prototype.getNick = function(userId, displayName) {
     return nick;
 };
 
-IrcServer.prototype.getAliasRegex = function(hsdomain) {
+IrcServer.prototype.getAliasRegex = function(homeserverDomain) {
     return templateToRegex(
         this.config.dynamicChannels.aliasTemplate,
         {
@@ -276,11 +276,11 @@ IrcServer.prototype.getAliasRegex = function(hsdomain) {
             "$CHANNEL": ".*"  // the nick is unknown, so replace with a wildcard
         },
         // Only match the domain of the HS
-        ":" + escapeRegExp(hsdomain)
+        ":" + escapeRegExp(homeserverDomain)
     );
 };
 
-IrcServer.prototype.getUserRegex = function(hsdomain) {
+IrcServer.prototype.getUserRegex = function(homeserverDomain) {
     return templateToRegex(
         this.config.matrixClients.userTemplate,
         {
@@ -290,7 +290,7 @@ IrcServer.prototype.getUserRegex = function(hsdomain) {
             "$NICK": ".*"  // the nick is unknown, so replace with a wildcard
         },
         // Only match the domain of the HS
-        ":" + escapeRegExp(hsdomain)
+        ":" + escapeRegExp(homeserverDomain)
     );
 };
 

--- a/lib/irc/IrcServer.js
+++ b/lib/irc/IrcServer.js
@@ -266,7 +266,7 @@ IrcServer.prototype.getNick = function(userId, displayName) {
     return nick;
 };
 
-IrcServer.prototype.getAliasRegex = function() {
+IrcServer.prototype.getAliasRegex = function(hsdomain) {
     return templateToRegex(
         this.config.dynamicChannels.aliasTemplate,
         {
@@ -275,12 +275,12 @@ IrcServer.prototype.getAliasRegex = function() {
         {
             "$CHANNEL": ".*"  // the nick is unknown, so replace with a wildcard
         },
-        // Only match the domain of the server
-        ":" + this.domain
+        // Only match the domain of the HS
+        ":" + hsdomain
     );
 };
 
-IrcServer.prototype.getUserRegex = function() {
+IrcServer.prototype.getUserRegex = function(hsdomain) {
     return templateToRegex(
         this.config.matrixClients.userTemplate,
         {
@@ -289,8 +289,8 @@ IrcServer.prototype.getUserRegex = function() {
         {
             "$NICK": ".*"  // the nick is unknown, so replace with a wildcard
         },
-        // Only match the domain of the server
-        ":" + this.domain
+        // Only match the domain of the HS
+        ":" + hsdomain
     );
 };
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -84,9 +84,9 @@ module.exports.generateRegistration = Promise.coroutine(function*(reg, config) {
         });
         // add an alias pattern for servers who want aliases exposed.
         if (server.createsDynamicAliases()) {
-            reg.addRegexPattern("aliases", server.getAliasRegex(), true);
+            reg.addRegexPattern("aliases", server.getAliasRegex(config.homeserver.domain), true);
         }
-        reg.addRegexPattern("users", server.getUserRegex(), true);
+        reg.addRegexPattern("users", server.getUserRegex(config.homeserver.domain), true);
     });
 
     return reg;


### PR DESCRIPTION
The regex for user ids and aliases has been modified to include by default the configured HS domain from config.yaml.

Refers to #28 