### PR TITLE
Provisioning API

### DIFF
--- a/lib/DataStore.js
+++ b/lib/DataStore.js
@@ -88,18 +88,39 @@ DataStore.prototype.storeRoom = function(ircRoom, matrixRoom, origin) {
         matrixRoom.getId(), ircRoom.get("domain"), ircRoom.channel, origin);
 
     let mappingId = createMappingId(matrixRoom.getId(), ircRoom.get("domain"), ircRoom.channel);
+    return this._roomStore.linkRooms(matrixRoom, ircRoom, {
+        origin: origin
+    }, mappingId);
+};
 
-    let self = this;
+/**
+ * Get an IRC <--> Matrix room mapping from the database.
+ * @param {string} roomId : The Matrix room ID.
+ * @param {string} ircDomain : The IRC server domain.
+ * @param {string} ircChannel : The IRC channel.
+ * @param {string} origin : (Optional) "config" if this mapping was from the config yaml,
+ * "provision" if this mapping was provisioned, "alias" if it was created via aliasing and
+ * "join" if it was created during a join.
+ * @return {Promise}
+ */
+DataStore.prototype.getRoom = function(roomId, ircDomain, ircChannel, origin) {
+    if (typeof origin !== 'undefined' && typeof origin !== 'string') {
+        throw new Error(`If defined, origin must be a string =
+            "config"|"provision"|"alias"|"join"`);
+    }
+    let mappingId = createMappingId(roomId, ircDomain, ircChannel);
 
-    return this._roomStore.selectOne({id : mappingId})
-        .then((doc) => {
-            if (doc) {
-                return Promise.reject(new Error("Room mapping already exists"));
-            }
-            return self._roomStore.linkRooms(matrixRoom, ircRoom, {
-                origin: origin
-            }, mappingId);
-        });
+    let query = {
+        id : mappingId
+    };
+
+    if (origin) {
+        query.data = {
+            origin : origin
+        };
+    }
+
+    return this._roomStore.selectOne(query);
 };
 
 /**

--- a/lib/DataStore.js
+++ b/lib/DataStore.js
@@ -112,7 +112,7 @@ DataStore.prototype.getRoom = function(roomId, ircDomain, ircChannel, origin) {
 
     return this._roomStore.getEntryById(mappingId).then(
         (entry) => {
-            if (origin && origin !== entry.data.origin) {
+            if (origin && entry && origin !== entry.data.origin) {
                 return null;
             }
             return entry;

--- a/lib/DataStore.js
+++ b/lib/DataStore.js
@@ -80,19 +80,13 @@ DataStore.prototype.setServerFromConfig = Promise.coroutine(function*(server, se
  * @return {Promise}
  */
 DataStore.prototype.storeRoom = function(ircRoom, matrixRoom, origin) {
-    if (typeof origin === 'boolean') {
-        log.warn('Origin must be a string = "config"|"provision"');
-        origin = origin?'config':'unknown';
-    }
-
     if (typeof origin !== 'string') {
-        throw new Error('Origin must be a string = "config"|"provision"');
+        throw new Error('Origin must be a string = "config"|"provision"|"alias"|"join"');
     }
 
     log.info("storeRoom (id=%s, addr=%s, chan=%s, origin=%s)",
         matrixRoom.getId(), ircRoom.get("domain"), ircRoom.channel, origin);
     return this._roomStore.linkRooms(matrixRoom, ircRoom, {
-        from_config: origin === 'config', // kept for backwards compatibility
         origin: origin
     }, createMappingId(matrixRoom.getId(), ircRoom.get("domain"), ircRoom.channel));
 };

