### PR TITLE
Better messages displayed with pastebin actions

### DIFF
--- a/lib/bridge/MatrixHandler.js
+++ b/lib/bridge/MatrixHandler.js
@@ -906,11 +906,13 @@ MatrixHandler.prototype._sendIrcAction = Promise.coroutine(
         event.content.body = fileName;
 
         // Create a file event to reflect the recent upload
-        let bigFileIrcAction = IrcAction.fromMatrixAction(
-            MatrixAction.fromEvent(
-                this.ircBridge.getAppServiceBridge().getClientFactory().getClientAs(), event
-            )
+        let mAction = MatrixAction.fromEvent(
+            this.ircBridge.getAppServiceBridge().getClientFactory().getClientAs(), event
         );
+        let bigFileIrcAction = IrcAction.fromMatrixAction(mAction);
+
+        // Replace "Posted a File with..."
+        bigFileIrcAction.text = 'Posted a long message: ' + mAction.text;
 
         // Notify the IRC side of the uploaded text file
         yield this.ircBridge.sendIrcAction(ircRoom, ircClient, bigFileIrcAction);
@@ -920,7 +922,7 @@ MatrixHandler.prototype._sendIrcAction = Promise.coroutine(
         // Modify the event to become a truncated version of the original
         //  the truncation limits the number of lines sent to lineLimit.
 
-        let msg = '\n...(Could not provide large text, truncated above, as file)';
+        let msg = '\n...(truncated)';
 
         event.content = {
             msgtype : "m.text",


### PR DESCRIPTION
When a file is successfully uploaded in light of a text that is too long, the IRC side is shown 'Posted a long message' instead of 'Posted a File' and when the upload fails, the truncated text is sent through with '...(truncated)' on the end.