### PR TITLE
Changed RAW IRC command format

### DIFF
--- a/lib/bridge/MatrixHandler.js
+++ b/lib/bridge/MatrixHandler.js
@@ -135,7 +135,7 @@ MatrixHandler.prototype._onAdminMessage = Promise.coroutine(function*(req, event
     req.log.info("Received admin message from %s", event.user_id);
     let botUser = new MatrixUser(this.ircBridge.getAppServiceUserId());
 
-    // Assumes all commands have the form "!cmd [irc.server] [args...]"
+    // Assumes all commands have the form "!cmd [irc.server] COMMAND [args...]"
     let segments = event.content.body.split(" ");
     let cmd = segments.shift();
     let args = segments;
@@ -143,6 +143,7 @@ MatrixHandler.prototype._onAdminMessage = Promise.coroutine(function*(req, event
     // Work out which IRC server the command is directed at.
     let clientList = this.ircBridge.getBridgedClientsForUserId(event.user_id);
     let ircServer = this.ircBridge.getServer(args[0]);
+
     if (ircServer) {
         args.shift(); // pop the server so commands don't need to know
     }
@@ -362,95 +363,56 @@ MatrixHandler.prototype._onAdminMessage = Promise.coroutine(function*(req, event
             `Valid commands:
             !join irc.example.com #channel [key]
             !nick irc.example.com DesiredNick
-            !whois nick`
+            !whois nick
+                OR
+            !cmd [irc.server] COMMAND [arg0 [arg1 [...]]]`
         );
         yield this.ircBridge.sendMatrixAction(adminRoom, botUser, notice, req);
         return;
     }
-    else {
-        let fmt = '\nirc.server\n'+
-                    '(COMMAND [arg0 [arg1 [...]]])\n'+
-                    '(COMMAND [arg0 [arg1 [...]]])\n'+
-                    'irc.server2';
+    else if (cmd === "!cmd" && args[0]) {
         req.log.info(`No valid (old form) admin command, will try new format`);
 
         // Assumes commands have the form
-        // irc.server
-        // (COMMAND [arg0 [arg1 [...]]])
-        // (COMMAND [arg0 [arg1 [...]]])
-        // irc.server2
-        // ...
-        let commandBlocks = event.content.body;
+        // !cmd [irc.server] COMMAND [arg0 [arg1 [...]]]
 
         let currentServer = ircServer;
         let blacklist = ['PROTOCTL'];
 
         try {
-            let lines = commandBlocks.replace(/\r/g, "").split("\n");
-            for (var ix = 0; ix < lines.length; ix++) {
-                let lineNumber = ix + 1;
-                let line = lines[ix].trim();
-                let commandMatch = line.match(/^([A-Z]+)(?: (.*))?$/);
-                let domainMatch = line.match(/([a-z0-9\.:-]+)/);
+            let keyword = args[0];
 
-                if (commandMatch) {
-                    if (!currentServer) {
-                        throw new Error(`A server address must be specified` +
-                                        ` - tried to execute command on line ${lineNumber}`);
-                    }
-
-                    let keyword = commandMatch[1];
-
-                    if (!keyword) {
-                        throw new Error(`Command required on line ${lineNumber}`);
-                    }
-
-                    if (blacklist.indexOf(keyword) != -1) {
-                        throw new Error(`Command blacklisted (${keyword})` +
-                                        ` on line ${lineNumber}`);
-                    }
-
-                    let argsJoined = commandMatch[2];
-                    let sendArgs = [];
-
-                    // Arguments are optional
-                    if (argsJoined) {
-                        sendArgs = argsJoined.split(' ');
-                    }
-
-                    sendArgs.unshift(keyword);
-
-                    let bridgedClient = yield this.ircBridge.getBridgedClient(
-                        currentServer, event.user_id
-                    );
-
-                    if (!bridgedClient.unsafeClient) {
-                        throw new Error('Possibly disconnected (on line ${lineNumber})');
-                    }
-
-                    bridgedClient.unsafeClient.send.apply(bridgedClient.unsafeClient, sendArgs);
-                }
-                else if (domainMatch) {
-                    // set domain of command to ircDomain
-                    let ircDomain = domainMatch[1];
-                    let server = this.ircBridge.getServer(domainMatch[1]);
-
-                    if (!server) {
-                        throw new Error(`IRC domain not found (${ircDomain})` +
-                                        ` on line ${lineNumber}`);
-                    }
-
-                    currentServer = server;
+            // keyword could be a failed server or a malformed command
+            if (!keyword.match(/^[A-Z]+$/)) {
+                // if not a domain OR is only word (which implies command)
+                if (!keyword.match(/^[a-z0-9:\.-]+$/) || args.length == 1) {
+                    throw new Error(`Malformed command: ${keyword}`);
                 }
                 else {
-                    throw new Error(`Failed to parse domain or command on line ${lineNumber}`);
+                    throw new Error(`Domain not accepted: ${keyword}`);
                 }
             }
+
+            if (blacklist.indexOf(keyword) != -1) {
+                throw new Error(`Command blacklisted: ${keyword}`);
+            }
+
+            // If no args after COMMAND, this will be []
+            let sendArgs = args.splice(1);
+            sendArgs.unshift(keyword);
+
+            let bridgedClient = yield this.ircBridge.getBridgedClient(
+                currentServer, event.user_id
+            );
+
+            if (!bridgedClient.unsafeClient) {
+                throw new Error('Possibly disconnected');
+            }
+
+            bridgedClient.unsafeClient.send.apply(bridgedClient.unsafeClient, sendArgs);
         }
         catch (err) {
-            let notice = new MatrixAction("notice",
-                `${err}\n`+
-               `Usage: ${fmt}` );
+            let notice = new MatrixAction("notice", `${err}\n` );
             yield this.ircBridge.sendMatrixAction(adminRoom, botUser, notice, req);
             return;
         }


### PR DESCRIPTION
To prevent commands being issued by mistake and to be less verbose in terms of errors
occuring, the command format and handling has changed. Commands issued now have this
form (which matches the previously available ones) :
```
!cmd [server.com] COMMAND [arg1 [arg2 [...]]
```
The usage message will now only be shown when !help is used, and not when an error
occurs.