--- a/lib/DataStore.js
+++ b/lib/DataStore.js
@@ -260,8 +260,11 @@ DataStore.prototype.getRoomIdsFromConfig = function() {
 DataStore.prototype.removeConfigMappings = function() {
     log.debug("removeConfigMappings ");
     return this._roomStore.removeEntriesByLinkData({
-        from_config: true, // for backwards compatibility
-        origin: 'config'
+        from_config: true // for backwards compatibility
+    }).then(() => {
+        return this._roomStore.removeEntriesByLinkData({
+            origin: 'config'
+        })
     });
 };
 

--- a/lib/DataStore.js
+++ b/lib/DataStore.js
@@ -74,8 +74,9 @@ DataStore.prototype.setServerFromConfig = Promise.coroutine(function*(server, se
  * Persists an IRC <--> Matrix room mapping in the database.
  * @param {IrcRoom} ircRoom : The IRC room to store.
  * @param {MatrixRoom} matrixRoom : The Matrix room to store.
- * @param {string} origin : "config" if this mapping is from the config yaml. 
- * "provision" if this mapping was provisioned.
+ * @param {string} origin : "config" if this mapping is from the config yaml,
+ * "provision" if this mapping was provisioned, "alias" if it was created via
+ * aliasing and "join" if it was created during a join.
  * @return {Promise}
  */
 DataStore.prototype.storeRoom = function(ircRoom, matrixRoom, origin) {

--- a/lib/DataStore.js
+++ b/lib/DataStore.js
@@ -101,7 +101,7 @@ DataStore.prototype.storeRoom = function(ircRoom, matrixRoom, origin) {
  * @param {string} origin : (Optional) "config" if this mapping was from the config yaml,
  * "provision" if this mapping was provisioned, "alias" if it was created via aliasing and
  * "join" if it was created during a join.
- * @return {Promise}
+ * @return {Promise} A promise which resolves to a room entry, or null if one is not found.
  */
 DataStore.prototype.getRoom = function(roomId, ircDomain, ircChannel, origin) {
     if (typeof origin !== 'undefined' && typeof origin !== 'string') {
@@ -110,17 +110,13 @@ DataStore.prototype.getRoom = function(roomId, ircDomain, ircChannel, origin) {
     }
     let mappingId = createMappingId(roomId, ircDomain, ircChannel);
 
-    let query = {
-        id : mappingId
-    };
-
-    if (origin) {
-        query.data = {
-            origin : origin
-        };
-    }
-
-    return this._roomStore.selectOne(query);
+    return this._roomStore.getEntryById(mappingId).then(
+        (entry) => {
+            if (origin && origin !== entry.data.origin) {
+                return null;
+            }
+            return entry;
+        });
 };
 
 /**

--- a/lib/DataStore.js
+++ b/lib/DataStore.js
@@ -74,15 +74,25 @@ DataStore.prototype.setServerFromConfig = Promise.coroutine(function*(server, se
  * Persists an IRC <--> Matrix room mapping in the database.
  * @param {IrcRoom} ircRoom : The IRC room to store.
  * @param {MatrixRoom} matrixRoom : The Matrix room to store.
- * @param {boolean} fromConfig : True if this mapping is from the config yaml.
+ * @param {string} origin : "config" if this mapping is from the config yaml. 
+ * "provision" if this mapping was provisioned.
  * @return {Promise}
  */
-DataStore.prototype.storeRoom = function(ircRoom, matrixRoom, fromConfig) {
-    fromConfig = Boolean(fromConfig);
-    log.info("storeRoom (id=%s, addr=%s, chan=%s, config=%s)",
-        matrixRoom.getId(), ircRoom.get("domain"), ircRoom.channel, fromConfig);
+DataStore.prototype.storeRoom = function(ircRoom, matrixRoom, origin) {
+    if (typeof origin === 'boolean') {
+        log.warn('Origin must be a string = "config"|"provision"');
+        origin = origin?'config':'unknown';
+    }
+
+    if (typeof origin !== 'string') {
+        throw new Error('Origin must be a string = "config"|"provision"');
+    }
+
+    log.info("storeRoom (id=%s, addr=%s, chan=%s, origin=%s)",
+        matrixRoom.getId(), ircRoom.get("domain"), ircRoom.channel, origin);
     return this._roomStore.linkRooms(matrixRoom, ircRoom, {
-        from_config: fromConfig
+        from_config: origin === 'config', // kept for backwards compatibility
+        origin: origin
     }, createMappingId(matrixRoom.getId(), ircRoom.get("domain"), ircRoom.channel));
 };
 
@@ -187,7 +197,7 @@ DataStore.prototype.getTrackedChannelsForServer = function(ircAddr) {
 DataStore.prototype.getRoomIdsFromConfig = function() {
     log.debug("getRoomIdsFromConfig ");
     return this._roomStore.getEntriesByLinkData({
-        from_config: true
+        origin: 'config'
     }).then(function(entries) {
         return entries.map((e) => {
             return e.matrix.getId();
@@ -198,7 +208,7 @@ DataStore.prototype.getRoomIdsFromConfig = function() {
 DataStore.prototype.removeConfigMappings = function() {
     log.debug("removeConfigMappings ");
     return this._roomStore.removeEntriesByLinkData({
-        from_config: true
+        origin: 'config'
     });
 };
 

--- a/lib/DataStore.js
+++ b/lib/DataStore.js
@@ -92,6 +92,31 @@ DataStore.prototype.storeRoom = function(ircRoom, matrixRoom, origin) {
 };
 
 /**
+ * Remove an IRC <--> Matrix room mapping from the database.
+ * @param {string} roomId : The Matrix room ID.
+ * @param {string} ircDomain : The IRC server domain.
+ * @param {string} ircChannel : The IRC channel.
+ * @param {string} origin : "config" if this mapping was from the config yaml,
+ * "provision" if this mapping was provisioned, "alias" if it was created via
+ * aliasing and "join" if it was created during a join.
+ * @return {Promise}
+ */
+DataStore.prototype.removeRoom = function(roomId, ircDomain, ircChannel, origin) {
+    if (typeof origin !== 'string') {
+        throw new Error('Origin must be a string = "config"|"provision"|"alias"|"join"');
+    }
+
+    log.info("removeRoom (id=%s, addr=%s, chan=%s, origin=%s)",
+        roomId, ircDomain, ircChannel, origin);
+    return this._roomStore.delete({
+        id: createMappingId(roomId, ircDomain, ircChannel),
+        data: {
+            origin: origin
+        }
+    });
+};
+
+/**
  * Retrieve a list of IRC rooms for a given room ID.
  * @param {string} roomId : The room ID to get mapped IRC channels.
  * @return {Promise<Array<IrcRoom>>} A promise which resolves to a list of
@@ -203,6 +228,7 @@ DataStore.prototype.getRoomIdsFromConfig = function() {
 DataStore.prototype.removeConfigMappings = function() {
     log.debug("removeConfigMappings ");
     return this._roomStore.removeEntriesByLinkData({
+        from_config: true, // for backwards compatibility
         origin: 'config'
     });
 };

--- a/lib/DataStore.js
+++ b/lib/DataStore.js
@@ -65,7 +65,7 @@ DataStore.prototype.setServerFromConfig = Promise.coroutine(function*(server, se
             var mxRoom = new MatrixRoom(
                 serverConfig.mappings[channel][k]
             );
-            yield this.storeRoom(ircRoom, mxRoom, true);
+            yield this.storeRoom(ircRoom, mxRoom, 'config');
         }
     }
 });

--- a/lib/DataStore.js
+++ b/lib/DataStore.js
@@ -86,9 +86,20 @@ DataStore.prototype.storeRoom = function(ircRoom, matrixRoom, origin) {
 
     log.info("storeRoom (id=%s, addr=%s, chan=%s, origin=%s)",
         matrixRoom.getId(), ircRoom.get("domain"), ircRoom.channel, origin);
-    return this._roomStore.linkRooms(matrixRoom, ircRoom, {
-        origin: origin
-    }, createMappingId(matrixRoom.getId(), ircRoom.get("domain"), ircRoom.channel));
+
+    let mappingId = createMappingId(matrixRoom.getId(), ircRoom.get("domain"), ircRoom.channel);
+
+    let self = this;
+
+    return this._roomStore.selectOne({id : mappingId})
+        .then((doc) => {
+            if (doc) {
+                return Promise.reject(new Error("Room mapping already exists"));
+            }
+            return self._roomStore.linkRooms(matrixRoom, ircRoom, {
+                origin: origin
+            }, mappingId);
+        });
 };
 
 /**

--- a/lib/bridge/IrcBridge.js
+++ b/lib/bridge/IrcBridge.js
@@ -22,6 +22,7 @@ var log = require("../logging").get("IrcBridge");
 var Bridge = require("matrix-appservice-bridge").Bridge;
 var MatrixUser = require("matrix-appservice-bridge").MatrixUser;
 var DebugApi = require("../DebugApi");
+var Provisioner = require("../provisioning/Provisioner.js");
 
 const DELAY_TIME_MS = 10 * 1000;
 const DEAD_TIME_MS = 5 * 60 * 1000;
@@ -84,6 +85,8 @@ function IrcBridge(config, registration) {
             registration.getAppServiceToken()
         ) : null
     );
+
+    this._provisioner = null;
 }
 
 IrcBridge.prototype.getAppServiceUserId = function() {
@@ -250,6 +253,9 @@ IrcBridge.prototype.run = Promise.coroutine(function*(port) {
             this.memberListSyncers[server.domain].sync()
         );
     });
+    log.info("Starting provisioning...");
+    this._provisioner = new Provisioner(this);
+
     log.info("Connecting to IRC networks...");
     yield this.connectToIrcNetworks();
     yield Promise.all(memberlistPromises);

--- a/lib/bridge/MatrixHandler.js
+++ b/lib/bridge/MatrixHandler.js
@@ -291,7 +291,7 @@ MatrixHandler.prototype._onAdminMessage = Promise.coroutine(function*(req, event
             });
             let mxRoom = new MatrixRoom(response.room_id);
             yield this.ircBridge.getStore().storeRoom(
-                ircRoom, mxRoom
+                ircRoom, mxRoom, 'join'
             );
             req.log.info(
                 "Created a room to track %s on %s and invited %s",
@@ -861,7 +861,7 @@ MatrixHandler.prototype._onAliasQuery = Promise.coroutine(function*(req, roomAli
 
         // ========= store the mapping and return OK
         let ircRoom = new IrcRoom(channelInfo.server, channelInfo.channel);
-        yield this.ircBridge.getStore().storeRoom(ircRoom, matrixRoom);
+        yield this.ircBridge.getStore().storeRoom(ircRoom, matrixRoom, 'alias');
     }
     else {
         // create an alias pointing to this room (take first)

--- a/lib/provisioning/Provisioner.js
+++ b/lib/provisioning/Provisioner.js
@@ -80,7 +80,7 @@ Provisioner.prototype.link = Promise.coroutine(function*(options) {
     let ircRoom = new IrcRoom(server, ircChannel);
     let mxRoom = new MatrixRoom(roomId);
 
-    yield this._ircBridge.getStore().storeRoom(ircRoom, mxRoom, false);
+    yield this._ircBridge.getStore().storeRoom(ircRoom, mxRoom, 'provision');
 });
 
 // Unlink an IRC channel from a matrix room ID

--- a/lib/provisioning/Provisioner.js
+++ b/lib/provisioning/Provisioner.js
@@ -97,7 +97,7 @@ Provisioner.prototype.link = Promise.coroutine(function*(options) {
 
     let entry = yield this._ircBridge.getStore().getRoom(roomId, ircDomain, ircChannel);
     if (!entry) {
-        this._ircBridge.getStore().storeRoom(ircRoom, mxRoom, 'provision');
+        yield this._ircBridge.getStore().storeRoom(ircRoom, mxRoom, 'provision');
     }
     else {
         throw new Error(`Room mapping already exists (${mappingLogId},` +
@@ -126,7 +126,7 @@ Provisioner.prototype.unlink = Promise.coroutine(function*(options) {
         .getRoom(roomId, ircDomain, ircChannel, 'provision');
 
     if (entry) {
-        this._ircBridge.getStore().removeRoom(roomId, ircDomain, ircChannel, 'provision');
+        yield this._ircBridge.getStore().removeRoom(roomId, ircDomain, ircChannel, 'provision');
     }
     else {
         throw new Error(`Provisioned room mapping does not exist (${mappingLogId})`);

--- a/lib/provisioning/Provisioner.js
+++ b/lib/provisioning/Provisioner.js
@@ -12,20 +12,16 @@ function Provisioner(ircBridge) {
 
     
     as.app.post("/_matrix/provision/link", (req, res) => {
-        log.info("Provisioning link");
-
         this.validate(req.body).then(
             ()  => { res.json({}) },
             (err) => { res.status(500).json({error: err.message}) }
         ).then(
-            ()  => { this.unlink(req.body) },
+            ()  => { this.link(req.body) },
             (err) => { res.status(500).json({error: err.message}) }
         );
     });
 
     as.app.post("/_matrix/provision/unlink", (req, res) => {
-        log.info("Provisioning unlink");
-
         this.validate(req.body).then(
             ()  => { res.json({}) },
             (err) => { res.status(500).json({error: err.message}) }
@@ -65,6 +61,8 @@ Provisioner.prototype.link = Promise.coroutine(function*(options) {
     let ircChannel = options.remote_room_channel;
     let roomId = options.matrix_room_id;
 
+    log.info(`Provisioning link for room ${roomId} <---> ${ircChannel}`);
+
     if (!ircDomain || !ircChannel|| !roomId) {
         throw new Error("Server domain, ircChannel and room ID are required.");
     }
@@ -88,6 +86,9 @@ Provisioner.prototype.unlink = Promise.coroutine(function*(options) {
     let ircDomain = options.remote_room_server;
     let ircChannel = options.remote_room_channel;
     let roomId = options.matrix_room_id;
+
+    log.info(`Provisioning unlink for room ${roomId} <-/-> ${ircChannel}`);
+
 
     if (!ircDomain || !ircChannel|| !roomId) {
         throw new Error("Server domain, ircChannel and room ID are required.");

--- a/lib/provisioning/Provisioner.js
+++ b/lib/provisioning/Provisioner.js
@@ -1,3 +1,4 @@
+/*eslint no-invalid-this: 0*/ // eslint doesn't understand Promise.coroutine wrapping
 "use strict";
 var Promise = require("bluebird");
 var IrcRoom = require("../models/IrcRoom");
@@ -12,44 +13,46 @@ function Provisioner(ircBridge) {
 
     as.app.post("/_matrix/provision/link", (req, res) => {
         this.validate(req.body).then(
-            ()  => { res.json({}) },
+            () => { res.json({}) },
             (err) => { res.status(500).json({error: err.message}) }
         ).then(
-            ()  => { this.link(req.body) },
+            () => { this.link(req.body) },
             (err) => { res.status(500).json({error: err.message}) }
         );
     });
 
     as.app.post("/_matrix/provision/unlink", (req, res) => {
         this.validate(req.body).then(
-            ()  => { res.json({}) },
+            () => { res.json({}) },
             (err) => { res.status(500).json({error: err.message}) }
         ).then(
-            ()  => { this.unlink(req.body) },
+            () => { this.unlink(req.body) },
             (err) => { res.status(500).json({error: err.message}) }
         );
     });
-};
+}
 
-var parameterRegexes = {
-    matrix_room_id : /^![0-9A-Za-z]+?:[^:]+(\:[0-9]+)?$/,
-    remote_room_channel : /^#.+$/,
-    remote_room_server : /^[a-z\.]+$/
-};
-
-var parameterExamples = {
-    matrix_room_id : '!Abcdefg:example.com[:8080]',
-    remote_room_channel : '#roomname',
-    remote_room_server : 'example.com or localhost'
+var parameterValidation = {
+    matrix_room_id :
+        {regex : /^![0-9A-Za-z]+?:[^:]+(\:[0-9]+)?$/, example : '!Abcdefg:example.com[:8080]'},
+    remote_room_channel :
+        {regex : /^#.+$/, example : '#roomname'},
+    remote_room_server :
+        {regex :  /^[a-z\.]+$/, example : 'example.com or localhost'},
 };
 
 Provisioner.prototype.validate = Promise.coroutine(function*(parameters) {
-    for (var name in parameters) {
-        let actual = parameters[name];
+    let parameterNames = ['matrix_room_id', 'remote_room_channel', 'remote_room_server'];
+    for (var i = 0; i < parameterNames.length; i++) {
+        let name = parameterNames[i];
 
-        if (!actual.match(parameterRegexes[name])) {
-            let example = parameterExamples[name];
-            throw new Error(`Malformed ${name} ('${actual}'), should look like '${example}'.`);
+        let actual = parameters[name];
+        let valid = parameterValidation[name];
+
+        if (!actual.match(valid.regex)) {
+            throw new Error(
+                `Malformed ${name} ('${actual}'), should look like '${valid.example}'.`
+            );
         }
     }
 });

--- a/lib/provisioning/Provisioner.js
+++ b/lib/provisioning/Provisioner.js
@@ -79,8 +79,9 @@ Provisioner.prototype.link = Promise.coroutine(function*(options) {
     let ircDomain = options.remote_room_server;
     let ircChannel = options.remote_room_channel;
     let roomId = options.matrix_room_id;
+    let mappingLogId = `${roomId} <---> ${ircDomain}/${ircChannel}`;
 
-    log.info(`Provisioning link for room ${roomId} <---> ${ircDomain}/${ircChannel}`);
+    log.info(`Provisioning link for room ${mappingLogId}`);
 
     // Try to find the domain requested for linking
     //TODO: ircDomain might include protocol, i.e. irc://irc.freenode.net
@@ -94,7 +95,18 @@ Provisioner.prototype.link = Promise.coroutine(function*(options) {
     let ircRoom = new IrcRoom(server, ircChannel);
     let mxRoom = new MatrixRoom(roomId);
 
-    yield this._ircBridge.getStore().storeRoom(ircRoom, mxRoom, 'provision');
+    yield this._ircBridge.getStore()
+        .getRoom(roomId, ircDomain, ircChannel)
+        .then((doc) => {
+            if (!doc) {
+                this._ircBridge.getStore().storeRoom(ircRoom, mxRoom, 'provision');
+            }
+            else {
+                return Promise.reject(
+                    new Error(
+                        `Room mapping already exists (${mappingLogId},
+                        origin = ${doc.data.origin})`));
+            }})
 });
 
 // Unlink an IRC channel from a matrix room ID
@@ -102,8 +114,9 @@ Provisioner.prototype.unlink = Promise.coroutine(function*(options) {
     let ircDomain = options.remote_room_server;
     let ircChannel = options.remote_room_channel;
     let roomId = options.matrix_room_id;
+    let mappingLogId = `${roomId} <-/-> ${ircDomain}/${ircChannel}`;
 
-    log.info(`Provisioning unlink for room ${roomId} <-/-> ${ircDomain}/${ircChannel}`);
+    log.info(`Provisioning unlink for room ${mappingLogId}`);
 
     // Try to find the domain requested for unlinking
     let server = this._ircBridge.getServer(ircDomain);
@@ -112,8 +125,17 @@ Provisioner.prototype.unlink = Promise.coroutine(function*(options) {
         throw new Error("Server requested for linking not found");
     }
 
-    // Delete the room link, but don't update the bridge
-    yield this._ircBridge.getStore().removeRoom(roomId, ircDomain, ircChannel, 'provision');
+    // Delete the room link
+    yield this._ircBridge.getStore()
+        .getRoom(roomId, ircDomain, ircChannel, 'provision')
+        .then((doc) => {
+            if (doc) {
+                this._ircBridge.getStore().removeRoom(roomId, ircDomain, ircChannel, 'provision');
+            }
+            else {
+                return Promise.reject(new Error(
+                    `Provisioned room mapping does not exist (${mappingLogId})`));
+            }})
 });
 
 module.exports = Provisioner;

--- a/lib/provisioning/Provisioner.js
+++ b/lib/provisioning/Provisioner.js
@@ -1,0 +1,47 @@
+"use strict";
+var Promise = require("bluebird");
+var IrcRoom = require("../models/IrcRoom");
+var MatrixRoom = require("matrix-appservice-bridge").MatrixRoom;
+
+var log = require("../logging").get("Provisioner");
+
+function Provisioner(ircBridge) {
+    this._ircBridge = ircBridge;
+
+    let as = this._ircBridge.getAppServiceBridge().appService;
+
+    as.app.post("/_matrix/provision/link", (req, res) => {
+        log.info("Provisioning link");
+
+        let serverDomain = req.body.remote_room_server;
+        let channel = req.body.remote_room_channel;
+        let mxRoomId = req.body.matrix_room_id;
+
+        this.link(serverDomain, channel, mxRoomId);
+    });
+};
+
+// Link an IRC channel to a matrix room ID
+Provisioner.prototype.link = Promise.coroutine(function*(serverDomain, channel, mxRoomId) {
+    log.info(serverDomain, channel, mxRoomId);
+    if (!serverDomain || !channel|| !mxRoomId) {
+        throw new Error("Server domain, channel and room ID are required.");
+    }
+
+
+    // Try to find the domain requested for linking
+    let server = this._ircBridge.getServer(serverDomain);
+
+    if (!server) {
+        log.error('Server requested for linking not found');
+        return;
+    }
+
+    // Create rooms for the link
+    let ircRoom = new IrcRoom(server, channel);
+    let mxRoom = new MatrixRoom(mxRoomId);
+
+    yield this._ircBridge.getStore().storeRoom(ircRoom, mxRoom, false);
+});
+
+module.exports = Provisioner;

--- a/lib/provisioning/Provisioner.js
+++ b/lib/provisioning/Provisioner.js
@@ -95,18 +95,14 @@ Provisioner.prototype.link = Promise.coroutine(function*(options) {
     let ircRoom = new IrcRoom(server, ircChannel);
     let mxRoom = new MatrixRoom(roomId);
 
-    yield this._ircBridge.getStore()
-        .getRoom(roomId, ircDomain, ircChannel)
-        .then((doc) => {
-            if (!doc) {
-                this._ircBridge.getStore().storeRoom(ircRoom, mxRoom, 'provision');
-            }
-            else {
-                return Promise.reject(
-                    new Error(
-                        `Room mapping already exists (${mappingLogId},
-                        origin = ${doc.data.origin})`));
-            }})
+    let entry = yield this._ircBridge.getStore().getRoom(roomId, ircDomain, ircChannel);
+    if (!entry) {
+        this._ircBridge.getStore().storeRoom(ircRoom, mxRoom, 'provision');
+    }
+    else {
+        throw new Error(`Room mapping already exists (${mappingLogId},` +
+                        `origin = ${doc.data.origin})`);
+    }
 });
 
 // Unlink an IRC channel from a matrix room ID
@@ -126,16 +122,15 @@ Provisioner.prototype.unlink = Promise.coroutine(function*(options) {
     }
 
     // Delete the room link
-    yield this._ircBridge.getStore()
-        .getRoom(roomId, ircDomain, ircChannel, 'provision')
-        .then((doc) => {
-            if (doc) {
-                this._ircBridge.getStore().removeRoom(roomId, ircDomain, ircChannel, 'provision');
-            }
-            else {
-                return Promise.reject(new Error(
-                    `Provisioned room mapping does not exist (${mappingLogId})`));
-            }})
+    let entry = yield this._ircBridge.getStore()
+        .getRoom(roomId, ircDomain, ircChannel, 'provision');
+
+    if (entry) {
+        this._ircBridge.getStore().removeRoom(roomId, ircDomain, ircChannel, 'provision');
+    }
+    else {
+        throw new Error(`Provisioned room mapping does not exist (${mappingLogId})`);
+    }
 });
 
 module.exports = Provisioner;

--- a/lib/provisioning/Provisioner.js
+++ b/lib/provisioning/Provisioner.js
@@ -17,7 +17,10 @@ function Provisioner(ircBridge) {
         let channel = req.body.remote_room_channel;
         let mxRoomId = req.body.matrix_room_id;
 
-        this.link(serverDomain, channel, mxRoomId);
+        this.link(serverDomain, channel, mxRoomId).then(
+            ()  => { res.json({}) },
+            (err) => { res.status(500).json({error: err.message}) }
+        );
     });
 };
 
@@ -28,13 +31,28 @@ Provisioner.prototype.link = Promise.coroutine(function*(serverDomain, channel, 
         throw new Error("Server domain, channel and room ID are required.");
     }
 
+    // Validation
+
+    // Check room id
+    if (!mxRoomId.match(/^![0-9A-Za-z]+?:[^:]+(\:[0-9]+)?$/)) {
+        throw new Error("Malformed matrix_room_id, should look like '!Abcdefg:example.com[:8080]'");
+    }
+
+    // Check room channel
+    if (!channel.match(/^#.+$/)) {
+        throw new Error("Malformed remote_room_channel, should look like '#roomname'");
+    }
+
+    // Check room IRC server domain 
+    if (!serverDomain.match(/^[a-z\.]+$/)) {
+        throw new Error(`Malformed remote_room_server ('${serverDomain}'), should look like 'example.com' or 'localhost'`);
+    }
 
     // Try to find the domain requested for linking
     let server = this._ircBridge.getServer(serverDomain);
 
     if (!server) {
-        log.error('Server requested for linking not found');
-        return;
+        throw new Error("Server requested for linking not found");
     }
 
     // Create rooms for the link

--- a/lib/provisioning/Provisioner.js
+++ b/lib/provisioning/Provisioner.js
@@ -10,56 +10,100 @@ function Provisioner(ircBridge) {
 
     let as = this._ircBridge.getAppServiceBridge().appService;
 
+    
     as.app.post("/_matrix/provision/link", (req, res) => {
         log.info("Provisioning link");
 
-        let serverDomain = req.body.remote_room_server;
-        let channel = req.body.remote_room_channel;
-        let mxRoomId = req.body.matrix_room_id;
-
-        this.link(serverDomain, channel, mxRoomId).then(
+        this.validate(req.body).then(
             ()  => { res.json({}) },
+            (err) => { res.status(500).json({error: err.message}) }
+        ).then(
+            ()  => { this.unlink(req.body) },
+            (err) => { res.status(500).json({error: err.message}) }
+        );
+    });
+
+    as.app.post("/_matrix/provision/unlink", (req, res) => {
+        log.info("Provisioning unlink");
+
+        this.validate(req.body).then(
+            ()  => { res.json({}) },
+            (err) => { res.status(500).json({error: err.message}) }
+        ).then(
+            ()  => { this.unlink(req.body) },
             (err) => { res.status(500).json({error: err.message}) }
         );
     });
 };
 
+var parameterRegexes = {
+    matrix_room_id : /^![0-9A-Za-z]+?:[^:]+(\:[0-9]+)?$/,
+    remote_room_channel : /^#.+$/,
+    remote_room_server : /^[a-z\.]+$/
+};
+
+var parameterExamples = {
+    matrix_room_id : '!Abcdefg:example.com[:8080]',
+    remote_room_channel : '#roomname',
+    remote_room_server : 'example.com or localhost'
+};
+
+Provisioner.prototype.validate = Promise.coroutine(function*(parameters) {
+    for (var name in parameters) {
+        let actual = parameters[name];
+
+        if (!actual.match(parameterRegexes[name])) {
+            let example = parameterExamples[name];
+            throw new Error(`Malformed ${name} ('${actual}'), should look like '${example}'.`);
+        }
+    }
+});
+
 // Link an IRC channel to a matrix room ID
-Provisioner.prototype.link = Promise.coroutine(function*(serverDomain, channel, mxRoomId) {
-    log.info(serverDomain, channel, mxRoomId);
-    if (!serverDomain || !channel|| !mxRoomId) {
-        throw new Error("Server domain, channel and room ID are required.");
-    }
+Provisioner.prototype.link = Promise.coroutine(function*(options) {
+    let ircDomain = options.remote_room_server;
+    let ircChannel = options.remote_room_channel;
+    let roomId = options.matrix_room_id;
 
-    // Validation
-
-    // Check room id
-    if (!mxRoomId.match(/^![0-9A-Za-z]+?:[^:]+(\:[0-9]+)?$/)) {
-        throw new Error("Malformed matrix_room_id, should look like '!Abcdefg:example.com[:8080]'");
-    }
-
-    // Check room channel
-    if (!channel.match(/^#.+$/)) {
-        throw new Error("Malformed remote_room_channel, should look like '#roomname'");
-    }
-
-    // Check room IRC server domain 
-    if (!serverDomain.match(/^[a-z\.]+$/)) {
-        throw new Error(`Malformed remote_room_server ('${serverDomain}'), should look like 'example.com' or 'localhost'`);
+    if (!ircDomain || !ircChannel|| !roomId) {
+        throw new Error("Server domain, ircChannel and room ID are required.");
     }
 
     // Try to find the domain requested for linking
-    let server = this._ircBridge.getServer(serverDomain);
+    let server = this._ircBridge.getServer(ircDomain);
 
     if (!server) {
         throw new Error("Server requested for linking not found");
     }
 
     // Create rooms for the link
-    let ircRoom = new IrcRoom(server, channel);
-    let mxRoom = new MatrixRoom(mxRoomId);
+    let ircRoom = new IrcRoom(server, ircChannel);
+    let mxRoom = new MatrixRoom(roomId);
 
     yield this._ircBridge.getStore().storeRoom(ircRoom, mxRoom, false);
+});
+
+// Unlink an IRC channel from a matrix room ID
+Provisioner.prototype.unlink = Promise.coroutine(function*(options) {
+    let ircDomain = options.remote_room_server;
+    let ircChannel = options.remote_room_channel;
+    let roomId = options.matrix_room_id;
+
+    if (!ircDomain || !ircChannel|| !roomId) {
+        throw new Error("Server domain, ircChannel and room ID are required.");
+    }
+
+    // Try to find the domain requested for unlinking
+    let server = this._ircBridge.getServer(ircDomain);
+
+    if (!server) {
+        throw new Error("Server requested for linking not found");
+    }
+
+    // Delete the room link, but don't update the bridge
+    yield this._ircBridge.getStore()._roomStore.delete({
+        id: roomId + " " + ircDomain + " " + ircChannel
+    });
 });
 
 module.exports = Provisioner;

--- a/lib/provisioning/Provisioner.js
+++ b/lib/provisioning/Provisioner.js
@@ -12,22 +12,22 @@ function Provisioner(ircBridge) {
     let as = this._ircBridge.getAppServiceBridge().appService;
 
     as.app.post("/_matrix/provision/link", (req, res) => {
-        this.validate(req.body).then(
+        return this.validate(req.body).then(
             () => { res.json({}) },
-            (err) => { res.status(500).json({error: err.message}) }
+            (err) => { res.status(500).json({error: err.message}); return Promise.reject(err); }
         ).then(
-            () => { this.link(req.body) },
-            (err) => { res.status(500).json({error: err.message}) }
+            () => { return this.link(req.body) },
+            (err) => { res.status(500).json({error: err.message}); return Promise.reject(err); }
         );
     });
 
     as.app.post("/_matrix/provision/unlink", (req, res) => {
-        this.validate(req.body).then(
+        return this.validate(req.body).then(
             () => { res.json({}) },
-            (err) => { res.status(500).json({error: err.message}) }
+            (err) => { res.status(500).json({error: err.message}); return Promise.reject(err); }
         ).then(
-            () => { this.unlink(req.body) },
-            (err) => { res.status(500).json({error: err.message}) }
+            () => { return this.unlink(req.body) },
+            (err) => { res.status(500).json({error: err.message}); return Promise.reject(err); }
         );
     });
 }

--- a/lib/provisioning/Provisioner.js
+++ b/lib/provisioning/Provisioner.js
@@ -10,38 +10,43 @@ function Provisioner(ircBridge) {
     this._ircBridge = ircBridge;
 
     let as = this._ircBridge.getAppServiceBridge().appService;
+    let self = this;
 
-    as.app.post("/_matrix/provision/link", (req, res) => {
-        return this.validate(req.body).then(
-            () => { res.json({}) },
-            (err) => { res.status(500).json({error: err.message}); return Promise.reject(err); }
-        ).then(
-            () => { return this.link(req.body) },
-            (err) => { res.status(500).json({error: err.message}); return Promise.reject(err); }
-        );
-    });
+    as.app.post("/_matrix/provision/link", Promise.coroutine(function*(req, res) {
+        try {
+            self.validate(req.body);
+            yield self.link(req.body);
+            res.json({});
+        }
+        catch (err) {
+            res.status(500).json({error: err.message});
+            throw err;
+        }
+    }));
 
-    as.app.post("/_matrix/provision/unlink", (req, res) => {
-        return this.validate(req.body).then(
-            () => { res.json({}) },
-            (err) => { res.status(500).json({error: err.message}); return Promise.reject(err); }
-        ).then(
-            () => { return this.unlink(req.body) },
-            (err) => { res.status(500).json({error: err.message}); return Promise.reject(err); }
-        );
-    });
+    as.app.post("/_matrix/provision/unlink", Promise.coroutine(function*(req, res) {
+        try {
+            self.validate(req.body);
+            yield self.unlink(req.body);
+            res.json({});
+        }
+        catch (err) {
+            res.status(500).json({error: err.message});
+            throw err;
+        }
+    }));
 }
 
 var parameterValidation = {
     matrix_room_id :
-        {regex : /^![0-9A-Za-z]+?:[^:]+(\:[0-9]+)?$/, example : '!Abcdefg:example.com[:8080]'},
+        {regex : /^!.*:.*$/, example : '!Abcdefg:example.com[:8080]'},
     remote_room_channel :
-        {regex : /^#.+$/, example : '#roomname'},
+        {regex : /^([#+&]|(![A-Z0-9]{5}))[^\s:,]+$/, example : '#roomname'},
     remote_room_server :
-        {regex :  /^[a-z\.]+$/, example : 'example.com or localhost'},
+        {regex : /^[a-z\.0-9:-]+$/, example : 'example.com or localhost'},
 };
 
-Provisioner.prototype.validate = Promise.coroutine(function*(parameters) {
+Provisioner.prototype.validate = function(parameters) {
     let parameterNames = ['matrix_room_id', 'remote_room_channel', 'remote_room_server'];
     for (var i = 0; i < parameterNames.length; i++) {
         let name = parameterNames[i];
@@ -49,13 +54,25 @@ Provisioner.prototype.validate = Promise.coroutine(function*(parameters) {
         let actual = parameters[name];
         let valid = parameterValidation[name];
 
+        if (!actual) {
+            throw new Error(
+                `${name} not provided (like '${valid.example}').`
+            );
+        }
+
+        if (typeof actual !== 'string') {
+            throw new Error(
+                `${name} should be a string (like '${valid.example}').`
+            );
+        }
+
         if (!actual.match(valid.regex)) {
             throw new Error(
                 `Malformed ${name} ('${actual}'), should look like '${valid.example}'.`
             );
         }
     }
-});
+};
 
 // Link an IRC channel to a matrix room ID
 Provisioner.prototype.link = Promise.coroutine(function*(options) {
@@ -63,17 +80,14 @@ Provisioner.prototype.link = Promise.coroutine(function*(options) {
     let ircChannel = options.remote_room_channel;
     let roomId = options.matrix_room_id;
 
-    log.info(`Provisioning link for room ${roomId} <---> ${ircChannel}`);
-
-    if (!ircDomain || !ircChannel|| !roomId) {
-        throw new Error("Server domain, ircChannel and room ID are required.");
-    }
+    log.info(`Provisioning link for room ${roomId} <---> ${ircDomain}/${ircChannel}`);
 
     // Try to find the domain requested for linking
+    //TODO: ircDomain might include protocol, i.e. irc://irc.freenode.net
     let server = this._ircBridge.getServer(ircDomain);
 
     if (!server) {
-        throw new Error("Server requested for linking not found");
+        throw new Error(`Server requested for linking not found ('${ircDomain}')`);
     }
 
     // Create rooms for the link
@@ -89,12 +103,7 @@ Provisioner.prototype.unlink = Promise.coroutine(function*(options) {
     let ircChannel = options.remote_room_channel;
     let roomId = options.matrix_room_id;
 
-    log.info(`Provisioning unlink for room ${roomId} <-/-> ${ircChannel}`);
-
-
-    if (!ircDomain || !ircChannel|| !roomId) {
-        throw new Error("Server domain, ircChannel and room ID are required.");
-    }
+    log.info(`Provisioning unlink for room ${roomId} <-/-> ${ircDomain}/${ircChannel}`);
 
     // Try to find the domain requested for unlinking
     let server = this._ircBridge.getServer(ircDomain);
@@ -104,9 +113,7 @@ Provisioner.prototype.unlink = Promise.coroutine(function*(options) {
     }
 
     // Delete the room link, but don't update the bridge
-    yield this._ircBridge.getStore()._roomStore.delete({
-        id: roomId + " " + ircDomain + " " + ircChannel
-    });
+    yield this._ircBridge.getStore().removeRoom(roomId, ircDomain, ircChannel, 'provision');
 });
 
 module.exports = Provisioner;

--- a/lib/provisioning/Provisioner.js
+++ b/lib/provisioning/Provisioner.js
@@ -10,7 +10,6 @@ function Provisioner(ircBridge) {
 
     let as = this._ircBridge.getAppServiceBridge().appService;
 
-    
     as.app.post("/_matrix/provision/link", (req, res) => {
         this.validate(req.body).then(
             ()  => { res.json({}) },

--- a/spec/integ/provisioning.spec.js
+++ b/spec/integ/provisioning.spec.js
@@ -1,0 +1,121 @@
+"use strict";
+var Promise = require("bluebird");
+var test = require("../util/test");
+var env = test.mkEnv();
+var config = env.config;
+
+describe("Provisioning API", function() {
+    var mxUser = {
+        id: "@flibble:wibble",
+        nick: "M-flibble"
+    };
+
+    var ircUser = {
+        nick: "bob",
+        localpart: config._server + "_bob",
+        id: "@" + config._server + "_bob:" + config.homeserver.domain
+    };
+
+    beforeEach(function(done) {
+        test.beforeEach(this, env); // eslint-disable-line no-invalid-this
+
+        // accept connection requests from eeeeeeeeveryone!
+        env.ircMock._autoConnectNetworks(
+            config._server, mxUser.nick, config._server
+        );
+        env.ircMock._autoConnectNetworks(
+            config._server, ircUser.nick, config._server
+        );
+        env.ircMock._autoConnectNetworks(
+            config._server, config._botnick, config._server
+        );
+        // accept join requests from eeeeeeeeveryone!
+        env.ircMock._autoJoinChannels(
+            config._server, mxUser.nick, config._chan
+        );
+        env.ircMock._autoJoinChannels(
+            config._server, ircUser.nick, config._chan
+        );
+        env.ircMock._autoJoinChannels(
+            config._server, config._botnick, config._chan
+        );
+
+        // do the init
+        test.initEnv(env).done(function() {
+            done();
+        });
+    });
+
+    let mockLink = function (parameters, shouldSucceed, link) {
+        return test.coroutine(function*() {
+            let json = jasmine.createSpy("json(obj)");
+            let status = jasmine.createSpy("status(num)");
+
+            // Defaults
+            if (!parameters.matrix_room_id) {
+                parameters.matrix_room_id = "!foo:bar";
+            }
+            if (!parameters.remote_room_server) {
+                parameters.remote_room_server = "irc.example";
+            }
+            if (!parameters.remote_room_channel) {
+                parameters.remote_room_channel = "#coffee";
+            }
+
+            // When the _link promise resolves
+            let resolve = shouldSucceed ?
+                // success is indicated with empty object
+                () => { expect(json.calls[0].args[0]).toEqual({}); }:
+                // failure with 500 and JSON error message
+                () => {
+                    expect(json).toHaveBeenCalled();
+                    expect(status).toHaveBeenCalled();
+                    expect(status.calls[0].args[0]).toEqual(500);
+                    expect(json.calls[0].args[0].error).toBeDefined();
+                };
+
+            // When the _link fails
+            let reject = shouldSucceed ?
+                // but it should have succeeded
+                (err) => { return Promise.reject(err) }: // propagate rejection
+                // and it should have failed
+                (err) => { expect(err).toBeDefined(); }; // error should be given
+
+            return env.mockAppService._linkaction(
+               parameters, status, json, link
+            ).then(resolve, reject);
+        });
+    };
+
+    describe("link endpoint", function() {
+
+        it("should create a M<--->I link",
+            mockLink({}, true, true)
+        );
+
+        it("should not create a M<--->I link when room_id is malformed",
+            mockLink({matrix_room_id : '!f!!oo:ba::r'}, false, true));
+
+        it("should not create a M<--->I link when remote_room_server is malformed",
+            mockLink({remote_room_server : 'irc./example'}, false, true));
+
+        it("should not create a M<--->I link when remote_room_channel is malformed",
+            mockLink({remote_room_channel : 'coffe####e'}, false, true));
+    });
+
+    describe("unlink endpoint", function() {
+
+        it("should remove a M<--->I link",
+            mockLink({}, true, false)
+        );
+
+        it("should not remove a M<--->I link when room_id is malformed",
+            mockLink({matrix_room_id : '!f!!oo:ba::r'}, false, false));
+
+        it("should not remove a M<--->I link when remote_room_server is malformed",
+            mockLink({remote_room_server : 'irc./example'}, false, false));
+
+        it("should not remove a M<--->I link when remote_room_channel is malformed",
+            mockLink({remote_room_channel : 'coffe####e'}, false, false));
+    });
+});

--- a/spec/integ/provisioning.spec.js
+++ b/spec/integ/provisioning.spec.js
@@ -15,107 +15,277 @@ describe("Provisioning API", function() {
         localpart: config._server + "_bob",
         id: "@" + config._server + "_bob:" + config.homeserver.domain
     };
+    describe("room setup", function() {
+        beforeEach(function(done) {
+            test.beforeEach(this, env); // eslint-disable-line no-invalid-this
 
-    beforeEach(function(done) {
-        test.beforeEach(this, env); // eslint-disable-line no-invalid-this
+            // accept connection requests from eeeeeeeeveryone!
+            env.ircMock._autoConnectNetworks(
+                config._server, mxUser.nick, config._server
+            );
+            env.ircMock._autoConnectNetworks(
+                config._server, ircUser.nick, config._server
+            );
+            env.ircMock._autoConnectNetworks(
+                config._server, config._botnick, config._server
+            );
+            // accept join requests from eeeeeeeeveryone!
+            env.ircMock._autoJoinChannels(
+                config._server, mxUser.nick, config._chan
+            );
+            env.ircMock._autoJoinChannels(
+                config._server, ircUser.nick, config._chan
+            );
+            env.ircMock._autoJoinChannels(
+                config._server, config._botnick, config._chan
+            );
 
-        // accept connection requests from eeeeeeeeveryone!
-        env.ircMock._autoConnectNetworks(
-            config._server, mxUser.nick, config._server
-        );
-        env.ircMock._autoConnectNetworks(
-            config._server, ircUser.nick, config._server
-        );
-        env.ircMock._autoConnectNetworks(
-            config._server, config._botnick, config._server
-        );
-        // accept join requests from eeeeeeeeveryone!
-        env.ircMock._autoJoinChannels(
-            config._server, mxUser.nick, config._chan
-        );
-        env.ircMock._autoJoinChannels(
-            config._server, ircUser.nick, config._chan
-        );
-        env.ircMock._autoJoinChannels(
-            config._server, config._botnick, config._chan
-        );
+            // do the init
+            test.initEnv(env).done(function() {
+                done();
+            });
+        });
 
-        // do the init
-        test.initEnv(env).done(function() {
-            done();
+        // Create a coroutine to test certain API parameters.
+        //  parameters {object} - the API parameters
+        //  shouldSucceed {boolean} - true if the request should succeed
+        //  link {boolean} - true if this is a link request (false if unlink)
+        let mockLink = function (parameters, shouldSucceed, link) {
+
+            return test.coroutine(function*() {
+                let json = jasmine.createSpy("json(obj)");
+                let status = jasmine.createSpy("status(num)");
+
+                // Defaults
+                if (!parameters.matrix_room_id) {
+                    parameters.matrix_room_id = "!foo:bar";
+                }
+                if (!parameters.remote_room_server) {
+                    parameters.remote_room_server = "irc.example";
+                }
+                if (!parameters.remote_room_channel) {
+                    parameters.remote_room_channel = "#coffee";
+                }
+
+                // When the _link promise resolves
+                let resolve = shouldSucceed ?
+                    // success is indicated with empty object
+                    () => { expect(json.calls[0].args[0]).toEqual({}); }:
+                    // failure with 500 and JSON error message
+                    () => {
+                        expect(json).toHaveBeenCalled();
+                        expect(status).toHaveBeenCalled();
+                        expect(status.calls[0].args[0]).toEqual(500);
+                        expect(json.calls[0].args[0].error).toBeDefined();
+                    };
+
+                // When the _link fails
+                let reject = shouldSucceed ?
+                    // but it should have succeeded
+                    (err) => { return Promise.reject(err) }: // propagate rejection
+                    // and it should have failed
+                    (err) => { expect(err).toBeDefined(); }; // error should be given
+
+                return env.mockAppService._linkAction(
+                   parameters, status, json, link
+                ).then(resolve, reject);
+            });
+        };
+
+        describe("link endpoint", function() {
+
+            it("should create a M<--->I link",
+                mockLink({}, true, true)
+            );
+
+            it("should not create a M<--->I link when room_id is malformed",
+                mockLink({matrix_room_id : '!f!!oo:ba::r'}, false, true));
+
+            it("should not create a M<--->I link when remote_room_server is malformed",
+                mockLink({remote_room_server : 'irc./example'}, false, true));
+
+            it("should not create a M<--->I link when remote_room_channel is malformed",
+                mockLink({remote_room_channel : 'coffe####e'}, false, true));
+        });
+
+        describe("unlink endpoint", function() {
+            it("should remove a M<--->I link",
+                mockLink({}, true, false)
+            );
+
+            it("should not remove a M<--->I link when room_id is malformed",
+                mockLink({matrix_room_id : '!f!!oo:ba::r'}, false, false));
+
+            it("should not remove a M<--->I link when remote_room_server is malformed",
+                mockLink({remote_room_server : 'irc./example'}, false, false));
+
+            it("should not remove a M<--->I link when remote_room_channel is malformed",
+                mockLink({remote_room_channel : 'coffe####e'}, false, false));
         });
     });
 
-    let mockLink = function (parameters, shouldSucceed, link) {
-        return test.coroutine(function*() {
-            let json = jasmine.createSpy("json(obj)");
-            let status = jasmine.createSpy("status(num)");
+    describe("message sending and joining", function() {
+        beforeEach(function(done) {
+            test.beforeEach(this, env); // eslint-disable-line no-invalid-this
 
-            // Defaults
-            if (!parameters.matrix_room_id) {
-                parameters.matrix_room_id = "!foo:bar";
-            }
-            if (!parameters.remote_room_server) {
-                parameters.remote_room_server = "irc.example";
-            }
-            if (!parameters.remote_room_channel) {
-                parameters.remote_room_channel = "#coffee";
-            }
+            // Ignore bot connecting
+            env.ircMock._autoConnectNetworks(
+                config._server, config._botnick, config._server
+            );
 
-            // When the _link promise resolves
-            let resolve = shouldSucceed ?
-                // success is indicated with empty object
-                () => { expect(json.calls[0].args[0]).toEqual({}); }:
-                // failure with 500 and JSON error message
-                () => {
-                    expect(json).toHaveBeenCalled();
-                    expect(status).toHaveBeenCalled();
-                    expect(status.calls[0].args[0]).toEqual(500);
-                    expect(json.calls[0].args[0].error).toBeDefined();
+            // do the init
+            test.initEnv(env).done(function() {
+                done();
+            });
+        });
+
+        it("should allow IRC to send messages via the new link",
+            test.coroutine(function*() {
+
+                let json = jasmine.createSpy("json(obj)");
+                let status = jasmine.createSpy("status(num)");
+
+                let parameters = {
+                    matrix_room_id : "!foo:bar",
+                    remote_room_server : "irc.example",
+                    remote_room_channel : "#coffee"
                 };
 
-            // When the _link fails
-            let reject = shouldSucceed ?
-                // but it should have succeeded
-                (err) => { return Promise.reject(err) }: // propagate rejection
-                // and it should have failed
-                (err) => { expect(err).toBeDefined(); }; // error should be given
+                let roomMapping = {
+                    roomId : parameters.matrix_room_id,
+                    server : parameters.remote_room_server,
+                    channel : parameters.remote_room_channel
+                };
 
-            return env.mockAppService._linkaction(
-               parameters, status, json, link
-            ).then(resolve, reject);
-        });
-    };
+                let nickForDisplayName = mxUser.nick;
 
-    describe("link endpoint", function() {
+                var gotConnectCall = false;
+                env.ircMock._whenClient(roomMapping.server, nickForDisplayName, "connect",
+                function(client, cb) {
+                    gotConnectCall = true;
+                    client._invokeCallback(cb);
+                });
 
-        it("should create a M<--->I link",
-            mockLink({}, true, true)
+                var gotJoinCall = false;
+                env.ircMock._whenClient(roomMapping.server, nickForDisplayName, "join",
+                function(client, channel, cb) {
+                    gotJoinCall = true;
+                    client._invokeCallback(cb);
+                });
+
+                var gotSayCall = false;
+                env.ircMock._whenClient(roomMapping.server, nickForDisplayName, "say",
+                function(client, channel, text) {
+                    expect(client.nick).toEqual(nickForDisplayName);
+                    expect(client.addr).toEqual(roomMapping.server);
+                    expect(channel).toEqual(roomMapping.channel);
+                    gotSayCall = true;
+                });
+
+                return env.mockAppService._linkAction(
+                   parameters, status, json, true
+                ).then(
+                    () => {
+                        return env.mockAppService._trigger("type:m.room.message", {
+                            content: {
+                                body: "A message",
+                                msgtype: "m.text"
+                            },
+                            user_id: mxUser.id,
+                            room_id: roomMapping.roomId,
+                            type: "m.room.message"
+                        }).then(function() {
+                            expect(gotConnectCall).toBe(
+                                true, nickForDisplayName + " failed to connect to IRC."
+                            );
+                            expect(gotJoinCall).toBe(
+                                true, nickForDisplayName + " failed to join IRC channel."
+                            );
+                            expect(gotSayCall).toBe(true, "Didn't get say");
+                        })
+                });
+            })
         );
 
-        it("should not create a M<--->I link when room_id is malformed",
-            mockLink({matrix_room_id : '!f!!oo:ba::r'}, false, true));
 
-        it("should not create a M<--->I link when remote_room_server is malformed",
-            mockLink({remote_room_server : 'irc./example'}, false, true));
+        it("should not allow IRC to send messages following unlink",
+            test.coroutine(function*() {
 
-        it("should not create a M<--->I link when remote_room_channel is malformed",
-            mockLink({remote_room_channel : 'coffe####e'}, false, true));
-    });
+                let json = jasmine.createSpy("json(obj)");
+                let status = jasmine.createSpy("status(num)");
 
-    describe("unlink endpoint", function() {
+                let parameters = {
+                    matrix_room_id : "!foo:bar",
+                    remote_room_server : "irc.example",
+                    remote_room_channel : "#coffee"
+                };
 
-        it("should remove a M<--->I link",
-            mockLink({}, true, false)
+                let roomMapping = {
+                    roomId : parameters.matrix_room_id,
+                    server : parameters.remote_room_server,
+                    channel : parameters.remote_room_channel
+                };
+
+                let nickForDisplayName = mxUser.nick;
+
+                var gotConnectCall = false;
+                env.ircMock._whenClient(roomMapping.server, nickForDisplayName, "connect",
+                function(client, cb) {
+                    gotConnectCall = true;
+                    client._invokeCallback(cb);
+                });
+
+                var gotJoinCall = false;
+                env.ircMock._whenClient(roomMapping.server, nickForDisplayName, "join",
+                function(client, channel, cb) {
+                    gotJoinCall = true;
+                    client._invokeCallback(cb);
+                });
+
+                var countSays = 0;
+                env.ircMock._whenClient(roomMapping.server, nickForDisplayName, "say",
+                function(client, channel, text) {
+                    expect(client.nick).toEqual(nickForDisplayName);
+                    expect(client.addr).toEqual(roomMapping.server);
+                    expect(channel).toEqual(roomMapping.channel);
+                    countSays++;
+                });
+
+                return env.mockAppService._linkAction(parameters, status, json, true)
+                    .then(() => {
+                        return env.mockAppService._trigger("type:m.room.message", {
+                            content: {
+                                body: "First message",
+                                msgtype: "m.text"
+                            },
+                            user_id: mxUser.id,
+                            room_id: roomMapping.roomId,
+                            type: "m.room.message"
+                    }).then(() => {
+                        return env.mockAppService._linkAction(parameters, status, json, false)
+                        .then(() => {
+                                return env.mockAppService._trigger("type:m.room.message", {
+                                    content: {
+                                        body: "This message should not be sent",
+                                        msgtype: "m.text"
+                                    },
+                                    user_id: mxUser.id,
+                                    room_id: roomMapping.roomId,
+                                    type: "m.room.message"
+                                }).then(() => {
+                                    expect(gotConnectCall).toBe(
+                                        true, nickForDisplayName + " failed to connect to IRC."
+                                    );
+                                    expect(gotJoinCall).toBe(
+                                        true, nickForDisplayName + " failed to join IRC channel."
+                                    );
+                                    expect(countSays).toBe(1, "Should have only sent one message");
+                                })
+                            }
+                        )
+                    })
+                });
+            })
         );
-
-        it("should not remove a M<--->I link when room_id is malformed",
-            mockLink({matrix_room_id : '!f!!oo:ba::r'}, false, false));
-
-        it("should not remove a M<--->I link when remote_room_server is malformed",
-            mockLink({remote_room_server : 'irc./example'}, false, false));
-
-        it("should not remove a M<--->I link when remote_room_channel is malformed",
-            mockLink({remote_room_channel : 'coffe####e'}, false, false));
     });
 });

--- a/spec/integ/provisioning.spec.js
+++ b/spec/integ/provisioning.spec.js
@@ -99,7 +99,7 @@ describe("Provisioning API", function() {
             );
 
             it("should not create a M<--->I link when room_id is malformed",
-                mockLink({matrix_room_id : '!f!!oo:ba::r'}, false, true));
+                mockLink({matrix_room_id : '!fooooooo'}, false, true));
 
             it("should not create a M<--->I link when remote_room_server is malformed",
                 mockLink({remote_room_server : 'irc./example'}, false, true));
@@ -114,7 +114,7 @@ describe("Provisioning API", function() {
             );
 
             it("should not remove a M<--->I link when room_id is malformed",
-                mockLink({matrix_room_id : '!f!!oo:ba::r'}, false, false));
+                mockLink({matrix_room_id : '!fooooooooo'}, false, false));
 
             it("should not remove a M<--->I link when remote_room_server is malformed",
                 mockLink({remote_room_server : 'irc./example'}, false, false));

--- a/spec/integ/provisioning.spec.js
+++ b/spec/integ/provisioning.spec.js
@@ -46,21 +46,24 @@ describe("Provisioning API", function() {
             // When the _link promise resolves
             let resolve = shouldSucceed ?
                 // success is indicated with empty object
-                () => { expect(json.calls[0].args[0]).toEqual({}); }:
-                // failure with 500 and JSON error message
                 () => {
-                    expect(json).toHaveBeenCalled();
-                    expect(status).toHaveBeenCalled();
-                    expect(status.calls[0].args[0]).toEqual(500);
-                    expect(json.calls[0].args[0].error).toBeDefined();
-                };
+                    expect(json).toHaveBeenCalledWith({});
+                }:
+                // but it should not have resolved
+                () => { return Promise.reject(err) };
 
             // When the _link fails
             let reject = shouldSucceed ?
                 // but it should have succeeded
                 (err) => { return Promise.reject(err) }: // propagate rejection
                 // and it should have failed
-                (err) => { expect(err).toBeDefined(); }; // error should be given
+                (err) => {
+                    expect(err).toBeDefined();
+                    expect(status).toHaveBeenCalledWith(500);
+                    expect(json).toHaveBeenCalled();
+                    // Make sure the first call to JSON has error defined
+                    expect(json.calls[0].args[0].error).toBeDefined();
+                };
 
 
             // Unlink needs an existing link to remove, so add one first

--- a/spec/integ/provisioning.spec.js
+++ b/spec/integ/provisioning.spec.js
@@ -23,8 +23,14 @@ describe("Provisioning API", function() {
     let mockLink = function (parameters, shouldSucceed, link) {
 
         return test.coroutine(function*() {
-            let json = jasmine.createSpy("json(obj)").andCallFake(function(obj){console.log('JSON ' + JSON.stringify(obj))});
-            let status = jasmine.createSpy("status(num)").andCallFake(function(number){console.log(`HTTP STATUS ${number}`)});
+            let json = jasmine.createSpy("json(obj)")
+            .andCallFake(function(obj) {
+                console.log('JSON ' + JSON.stringify(obj))
+            });
+            let status = jasmine.createSpy("status(num)")
+            .andCallFake(function(number) {
+                console.log(`HTTP STATUS ${number}`)
+            });
 
             // Defaults
             if (!parameters.matrix_room_id) {
@@ -125,9 +131,11 @@ describe("Provisioning API", function() {
         });
     });
 
-    describe("with config links existing",function(){
-        beforeEach(function(done){
-            config.ircService.servers[config._server].mappings['#provisionedchannel'] = ['!foo:bar'];
+    describe("with config links existing", function() {
+        beforeEach(function(done) {
+            config.ircService
+                .servers[config._server]
+                .mappings['#provisionedchannel'] = ['!foo:bar'];
 
             test.beforeEach(this, env); // eslint-disable-line no-invalid-this
 

--- a/spec/util/app-service-mock.js
+++ b/spec/util/app-service-mock.js
@@ -4,6 +4,13 @@ var util = require("util");
 var instance = null;
 
 function MockAppService() {
+
+    this.app = {
+        post: function() {
+            //stub (to prevent crashing when provisioner is created)
+        }
+    };
+
     EventEmitter.call(this);
 }
 util.inherits(MockAppService, EventEmitter);

--- a/spec/util/app-service-mock.js
+++ b/spec/util/app-service-mock.js
@@ -15,7 +15,7 @@ function MockAppService() {
                 self.unlink = handler;
             }
             else {
-                throw new Error(`Unrecognised path for mock provisioning endpoint \"${path}\"`);
+                throw new Error(`Unrecognised path for mock provisioning endpoint "${path}"`);
             }
         }
     };
@@ -25,7 +25,7 @@ function MockAppService() {
 util.inherits(MockAppService, EventEmitter);
 
 // Simulate a request to the link provisioning API
-//  parameters {object} - the API parameters
+//  parameters {object} - the API request parameters
 //  statusCallback {function} - Called when the server returns a HTTP response code.
 //  jsonCallback {function} - Called when the server returns a JSON object.
 //  link {boolean} - true if this is a link request (false if unlink).
@@ -48,6 +48,14 @@ MockAppService.prototype._linkAction = function(parameters, statusCallback, json
     }
     return this.unlink(req, res);
 };
+
+MockAppService.prototype._link = function(parameters, statusCallback, jsonCallback) {
+    return this._linkAction(parameters, statusCallback, jsonCallback, true);
+}
+
+MockAppService.prototype._unlink = function(parameters, statusCallback, jsonCallback) {
+    return this._linkAction(parameters, statusCallback, jsonCallback, false);
+}
 
 
 MockAppService.prototype.listen = function(port) {

--- a/spec/util/app-service-mock.js
+++ b/spec/util/app-service-mock.js
@@ -8,7 +8,6 @@ function MockAppService() {
 
     this.app = {
         post: function(path, handler) {
-            // Assume that the first post handler will be for the /link path
             if (path === '/_matrix/provision/link') {
                 self.link = handler;
             }

--- a/spec/util/app-service-mock.js
+++ b/spec/util/app-service-mock.js
@@ -22,8 +22,12 @@ function MockAppService() {
 }
 util.inherits(MockAppService, EventEmitter);
 
-MockAppService.prototype._linkaction = function(parameters, statusCallback, jsonCallback, link) {
-    // Call handler with params
+// Simulate a request to the link provisioning API
+//  parameters {object} - the API parameters
+//  statusCallback {function} - Called when the server returns a HTTP response code.
+//  jsonCallback {function} - Called when the server returns a JSON object.
+//  link {boolean} - true if this is a link request (false if unlink).
+MockAppService.prototype._linkAction = function(parameters, statusCallback, jsonCallback, link) {
     if (link ? !this.link : !this.unlink) {
         throw new Error("IRC AS hasn't hooked into link/unlink yet.");
     }
@@ -39,9 +43,8 @@ MockAppService.prototype._linkaction = function(parameters, statusCallback, json
 
     if (link) {
         return this.link(req, res);
-    } else {
-        return this.unlink(req, res);
     }
+    return this.unlink(req, res);
 };
 
 

--- a/spec/util/app-service-mock.js
+++ b/spec/util/app-service-mock.js
@@ -9,11 +9,14 @@ function MockAppService() {
     this.app = {
         post: function(path, handler) {
             // Assume that the first post handler will be for the /link path
-            if (!self.link) {
+            if (path === '/_matrix/provision/link') {
                 self.link = handler;
             }
-            else {
+            else if (path === '/_matrix/provision/unlink') {
                 self.unlink = handler;
+            }
+            else {
+                throw new Error(`Unrecognised path for mock provisioning endpoint \"${path}\"`);
             }
         }
     };


### PR DESCRIPTION
A simple API has been provided with the bridge.

Required parameters to the /[un]link POST endpoints are validated so that they roughly resemble the following:

```JSON
{
    "matrix_room_id" : "!Abcdefgh:example.com[:8080]" , 
    "remote_room_server": "localhost", 
    "remote_room_channel" : "#room"
}
```

Tests have been done to make sure that messages are only sent to rooms when they are linked accordingly. However, the virtual users seem to hang around. Not sure if this is an issue.

I will move onto membership syncing tomorrow.