### PR TITLE
Quick fix for #130

### DIFF
--- a/lib/bridge/MatrixHandler.js
+++ b/lib/bridge/MatrixHandler.js
@@ -436,7 +436,7 @@ MatrixHandler.prototype._onAdminMessage = Promise.coroutine(function*(req, event
                     let server = this.ircBridge.getServer(domainMatch[1]);
 
                     if (!server) {
-                        throw new Error(`IRC domain not found (${ircDomain})`
+                        throw new Error(`IRC domain not found (${ircDomain})` +
                                         ` on line ${lineNumber}`);
                     }
 


### PR DESCRIPTION
This fix will make sure that the error is printed correctly, i.e:
```
IRC domain not found (somedomain) on line [some line number]
```

But it remains to be seend why @appservice-irc is sending out spam to _any_ matrix room it joins:
```
TypeError: (("IRC domain not found (" + (intermediate value)) + ")") is not a function
Usage: 
irc.server
(COMMAND [arg0 [arg1 [...]]])
(COMMAND [arg0 [arg1 [...]]])
irc.server2
```