### PR TITLE
IRC bot will leave matrix room with > 2 members

### DIFF
--- a/lib/bridge/IrcBridge.js
+++ b/lib/bridge/IrcBridge.js
@@ -359,7 +359,6 @@ IrcBridge.prototype._onEvent = Promise.coroutine(function*(baseRequest, context)
         this.ircHandler.onMatrixMemberEvent(event);
         var target = new MatrixUser(event.state_key);
         var sender = new MatrixUser(event.user_id);
-        yield this.matrixHandler.onMemberEvent(request, event, sender, target);
         if (event.content.membership === "invite") {
             yield this.matrixHandler.onInvite(request, event, sender, target);
         }

--- a/lib/bridge/IrcBridge.js
+++ b/lib/bridge/IrcBridge.js
@@ -359,6 +359,7 @@ IrcBridge.prototype._onEvent = Promise.coroutine(function*(baseRequest, context)
         this.ircHandler.onMatrixMemberEvent(event);
         var target = new MatrixUser(event.state_key);
         var sender = new MatrixUser(event.user_id);
+        yield this.matrixHandler.onMemberEvent(request, event, sender, target);
         if (event.content.membership === "invite") {
             yield this.matrixHandler.onInvite(request, event, sender, target);
         }

--- a/lib/bridge/MatrixHandler.js
+++ b/lib/bridge/MatrixHandler.js
@@ -152,7 +152,6 @@ MatrixHandler.prototype._onAdminMessage = Promise.coroutine(function*(req, event
                 return m.content.membership && m.content.membership === "join";
             }
         );
-
     }
     else {
         req.log.warn('Member tracker not running');
@@ -502,11 +501,11 @@ MatrixHandler.prototype._onAdminMessage = Promise.coroutine(function*(req, event
 /**
  * Called when the AS receives a new Matrix invite/join/leave event.
  * @param {Object} event : The Matrix member event.
- * @param {MatrixUser} inviter : The inviter (sender).
- * @param {MatrixUser} invitee : The invitee (receiver).
+ * @param {MatrixUser} sender : The sender.
+ * @param {MatrixUser} receiver : The receiver.
  * @return {Promise} which is resolved/rejected when the request finishes.
  */
-MatrixHandler.prototype._onMemberEvent = Promise.coroutine(function*(req, event, inviter, invitee) {
+MatrixHandler.prototype._onMemberEvent = Promise.coroutine(function*(req, event, sender, receiver) {
     if (!this._memberTracker) {
         let matrixClient = this.ircBridge.getAppServiceBridge().getClientFactory().getClientAs();
 
@@ -517,8 +516,6 @@ MatrixHandler.prototype._onMemberEvent = Promise.coroutine(function*(req, event,
     }
     else {
         this._memberTracker.onEvent(event);
-
-        yield Promise.resolve();
     }
 });
 

--- a/lib/bridge/MatrixHandler.js
+++ b/lib/bridge/MatrixHandler.js
@@ -11,6 +11,7 @@ var IrcClientConfig = require("../models/IrcClientConfig");
 var MatrixUser = require("matrix-appservice-bridge").MatrixUser;
 var BridgeRequest = require("../models/BridgeRequest");
 var toIrcLowerCase = require("../irc/formatting").toIrcLowerCase;
+var StateLookup = require('matrix-appservice-bridge').StateLookup;
 
 function MatrixHandler(ircBridge) {
     this.ircBridge = ircBridge;
@@ -129,11 +130,40 @@ MatrixHandler.prototype._handleInviteFromUser = Promise.coroutine(function*(req,
     );
 });
 
-
 // === Admin room handling ===
 MatrixHandler.prototype._onAdminMessage = Promise.coroutine(function*(req, event, adminRoom) {
     req.log.info("Received admin message from %s", event.user_id);
+
     let botUser = new MatrixUser(this.ircBridge.getAppServiceUserId());
+
+    // If an admin room has more than 2 people in it, kick the bot out
+
+    let matrixClient = this.ircBridge.getAppServiceBridge().getClientFactory().getClientAs();
+
+    let lookup = new StateLookup({
+        client : matrixClient,
+        eventTypes: ['m.room.member']
+    });
+
+    yield lookup.trackRoom(adminRoom.getId());
+    let members = lookup.getState(adminRoom.getId(), 'm.room.member');
+    console.log(members.length, members);
+
+    if (members.length > 2) {
+        req.log.error('_onAdminMessage: admin room has too many users; bot will leave');
+
+        yield this.ircBridge.getAppServiceBridge().getIntent(
+                botUser.getId()
+            ).leave(adminRoom.getId());
+
+        // Notify users in admin room
+        let notice = new MatrixAction("notice",
+            "There are too many (>2) users in this admin room, I'll see myself out!"
+        );
+        yield this.ircBridge.sendMatrixAction(adminRoom, botUser, notice, req);
+
+        return;
+    }
 
     // Assumes all commands have the form "!cmd [irc.server] [args...]"
     let segments = event.content.body.split(" ");
@@ -425,7 +455,7 @@ MatrixHandler.prototype._onAdminMessage = Promise.coroutine(function*(req, event
                     );
 
                     if (!bridgedClient.unsafeClient) {
-                        throw new Error('Possibly disconnected (on line ${lineNumber})');
+                        throw new Error(`Possibly disconnected (on line ${lineNumber})`);
                     }
 
                     bridgedClient.unsafeClient.send.apply(bridgedClient.unsafeClient, sendArgs);

--- a/lib/bridge/MatrixHandler.js
+++ b/lib/bridge/MatrixHandler.js
@@ -146,21 +146,27 @@ MatrixHandler.prototype._onAdminMessage = Promise.coroutine(function*(req, event
     });
 
     yield lookup.trackRoom(adminRoom.getId());
-    let members = lookup.getState(adminRoom.getId(), 'm.room.member');
-    console.log(members.length, members);
+    let members = lookup.getState(
+        adminRoom.getId(),
+        'm.room.member'
+    ).filter(
+        function (m) {
+            return m.membership && m.membership !== "leave";
+        }
+    );
 
     if (members.length > 2) {
         req.log.error('_onAdminMessage: admin room has too many users; bot will leave');
 
+        // Notify users in admin room
+        let notice = new MatrixAction("notice",
+            "There are more than 2 users in this admin room"
+        );
+        yield this.ircBridge.sendMatrixAction(adminRoom, botUser, notice, req);
+
         yield this.ircBridge.getAppServiceBridge().getIntent(
                 botUser.getId()
             ).leave(adminRoom.getId());
-
-        // Notify users in admin room
-        let notice = new MatrixAction("notice",
-            "There are too many (>2) users in this admin room, I'll see myself out!"
-        );
-        yield this.ircBridge.sendMatrixAction(adminRoom, botUser, notice, req);
 
         return;
     }

--- a/lib/bridge/MatrixHandler.js
+++ b/lib/bridge/MatrixHandler.js
@@ -21,6 +21,8 @@ function MatrixHandler(ircBridge) {
     this._processingInvitesForRooms = {
         // roomId+userId: defer
     };
+
+    this._memberTracker = null;
 }
 
 // ===== Matrix Invite Handling =====
@@ -137,26 +139,30 @@ MatrixHandler.prototype._onAdminMessage = Promise.coroutine(function*(req, event
     let botUser = new MatrixUser(this.ircBridge.getAppServiceUserId());
 
     // If an admin room has more than 2 people in it, kick the bot out
+    let members = [];
+    if (this._memberTracker) {
+        // First call begins tracking, subsequent calls do nothing
+        yield this._memberTracker.trackRoom(adminRoom.getId());
 
-    let matrixClient = this.ircBridge.getAppServiceBridge().getClientFactory().getClientAs();
+        members = this._memberTracker.getState(
+            adminRoom.getId(),
+            'm.room.member'
+        ).filter(
+            function (m) {
+                return m.content.membership && m.content.membership === "join";
+            }
+        );
 
-    let lookup = new StateLookup({
-        client : matrixClient,
-        eventTypes: ['m.room.member']
-    });
-
-    yield lookup.trackRoom(adminRoom.getId());
-    let members = lookup.getState(
-        adminRoom.getId(),
-        'm.room.member'
-    ).filter(
-        function (m) {
-            return m.membership && m.membership !== "leave";
-        }
-    );
+    }
+    else {
+        req.log.warn('Member tracker not running');
+    }
 
     if (members.length > 2) {
-        req.log.error('_onAdminMessage: admin room has too many users; bot will leave');
+        req.log.error(
+            `_onAdminMessage: admin room has ${members.length}` +
+            ` users instead of just 2; bot will leave`
+        );
 
         // Notify users in admin room
         let notice = new MatrixAction("notice",
@@ -490,6 +496,29 @@ MatrixHandler.prototype._onAdminMessage = Promise.coroutine(function*(req, event
             yield this.ircBridge.sendMatrixAction(adminRoom, botUser, notice, req);
             return;
         }
+    }
+});
+
+/**
+ * Called when the AS receives a new Matrix invite/join/leave event.
+ * @param {Object} event : The Matrix member event.
+ * @param {MatrixUser} inviter : The inviter (sender).
+ * @param {MatrixUser} invitee : The invitee (receiver).
+ * @return {Promise} which is resolved/rejected when the request finishes.
+ */
+MatrixHandler.prototype._onMemberEvent = Promise.coroutine(function*(req, event, inviter, invitee) {
+    if (!this._memberTracker) {
+        let matrixClient = this.ircBridge.getAppServiceBridge().getClientFactory().getClientAs();
+
+        this._memberTracker = new StateLookup({
+            client : matrixClient,
+            eventTypes: ['m.room.member']
+        });
+    }
+    else {
+        this._memberTracker.onEvent(event);
+
+        yield Promise.resolve();
     }
 });
 
@@ -1096,6 +1125,10 @@ MatrixHandler.prototype._onUserQuery = Promise.coroutine(function*(req, userId) 
 });
 
 // EXPORTS
+
+MatrixHandler.prototype.onMemberEvent = function(req, event, inviter, invitee) {
+    return reqHandler(req, this._onMemberEvent(req, event, inviter, invitee));
+};
 
 MatrixHandler.prototype.onInvite = function(req, event, inviter, invitee) {
     return reqHandler(req, this._onInvite(req, event, inviter, invitee));

--- a/lib/bridge/MatrixHandler.js
+++ b/lib/bridge/MatrixHandler.js
@@ -501,11 +501,8 @@ MatrixHandler.prototype._onAdminMessage = Promise.coroutine(function*(req, event
 /**
  * Called when the AS receives a new Matrix invite/join/leave event.
  * @param {Object} event : The Matrix member event.
- * @param {MatrixUser} sender : The sender.
- * @param {MatrixUser} receiver : The receiver.
- * @return {Promise} which is resolved/rejected when the request finishes.
  */
-MatrixHandler.prototype._onMemberEvent = Promise.coroutine(function*(req, event, sender, receiver) {
+MatrixHandler.prototype._onMemberEvent = function(req, event) {
     if (!this._memberTracker) {
         let matrixClient = this.ircBridge.getAppServiceBridge().getClientFactory().getClientAs();
 
@@ -517,7 +514,7 @@ MatrixHandler.prototype._onMemberEvent = Promise.coroutine(function*(req, event,
     else {
         this._memberTracker.onEvent(event);
     }
-});
+};
 
 /**
  * Called when the AS receives a new Matrix invite event.
@@ -536,6 +533,7 @@ MatrixHandler.prototype._onInvite = Promise.coroutine(function*(req, event, invi
      * [4] bot --invite--> MX   (bot telling real mx user IRC conn state)
      */
     req.log.info("onInvite: %s", JSON.stringify(event));
+    this._onMemberEvent(req, event);
 
     // mark this room as being processed in case we simultaneously get
     // messages for this room (which would fail if we haven't done the
@@ -578,6 +576,7 @@ MatrixHandler.prototype._onInvite = Promise.coroutine(function*(req, event, invi
 MatrixHandler.prototype._onJoin = Promise.coroutine(function*(req, event, user) {
     let self = this;
     req.log.info("onJoin: %s", JSON.stringify(event));
+    this._onMemberEvent(req, event);
     // membershiplists injects leave events when syncing initial membership
     // lists. We know if this event is injected because this flag is set.
     let syncKind = event._injected ? "initial" : "incremental";
@@ -645,6 +644,7 @@ MatrixHandler.prototype._onKick = Promise.coroutine(function*(req, event, kicker
         "onKick %s is kicking/banning %s from %s",
         kicker.getId(), kickee.getId(), event.room_id
     );
+    this._onMemberEvent(req, event);
 
     /*
     We know this is a Matrix client kicking someone.

--- a/spec/integ/admin-rooms.spec.js
+++ b/spec/integ/admin-rooms.spec.js
@@ -669,4 +669,111 @@ describe("Admin rooms", function() {
 
         expect(cmdCount).toBe(0);
     }));
+
+    it("mx bot should be kicked when there are > 2 users in room and a message is sent",
+    test.coroutine(function*() {
+
+        var sdk = env.clientMock._client(botUserId);
+        sdk.roomState.andCallFake(
+            function (roomId) {
+                expect(roomId).toBe(adminRoomId, 'Room state returned should be for admin room');
+                return Promise.resolve([
+                    {content: {membership: "join"}, type: "m.room.member", state_key: "fake bot state"},
+                    {content: {membership: "join"}, type: "m.room.member", state_key: "fake user1 state"},
+                    {content: {membership: "join"}, type: "m.room.member", state_key: "fake user2 state"}
+                ]);
+            }
+        );
+
+        var botLeft = false
+        sdk.leave.andCallFake(function(roomId) {
+            expect(roomId).toBe(adminRoomId, 'Bot did not leave admin room');
+            botLeft = true;
+            return Promise.resolve();
+        });
+
+        yield env.mockAppService._trigger("type:m.room.member", {
+            content: {
+                membership: "join",
+            },
+            state_key: botUserId,
+            user_id: "@user1:localhost",
+            room_id: adminRoomId,
+            type: "m.room.member"
+        });
+
+        yield env.mockAppService._trigger("type:m.room.member", {
+            content: {
+                membership: "join",
+            },
+            state_key: botUserId,
+            user_id: "@user2:localhost",
+            room_id: adminRoomId,
+            type: "m.room.member"
+        });
+
+        // trigger the bot to leave
+        yield env.mockAppService._trigger("type:m.room.message", {
+            content: {
+                body: "ping",
+                msgtype: "m.text"
+            },
+            user_id: "@user2:localhost",
+            room_id: adminRoomId,
+            type: "m.room.message"
+        }).then(
+            () => {
+                expect(botLeft).toBe(true);
+            },
+            (err) => {console.log(err)}
+        );
+    }));
+
+    it("mx bot should NOT be kicked when there are 2 users in room and a message is sent",
+    test.coroutine(function*() {
+
+        var sdk = env.clientMock._client(botUserId);
+        sdk.roomState.andCallFake(
+            function (roomId) {
+                expect(roomId).toBe(adminRoomId, 'Room state returned should be for admin room');
+                return Promise.resolve([
+                    {content: {membership: "join"}, type: "m.room.member", state_key: ":)"},
+                    {content: {membership: "join"}, type: "m.room.member", state_key: ";)"}
+                ]);
+            }
+        );
+
+        var botLeft = false
+        sdk.leave.andCallFake(function(roomId) {
+            expect(roomId).toBe(adminRoomId, 'Bot did not leave admin room');
+            botLeft = true;
+            return Promise.resolve();
+        });
+
+        yield env.mockAppService._trigger("type:m.room.member", {
+            content: {
+                membership: "join",
+            },
+            state_key: botUserId,
+            user_id: "@user1:localhost",
+            room_id: adminRoomId,
+            type: "m.room.member"
+        });
+
+        // trigger the bot to leave
+        yield env.mockAppService._trigger("type:m.room.message", {
+            content: {
+                body: "ping",
+                msgtype: "m.text"
+            },
+            user_id: "@user2:localhost",
+            room_id: adminRoomId,
+            type: "m.room.message"
+        }).then(
+            () => {
+                expect(botLeft).toBe(false);
+            },
+            (err) => {console.log(err)}
+        );
+    }));
 });

--- a/spec/integ/admin-rooms.spec.js
+++ b/spec/integ/admin-rooms.spec.js
@@ -678,9 +678,21 @@ describe("Admin rooms", function() {
             function (roomId) {
                 expect(roomId).toBe(adminRoomId, 'Room state returned should be for admin room');
                 return Promise.resolve([
-                    {content: {membership: "join"}, type: "m.room.member", state_key: "fake bot state"},
-                    {content: {membership: "join"}, type: "m.room.member", state_key: "fake user1 state"},
-                    {content: {membership: "join"}, type: "m.room.member", state_key: "fake user2 state"}
+                    {
+                        content: {membership: "join"},
+                        type: "m.room.member",
+                        state_key: "fake bot state"
+                    },
+                    {
+                        content: {membership: "join"},
+                        type: "m.room.member",
+                        state_key: "fake user1 state"
+                    },
+                    {content:
+                        {membership: "join"},
+                        type: "m.room.member",
+                        state_key: "fake user2 state"
+                    }
                 ]);
             }
         );

--- a/spec/util/client-sdk-mock.js
+++ b/spec/util/client-sdk-mock.js
@@ -46,6 +46,11 @@ function MockClient(config) {
         return Promise.resolve({});
     });
 
+    // mock up roomState
+    this.roomState.andCallFake(function() {
+        return Promise.resolve([{}]);
+    });
+
     // Helper to succeed sdk registration calls.
     this._onHttpRegister = function(params) {
         self.register.andCallFake(function(username, password) {


### PR DESCRIPTION
As seen with issue https://github.com/matrix-org/matrix-appservice-irc/issues/130, bots that are mistakenly invited to group chats will try to respond to every message sent (and prior to the new raw IRC commands feature (PR https://github.com/matrix-org/matrix-appservice-irc/pull/125), messages in the 'admin room' were ignored silently).

To deal with this, the bot will now leave a room if it determines that more than 2 members are in the Matrix room.