### PR TITLE
Large Blocks of SPAM Uploaded as File

### DIFF
--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -206,6 +206,13 @@ ircService:
         # not apply an idle timeout. This value is ignored if this IRC server is
         # mirroring matrix membership lists to IRC. Default: 172800 (48 hours)
         idleTimeout: 10800
+        # The number of lines to allow being sent by the IRC client that has received
+        # a large block of text to send from matrix. If the number of lines that would
+        # be sent is > lineLimit, the text will instead be uploaded to matrix and the
+        # resulting URI is treated as a file. As such, a link will be sent to the IRC
+        # side instead of potentially spamming IRC and getting the IRC client kicked.
+        # Default: 3.
+        lineLimit: 3
   
   # Configuration for an ident server. If you are running a public bridge it is
   # advised you setup an ident server so IRC mods can ban specific matrix users

--- a/lib/bridge/IrcBridge.js
+++ b/lib/bridge/IrcBridge.js
@@ -297,6 +297,18 @@ IrcBridge.prototype.sendMatrixAction = function(room, from, action, req) {
     return Promise.reject(new Error("Unknown action: " + action.type));
 };
 
+IrcBridge.prototype.sendMatrixPlaintextFile = function(plaintext, req) {
+    if (req) {
+        req.log.info("sendMatrixPlaintextFile");
+    }
+    let intent = this._bridge.getIntent();
+    return intent.getClient().uploadContent({
+        stream: new Buffer(plaintext),
+        name: Date().replace(/\s/g,'_') + ".txt",
+        type: "text/plain",
+    });
+};
+
 IrcBridge.prototype.getMatrixUser = Promise.coroutine(function*(ircUser) {
     let matrixUser = null;
     let userLocalpart = ircUser.server.getUserLocalpart(ircUser.nick);

--- a/lib/bridge/IrcBridge.js
+++ b/lib/bridge/IrcBridge.js
@@ -302,7 +302,7 @@ IrcBridge.prototype.sendMatrixPlaintextFile = function(fileName, plaintext, req)
         req.log.info("sendMatrixPlaintextFile");
     }
     let intent = this._bridge.getIntent();
-    
+
     return intent.getClient().uploadContent({
         stream: new Buffer(plaintext),
         name: fileName,

--- a/lib/bridge/IrcBridge.js
+++ b/lib/bridge/IrcBridge.js
@@ -297,14 +297,15 @@ IrcBridge.prototype.sendMatrixAction = function(room, from, action, req) {
     return Promise.reject(new Error("Unknown action: " + action.type));
 };
 
-IrcBridge.prototype.sendMatrixPlaintextFile = function(plaintext, req) {
+IrcBridge.prototype.sendMatrixPlaintextFile = function(fileName, plaintext, req) {
     if (req) {
         req.log.info("sendMatrixPlaintextFile");
     }
     let intent = this._bridge.getIntent();
+    
     return intent.getClient().uploadContent({
         stream: new Buffer(plaintext),
-        name: Date().replace(/\s/g,'_') + ".txt",
+        name: fileName,
         type: "text/plain",
     });
 };

--- a/lib/bridge/IrcBridge.js
+++ b/lib/bridge/IrcBridge.js
@@ -297,13 +297,12 @@ IrcBridge.prototype.sendMatrixAction = function(room, from, action, req) {
     return Promise.reject(new Error("Unknown action: " + action.type));
 };
 
-IrcBridge.prototype.sendMatrixPlaintextFile = function(fileName, plaintext, req) {
+IrcBridge.prototype.uploadTextFile = function(fileName, plaintext, req) {
     if (req) {
-        req.log.info("sendMatrixPlaintextFile");
+        req.log.info("uploadTextFile");
     }
-    let intent = this._bridge.getIntent();
 
-    return intent.getClient().uploadContent({
+    return this._bridge.getIntent().getClient().uploadContent({
         stream: new Buffer(plaintext),
         name: fileName,
         type: "text/plain",

--- a/lib/bridge/MatrixHandler.js
+++ b/lib/bridge/MatrixHandler.js
@@ -770,64 +770,77 @@ MatrixHandler.prototype._onMessage = Promise.coroutine(function*(req, event) {
 });
 
 MatrixHandler.prototype._sendIrcAction = Promise.coroutine(
-    function*(req, ircRoom, ircUser, ircAction, event) {
+    function*(req, ircRoom, ircClient, ircAction, event) {
     let self = this;
 
     if (event.content.msgtype !== "m.text" ||
-        !(ircUser.unsafeClient && ircUser.unsafeClient.wouldSend)) {
-        yield self.ircBridge.sendIrcAction(ircRoom, ircUser, ircAction);
+        !(ircClient.unsafeClient && ircClient.unsafeClient.wouldSend)) {
+        yield self.ircBridge.sendIrcAction(ircRoom, ircClient, ircAction);
+        return;
     }
-    else {
-        let text = event.content.body;
-        let wouldSend = ircUser.unsafeClient.wouldSend(ircRoom.channel, text);
-        let lineLimit = 2;
-        if (wouldSend.length > lineLimit) {
-            // Message body too long - send a file to HS instead and send link to IRC
 
-            try {
-                // Upload as a file and get URI
+    let text = event.content.body;
 
-                let fileName = Date().replace(/\s/g, '_') + ".txt";
-                let response = yield self.ircBridge.sendMatrixPlaintextFile(fileName, text);
-                let result = JSON.parse(response);
-                event.content.url = result.content_uri;
+    // Generate an array of individual messages that would be sent
+    let potentialMessages = ircClient.unsafeClient.wouldSend(ircRoom.channel, text);
+    let lineLimit = 3;
+    if (potentialMessages.length < lineLimit) {
+        yield self.ircBridge.sendIrcAction(ircRoom, ircClient, ircAction);
+        return;
+    }
 
-                // Send the link to IRC
-                event.content.msgtype = "m.file";
-                event.content.body = fileName;
+    // Message body too long, upload to HS instead
+    try {
+        // Use the current time as the name of the file
+        //  strip off day of week and timezone
+        //  replace whitespace with underscores
+        // result e.g : Aug_01_2016_13:41:44.txt
+        let fileName = new Date().toString()
+            .match(/.*?\s(.*\:[0-9]*\:[0-9]*).*/)[1]
+            .replace(/\s/g,'_') + ".txt";
 
-                let bigFileIrvAction = IrcAction.fromMatrixAction(
-                    MatrixAction.fromEvent(
-                        self.ircBridge.getAppServiceBridge().getClientFactory().getClientAs(), event
-                    )
-                );
+        // Try to upload as a file and get URI
+        //  (this could fail, see the catch statement)
+        let response = yield self.ircBridge.sendMatrixPlaintextFile(fileName, text);
+        let result = JSON.parse(response);
 
-                yield self.ircBridge.sendIrcAction(ircRoom, ircUser, bigFileIrvAction);
-            }
-            catch (err) {
-                req.log.error("Failed to upload file, will truncate and send instead", err);
+        // Alter event object so that it is treated as if a file has been uploaded
+        event.content.url = result.content_uri;
+        event.content.msgtype = "m.file";
+        event.content.body = fileName;
 
-                event.content = {
-                    url : undefined,
-                    msgtype : "m.text",
-                    body : wouldSend.splice(0, lineLimit).join('\n') +
-                     "\n(Could not convert large text (truncated above) to file: \"" +
-                     err.message +
-                     "\")"
-                };
+        // Recreate action from modified event
+        let bigFileIrcAction = IrcAction.fromMatrixAction(
+            MatrixAction.fromEvent(
+                self.ircBridge.getAppServiceBridge().getClientFactory().getClientAs(), event
+            )
+        );
 
-                let trucatedIrcAction = IrcAction.fromMatrixAction(
-                    MatrixAction.fromEvent(
-                        self.ircBridge.getAppServiceBridge().getClientFactory().getClientAs(), event
-                    )
-                );
+        // Send the recreated action in place of ircAction
+        yield self.ircBridge.sendIrcAction(ircRoom, ircClient, bigFileIrcAction);
+    }
+    catch (err) {
+        // Uploading the file to HS could fail
+        req.log.error("Failed to upload file, will truncate and send instead", err);
 
-                yield self.ircBridge.sendIrcAction(ircRoom, ircUser, trucatedIrcAction);
-            }
-        }
-        else {
-            yield self.ircBridge.sendIrcAction(ircRoom, ircUser, ircAction);
-        }
+        // Modify the event to become a truncated version of the original
+        //  the truncation limits the number of lines to lineLimit
+        event.content = {
+            url : undefined,
+            msgtype : "m.text",
+            body : potentialMessages.splice(0, lineLimit).join('\n') +
+             `\n(Could not convert large text (truncated above) to file: ${err.message})`
+        };
+
+        // Recreate action from modified event
+        let trucatedIrcAction = IrcAction.fromMatrixAction(
+            MatrixAction.fromEvent(
+                self.ircBridge.getAppServiceBridge().getClientFactory().getClientAs(), event
+            )
+        );
+
+        // Send the truncated message action
+        yield self.ircBridge.sendIrcAction(ircRoom, ircClient, trucatedIrcAction);
     }
 });
 

--- a/lib/bridge/MatrixHandler.js
+++ b/lib/bridge/MatrixHandler.js
@@ -746,22 +746,7 @@ MatrixHandler.prototype._onMessage = Promise.coroutine(function*(req, event) {
                     ircRoom.server, event.user_id, displayName
                 );
 
-                let wouldSend = ircUser.unsafeClient.wouldSend(ircRoom.channel, event.content.body);
-                if (wouldSend.length > 0) {
-                    // Too long - send a file to the HS
-
-                    // Upload as a file and get back URI
-                    try {
-                        let result = yield self.ircBridge.sendMatrixPlaintextFile(event.content.body);
-                        console.log(result);
-                    }
-                    catch (err) {
-                        console.log(err.stack);
-                    }
-
-                } else {
-                }
-                yield self.ircBridge.sendIrcAction(ircRoom, ircUser, ircAction);
+                yield self._sendIrcAction(req, ircRoom, ircUser, ircAction, event);
             })());
         }
         else {
@@ -770,9 +755,7 @@ MatrixHandler.prototype._onMessage = Promise.coroutine(function*(req, event) {
                 let ircUser = yield self.ircBridge.getBridgedClient(
                     ircRoom.server, event.user_id
                 );
-                yield self.ircBridge.sendIrcAction(
-                    ircRoom, ircUser, ircAction
-                );
+                yield self._sendIrcAction(req, ircRoom, ircUser, ircAction, event);
             })());
         }
     });
@@ -784,6 +767,62 @@ MatrixHandler.prototype._onMessage = Promise.coroutine(function*(req, event) {
     }
 
     yield Promise.all(promises);
+});
+
+MatrixHandler.prototype._sendIrcAction = Promise.coroutine(function*(req, ircRoom, ircUser, ircAction, event)  {
+    let self = this;
+
+    if (event.content.msgtype !== "m.text" || !(ircUser.unsafeClient && ircUser.unsafeClient.wouldSend)) {
+        yield self.ircBridge.sendIrcAction(ircRoom, ircUser, ircAction);
+    } else {
+        let text = event.content.body;
+        let wouldSend = ircUser.unsafeClient.wouldSend(ircRoom.channel, text);
+        let lineLimit = 2;
+        if (wouldSend.length > lineLimit) {
+            // Message body too long - send a file to HS instead and send link to IRC
+
+            try {
+                // Upload as a file and get URI
+
+                let fileName = Date().replace(/\s/g,'_') + ".txt";
+                let response = yield self.ircBridge.sendMatrixPlaintextFile(fileName, text);
+                let result = JSON.parse(response);
+                event.content.url = result.content_uri;
+
+                // Send the link to IRC
+                event.content.msgtype = "m.file";
+                event.content.body = fileName;
+
+                let bigFileIrvAction = IrcAction.fromMatrixAction(
+                    MatrixAction.fromEvent(
+                        self.ircBridge.getAppServiceBridge().getClientFactory().getClientAs(), event
+                    )
+                );
+
+                yield self.ircBridge.sendIrcAction(ircRoom, ircUser, bigFileIrvAction);
+            }
+            catch (err) {
+                req.log.error("Failed to upload file, will truncate and send instead", err);
+
+                event.content = {
+                    url : undefined,
+                    msgtype : "m.text",
+                    body : wouldSend.splice(0, lineLimit).join('\n') +
+                     "\n(Could not convert large text (truncated above) to file: \"" + err.message + "\")"
+                };
+
+                let trucatedIrcAction = IrcAction.fromMatrixAction(
+                    MatrixAction.fromEvent(
+                        self.ircBridge.getAppServiceBridge().getClientFactory().getClientAs(), event
+                    )
+                );
+
+                yield self.ircBridge.sendIrcAction(ircRoom, ircUser, trucatedIrcAction);
+            }
+        } else {
+            yield self.ircBridge.sendIrcAction(ircRoom, ircUser, ircAction);
+        }
+    }
 });
 
 /**

--- a/lib/bridge/MatrixHandler.js
+++ b/lib/bridge/MatrixHandler.js
@@ -772,8 +772,10 @@ MatrixHandler.prototype._onMessage = Promise.coroutine(function*(req, event) {
 MatrixHandler.prototype._sendIrcAction = Promise.coroutine(
     function*(req, ircRoom, ircClient, ircAction, event) {
 
+    // Send the action as is if it is not a text message 
+    //  Also, check for the existance of the getSplitMessages method.
     if (event.content.msgtype !== "m.text" ||
-        !(ircClient.unsafeClient && ircClient.unsafeClient.wouldSend)) {
+        !(ircClient.unsafeClient && ircClient.unsafeClient.getSplitMessages)) {
         yield this.ircBridge.sendIrcAction(ircRoom, ircClient, ircAction);
         return;
     }
@@ -781,9 +783,9 @@ MatrixHandler.prototype._sendIrcAction = Promise.coroutine(
     let text = event.content.body;
 
     // Generate an array of individual messages that would be sent
-    let potentialMessages = ircClient.unsafeClient.wouldSend(ircRoom.channel, text);
+    let potentialMessages = ircClient.unsafeClient.getSplitMessages(ircRoom.channel, text);
     let lineLimit = ircRoom.server.getLineLimit();
-    
+
     if (potentialMessages.length <= lineLimit) {
         yield this.ircBridge.sendIrcAction(ircRoom, ircClient, ircAction);
         return;

--- a/lib/bridge/MatrixHandler.js
+++ b/lib/bridge/MatrixHandler.js
@@ -772,7 +772,7 @@ MatrixHandler.prototype._onMessage = Promise.coroutine(function*(req, event) {
 MatrixHandler.prototype._sendIrcAction = Promise.coroutine(
     function*(req, ircRoom, ircClient, ircAction, event) {
 
-    // Send the action as is if it is not a text message 
+    // Send the action as is if it is not a text message
     //  Also, check for the existance of the getSplitMessages method.
     if (event.content.msgtype !== "m.text" ||
         !(ircClient.unsafeClient && ircClient.unsafeClient.getSplitMessages)) {
@@ -792,43 +792,49 @@ MatrixHandler.prototype._sendIrcAction = Promise.coroutine(
     }
 
     // Message body too long, upload to HS instead
-    try {
         // Use the current time as the name of the file
         //  strip off day of week and timezone
         //  replace whitespace with underscores
         // result e.g : Aug_01_2016_13:41:44.txt
-        let fileName = new Date().toString()
-            .match(/.*?\s(.*\:[0-9]*\:[0-9]*).*/)[1]
-            .replace(/\s/g,'_') + ".txt";
+    let fileName = new Date().toString()
+        .match(/.*?\s(.*\:[0-9]*\:[0-9]*).*/)[1]
+        .replace(/\s/g, '_') + ".txt";
 
+    let result = {};
+
+    try {
         // Try to upload as a file and get URI
         //  (this could fail, see the catch statement)
-        let response = yield this.ircBridge.sendMatrixPlaintextFile(fileName, text);
-        let result = JSON.parse(response);
+        let response = yield this.ircBridge.uploadTextFile(fileName, text);
+        result = JSON.parse(response);
+    }
+    catch (err) {
+        // Uploading the file to HS could fail
+        req.log.error("Failed to upload text file ", err);
+    }
 
+    // This is true if the upload was a success
+    if (result.content_uri) {
         // Alter event object so that it is treated as if a file has been uploaded
         event.content.url = result.content_uri;
         event.content.msgtype = "m.file";
         event.content.body = fileName;
 
-        // Recreate action from modified event
+        // Create a file event to reflect the recent upload
         let bigFileIrcAction = IrcAction.fromMatrixAction(
             MatrixAction.fromEvent(
                 this.ircBridge.getAppServiceBridge().getClientFactory().getClientAs(), event
             )
         );
 
-        // Send the recreated action in place of ircAction
+        // Notify the IRC side of the uploaded text file
         yield this.ircBridge.sendIrcAction(ircRoom, ircClient, bigFileIrcAction);
     }
-    catch (err) {
-        // Uploading the file to HS could fail
-        req.log.error("Failed to upload file, will truncate and send instead", err);
+    else {
 
         // Modify the event to become a truncated version of the original
-        //  the truncation limits the number of lines to lineLimit
+        //  the truncation limits the number of lines to lineLimit.
         event.content = {
-            url : undefined,
             msgtype : "m.text",
             body : potentialMessages.splice(0, lineLimit).join('\n') +
              `\n(Could not convert large text (truncated above) to file: ${err.message})`
@@ -841,7 +847,6 @@ MatrixHandler.prototype._sendIrcAction = Promise.coroutine(
             )
         );
 
-        // Send the truncated message action
         yield this.ircBridge.sendIrcAction(ircRoom, ircClient, trucatedIrcAction);
     }
 });

--- a/lib/bridge/MatrixHandler.js
+++ b/lib/bridge/MatrixHandler.js
@@ -769,12 +769,15 @@ MatrixHandler.prototype._onMessage = Promise.coroutine(function*(req, event) {
     yield Promise.all(promises);
 });
 
-MatrixHandler.prototype._sendIrcAction = Promise.coroutine(function*(req, ircRoom, ircUser, ircAction, event)  {
+MatrixHandler.prototype._sendIrcAction = Promise.coroutine(
+    function*(req, ircRoom, ircUser, ircAction, event) {
     let self = this;
 
-    if (event.content.msgtype !== "m.text" || !(ircUser.unsafeClient && ircUser.unsafeClient.wouldSend)) {
+    if (event.content.msgtype !== "m.text" ||
+        !(ircUser.unsafeClient && ircUser.unsafeClient.wouldSend)) {
         yield self.ircBridge.sendIrcAction(ircRoom, ircUser, ircAction);
-    } else {
+    }
+    else {
         let text = event.content.body;
         let wouldSend = ircUser.unsafeClient.wouldSend(ircRoom.channel, text);
         let lineLimit = 2;
@@ -784,7 +787,7 @@ MatrixHandler.prototype._sendIrcAction = Promise.coroutine(function*(req, ircRoo
             try {
                 // Upload as a file and get URI
 
-                let fileName = Date().replace(/\s/g,'_') + ".txt";
+                let fileName = Date().replace(/\s/g, '_') + ".txt";
                 let response = yield self.ircBridge.sendMatrixPlaintextFile(fileName, text);
                 let result = JSON.parse(response);
                 event.content.url = result.content_uri;
@@ -808,7 +811,9 @@ MatrixHandler.prototype._sendIrcAction = Promise.coroutine(function*(req, ircRoo
                     url : undefined,
                     msgtype : "m.text",
                     body : wouldSend.splice(0, lineLimit).join('\n') +
-                     "\n(Could not convert large text (truncated above) to file: \"" + err.message + "\")"
+                     "\n(Could not convert large text (truncated above) to file: \"" +
+                     err.message +
+                     "\")"
                 };
 
                 let trucatedIrcAction = IrcAction.fromMatrixAction(
@@ -819,7 +824,8 @@ MatrixHandler.prototype._sendIrcAction = Promise.coroutine(function*(req, ircRoo
 
                 yield self.ircBridge.sendIrcAction(ircRoom, ircUser, trucatedIrcAction);
             }
-        } else {
+        }
+        else {
             yield self.ircBridge.sendIrcAction(ircRoom, ircUser, ircAction);
         }
     }

--- a/lib/bridge/MatrixHandler.js
+++ b/lib/bridge/MatrixHandler.js
@@ -745,6 +745,22 @@ MatrixHandler.prototype._onMessage = Promise.coroutine(function*(req, event) {
                 let ircUser = yield self.ircBridge.getBridgedClient(
                     ircRoom.server, event.user_id, displayName
                 );
+
+                let wouldSend = ircUser.unsafeClient.wouldSend(ircRoom.channel, event.content.body);
+                if (wouldSend.length > 0) {
+                    // Too long - send a file to the HS
+
+                    // Upload as a file and get back URI
+                    try {
+                        let result = yield self.ircBridge.sendMatrixPlaintextFile(event.content.body);
+                        console.log(result);
+                    }
+                    catch (err) {
+                        console.log(err.stack);
+                    }
+
+                } else {
+                }
                 yield self.ircBridge.sendIrcAction(ircRoom, ircUser, ircAction);
             })());
         }

--- a/lib/bridge/MatrixHandler.js
+++ b/lib/bridge/MatrixHandler.js
@@ -771,11 +771,10 @@ MatrixHandler.prototype._onMessage = Promise.coroutine(function*(req, event) {
 
 MatrixHandler.prototype._sendIrcAction = Promise.coroutine(
     function*(req, ircRoom, ircClient, ircAction, event) {
-    let self = this;
 
     if (event.content.msgtype !== "m.text" ||
         !(ircClient.unsafeClient && ircClient.unsafeClient.wouldSend)) {
-        yield self.ircBridge.sendIrcAction(ircRoom, ircClient, ircAction);
+        yield this.ircBridge.sendIrcAction(ircRoom, ircClient, ircAction);
         return;
     }
 
@@ -783,9 +782,10 @@ MatrixHandler.prototype._sendIrcAction = Promise.coroutine(
 
     // Generate an array of individual messages that would be sent
     let potentialMessages = ircClient.unsafeClient.wouldSend(ircRoom.channel, text);
-    let lineLimit = 3;
-    if (potentialMessages.length < lineLimit) {
-        yield self.ircBridge.sendIrcAction(ircRoom, ircClient, ircAction);
+    let lineLimit = ircRoom.server.getLineLimit();
+    
+    if (potentialMessages.length <= lineLimit) {
+        yield this.ircBridge.sendIrcAction(ircRoom, ircClient, ircAction);
         return;
     }
 
@@ -801,7 +801,7 @@ MatrixHandler.prototype._sendIrcAction = Promise.coroutine(
 
         // Try to upload as a file and get URI
         //  (this could fail, see the catch statement)
-        let response = yield self.ircBridge.sendMatrixPlaintextFile(fileName, text);
+        let response = yield this.ircBridge.sendMatrixPlaintextFile(fileName, text);
         let result = JSON.parse(response);
 
         // Alter event object so that it is treated as if a file has been uploaded
@@ -812,12 +812,12 @@ MatrixHandler.prototype._sendIrcAction = Promise.coroutine(
         // Recreate action from modified event
         let bigFileIrcAction = IrcAction.fromMatrixAction(
             MatrixAction.fromEvent(
-                self.ircBridge.getAppServiceBridge().getClientFactory().getClientAs(), event
+                this.ircBridge.getAppServiceBridge().getClientFactory().getClientAs(), event
             )
         );
 
         // Send the recreated action in place of ircAction
-        yield self.ircBridge.sendIrcAction(ircRoom, ircClient, bigFileIrcAction);
+        yield this.ircBridge.sendIrcAction(ircRoom, ircClient, bigFileIrcAction);
     }
     catch (err) {
         // Uploading the file to HS could fail
@@ -835,12 +835,12 @@ MatrixHandler.prototype._sendIrcAction = Promise.coroutine(
         // Recreate action from modified event
         let trucatedIrcAction = IrcAction.fromMatrixAction(
             MatrixAction.fromEvent(
-                self.ircBridge.getAppServiceBridge().getClientFactory().getClientAs(), event
+                this.ircBridge.getAppServiceBridge().getClientFactory().getClientAs(), event
             )
         );
 
         // Send the truncated message action
-        yield self.ircBridge.sendIrcAction(ircRoom, ircClient, trucatedIrcAction);
+        yield this.ircBridge.sendIrcAction(ircRoom, ircClient, trucatedIrcAction);
     }
 });
 

--- a/lib/bridge/MatrixHandler.js
+++ b/lib/bridge/MatrixHandler.js
@@ -792,13 +792,14 @@ MatrixHandler.prototype._sendIrcAction = Promise.coroutine(
     }
 
     // Message body too long, upload to HS instead
-        // Use the current time as the name of the file
-        //  strip off day of week and timezone
-        //  replace whitespace with underscores
-        // result e.g : Aug_01_2016_13:41:44.txt
-    let fileName = new Date().toString()
-        .match(/.*?\s(.*\:[0-9]*\:[0-9]*).*/)[1]
-        .replace(/\s/g, '_') + ".txt";
+
+    // Use the current ISO datetime as the name of the file
+    //  strip off milliseconds and replace 'T' with an underscore
+    //  result e.g : 2016-08-03T10:40:48.620Z becomes 2016-08-03_10:40:48
+    let fileName = new Date().toISOString()
+        .split(/[T|\.]/)
+        .splice(0, 2)
+        .join('_') + '.txt';
 
     let result = {};
 

--- a/lib/bridge/MatrixHandler.js
+++ b/lib/bridge/MatrixHandler.js
@@ -831,23 +831,25 @@ MatrixHandler.prototype._sendIrcAction = Promise.coroutine(
         yield this.ircBridge.sendIrcAction(ircRoom, ircClient, bigFileIrcAction);
     }
     else {
-
+        req.log.warn("Sending truncated message");
         // Modify the event to become a truncated version of the original
-        //  the truncation limits the number of lines to lineLimit.
+        //  the truncation limits the number of lines sent to lineLimit.
+
+        let msg = '\n...(Could not provide large text, truncated above, as file)';
+
         event.content = {
             msgtype : "m.text",
-            body : potentialMessages.splice(0, lineLimit).join('\n') +
-             `\n(Could not convert large text (truncated above) to file: ${err.message})`
+            body : potentialMessages.splice(0, lineLimit - 1).join('\n') + msg
         };
 
         // Recreate action from modified event
-        let trucatedIrcAction = IrcAction.fromMatrixAction(
+        let truncatedIrcAction = IrcAction.fromMatrixAction(
             MatrixAction.fromEvent(
                 this.ircBridge.getAppServiceBridge().getClientFactory().getClientAs(), event
             )
         );
 
-        yield this.ircBridge.sendIrcAction(ircRoom, ircClient, trucatedIrcAction);
+        yield this.ircBridge.sendIrcAction(ircRoom, ircClient, truncatedIrcAction);
     }
 });
 

--- a/lib/config/schema.yml
+++ b/lib/config/schema.yml
@@ -237,4 +237,6 @@ properties:
                                         prefix:
                                             type: "string"
                                             pattern: "[ABCDEFabcdef0123456789:]+"
+                                lineLimit:
+                                    type: "integer"
         required: ["databaseUri", "servers"]

--- a/lib/irc/IrcServer.js
+++ b/lib/irc/IrcServer.js
@@ -91,6 +91,10 @@ IrcServer.prototype.getIpv6Prefix = function() {
     return this.config.ircClients.ipv6.prefix;
 };
 
+IrcServer.prototype.getLineLimit = function() {
+    return this.config.ircClients.lineLimit;
+};
+
 IrcServer.prototype.isExcludedChannel = function(channel) {
     return this.config.dynamicChannels.exclude.indexOf(channel) !== -1;
 };

--- a/lib/irc/IrcServer.js
+++ b/lib/irc/IrcServer.js
@@ -365,7 +365,8 @@ IrcServer.DEFAULT_CONFIG = {
         maxClients: 30,
         idleTimeout: 172800,
         allowNickChanges: false,
-        ipv6: {}
+        ipv6: {},
+        lineLimit: 3
     },
     membershipLists: {
         enabled: false,


### PR DESCRIPTION
In response to issue #56, the IRC bridge will now protect itself against large amounts of SPAM (which has been defined arbitrarily as anything with more than N lines) being sent across to IRC, and thus getting itself banned. When messages that are too long are sent from the HS, the bridge attempts to upload a plaintext file to the HS. If successful, it will send a URL to IRC in the same way IRC deals with files and images. If it fails to upload the file, the first N lines will be sent to IRC with a message explaining why the file could not be uploaded.

N has arbitrarily been set to 2. This should be refactored to the config file, which I can do. Any ideas as to what the default number of lines should be?