### PR TITLE
Scheduled IRC Reconnects

### DIFF
--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -208,7 +208,7 @@ ircService:
         idleTimeout: 10800
         # The number of millseconds to wait between consecutive reconnections if a
         # client gets disconnected. Default: 5000 (5 seconds)
-        reconnectInterval: 5000
+        reconnectIntervalMs: 5000
         # The number of lines to allow being sent by the IRC client that has received
         # a large block of text to send from matrix. If the number of lines that would
         # be sent is > lineLimit, the text will instead be uploaded to matrix and the

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -208,12 +208,10 @@ ircService:
         idleTimeout: 10800
         # The number of millseconds to wait between consecutive reconnections if a
         # client gets disconnected. Setting to 0 will cause the scheduling to be
-        # disabled, i.e. it will be scheduled immediately. Otherwise, the scheduling
-        # interval will be used such that one client reconnect for this server will
-        # be handled every reconnectIntervalMs ms using a FIFO queue. Regardless of
-        # scheduling, a delay will be added to the reconnect process:
-        #   addedDelay = 5000 + (1000 * attempts) * Math.random()
-        #                + 20000 // if throttled
+        # disabled, i.e. it will be scheduled immediately (with jitter.
+        # Otherwise, the scheduling interval will be used such that one client
+        # reconnect for this server will be handled every reconnectIntervalMs ms using
+        # a FIFO queue.
         # Default: 5000 (5 seconds)
         reconnectIntervalMs: 5000
         # The number of lines to allow being sent by the IRC client that has received

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -207,7 +207,14 @@ ircService:
         # mirroring matrix membership lists to IRC. Default: 172800 (48 hours)
         idleTimeout: 10800
         # The number of millseconds to wait between consecutive reconnections if a
-        # client gets disconnected. Default: 5000 (5 seconds)
+        # client gets disconnected. Setting to 0 will cause the scheduling to be
+        # disabled, i.e. it will be scheduled immediately. Otherwise, the scheduling
+        # interval will be used such that one client reconnect for this server will
+        # be handled every reconnectIntervalMs ms using a FIFO queue. Regardless of
+        # scheduling, a delay will be added to the reconnect process:
+        #   addedDelay = 5000 + (1000 * attempts) * Math.random()
+        #                + 20000 // if throttled
+        # Default: 5000 (5 seconds)
         reconnectIntervalMs: 5000
         # The number of lines to allow being sent by the IRC client that has received
         # a large block of text to send from matrix. If the number of lines that would

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -206,6 +206,9 @@ ircService:
         # not apply an idle timeout. This value is ignored if this IRC server is
         # mirroring matrix membership lists to IRC. Default: 172800 (48 hours)
         idleTimeout: 10800
+        # The number of millseconds to wait between consecutive reconnections if a
+        # client gets disconnected. Default: 5000 (5 seconds)
+        reconnectInterval: 5000
         # The number of lines to allow being sent by the IRC client that has received
         # a large block of text to send from matrix. If the number of lines that would
         # be sent is > lineLimit, the text will instead be uploaded to matrix and the

--- a/lib/config/schema.yml
+++ b/lib/config/schema.yml
@@ -233,7 +233,7 @@ properties:
                                 idleTimeout:
                                     type: "integer"
                                     minimum: 0
-                                reconnectInterval:
+                                reconnectIntervalMs:
                                     type: "integer"
                                     minimum: 0
                                 allowNickChanges:

--- a/lib/config/schema.yml
+++ b/lib/config/schema.yml
@@ -233,6 +233,9 @@ properties:
                                 idleTimeout:
                                     type: "integer"
                                     minimum: 0
+                                reconnectInterval:
+                                    type: "integer"
+                                    minimum: 0
                                 allowNickChanges:
                                     type: "boolean"
                                 ipv6:

--- a/lib/irc/ClientPool.js
+++ b/lib/irc/ClientPool.js
@@ -8,9 +8,26 @@ var stats = require("../config/stats");
 var log = require("../logging").get("ClientPool");
 var Promise = require("bluebird");
 
-const RECONNECT_TIME_MS = 10000;
-// Wait between recconections of clients
-const RECONNECT_INTERVAL_MS = 1000;
+const RECONNECT_TIME_MS = 1000;
+
+// Throttle
+function throttle (cp, func, delay) {
+    let queue = [];
+    let handleQueue = function () {
+        if (queue.length > 0) {
+            let args = queue.shift();
+            console.log('Doing call!');
+            func.apply(cp, args);
+        }
+    }
+
+    setInterval(handleQueue, delay);
+
+    return function () {
+        console.log('Queueing call!');
+        queue.push(Array.from(arguments));
+    }
+}
 
 function ClientPool(ircBridge) {
     this._ircBridge = ircBridge;
@@ -30,6 +47,8 @@ function ClientPool(ircBridge) {
         //    }
         // }
     };
+
+    this._throttledReconnects = {};
 }
 
 ClientPool.prototype.addBot = function(server, client) {
@@ -240,30 +259,31 @@ ClientPool.prototype._onClientDisconnected = function(bridgedClient) {
     // the timeout below holds it in a closure, preventing it from being GC'd.
     bridgedClient = undefined;
     setTimeout(function() {
-        self._reconnect(cli, chanList);
+        self._throttledReconnect(cli, chanList);
     }, RECONNECT_TIME_MS);
 };
 
-// Throttle
-function throttle (func, delay) {
-    let queue = [];
-    let handleQueue = function () {
-        if (queue.length > 0) {
-            func.apply(queue.shift());
+ClientPool.prototype._throttledReconnect = function (cli, chanList) {
+    let serverDomain = cli.server.domain;
+    let throttleRate = cli.server.getReconnectionInterval();
+
+    if (throttleRate > 0) {
+        let throttledReconnect = this._throttledReconnects[serverDomain];
+        if (!throttledReconnect) {
+            // Create a new throttled reconnection function
+            throttledReconnect = new throttle(this, this._reconnect, throttleRate);
+            this._throttledReconnects[serverDomain] = throttledReconnect;
         }
+        // Call the existing throttled reconnection function for this server
+        throttledReconnect(cli, chanList);
     }
-
-    setInterval(handleQueue, delay);
-
-    return function () {
-        queue.push(Array.from(arguments));
+    else {
+        this._reconnect(cli, chanList);
     }
 }
 
 // Take a reconnection request from the FIFO and process it
-ClientPool.prototype._reconnect = throttle(function(cli, chanList) {
-    log.info('Throttled reconnect');
-
+ClientPool.prototype._reconnect = function(cli, chanList) {
     var self = this;
     cli.connect().then(function() {
         log.info(
@@ -281,7 +301,7 @@ ClientPool.prototype._reconnect = throttle(function(cli, chanList) {
             "<%s> Failed to reconnect %s@%s", cli._id, cli.nick, cli.server.domain
         );
     });
-}, RECONNECT_INTERVAL_MS);
+};
 
 ClientPool.prototype._onNickChange = function(bridgedClient, oldNick, newNick) {
     this._virtualClients[bridgedClient.server.domain].nicks[oldNick] = undefined;

--- a/lib/irc/ClientPool.js
+++ b/lib/irc/ClientPool.js
@@ -238,29 +238,23 @@ ClientPool.prototype._onClientDisconnected = function(bridgedClient) {
     // the timeout below holds it in a closure, preventing it from being GC'd.
     bridgedClient = undefined;
     setTimeout(function() {
-        self._reconnect(cli, chanList);
+        cli.connect().then(function() {
+            log.info(
+                "<%s> Reconnected %s@%s", cli._id, cli.nick, cli.server.domain
+            );
+            if (chanList.length > 0) {
+                log.info("<%s> Rejoining %s channels", cli._id, chanList.length);
+                chanList.forEach(function(c) {
+                    cli.joinChannel(c);
+                });
+            }
+            self._sendConnectionMetric(cli.server);
+        }, function(e) {
+            log.error(
+                "<%s> Failed to reconnect %s@%s", cli._id, cli.nick, cli.server.domain
+            );
+        });
     }, RECONNECT_TIME_MS);
-};
-
-// Take a reconnection request from the FIFO and process it
-ClientPool.prototype._reconnect = function(cli, chanList) {
-    var self = this;
-    cli.connect().then(function() {
-        log.info(
-            "<%s> Reconnected %s@%s", cli._id, cli.nick, cli.server.domain
-        );
-        if (chanList.length > 0) {
-            log.info("<%s> Rejoining %s channels", cli._id, chanList.length);
-            chanList.forEach(function(c) {
-                cli.joinChannel(c);
-            });
-        }
-        self._sendConnectionMetric(cli.server);
-    }, function(e) {
-        log.error(
-            "<%s> Failed to reconnect %s@%s", cli._id, cli.nick, cli.server.domain
-        );
-    });
 };
 
 ClientPool.prototype._onNickChange = function(bridgedClient, oldNick, newNick) {

--- a/lib/irc/ClientPool.js
+++ b/lib/irc/ClientPool.js
@@ -9,6 +9,8 @@ var log = require("../logging").get("ClientPool");
 var Promise = require("bluebird");
 
 const RECONNECT_TIME_MS = 10000;
+// Wait between recconections of clients
+const RECONNECT_INTERVAL_MS = 1000;
 
 function ClientPool(ircBridge) {
     this._ircBridge = ircBridge;
@@ -238,24 +240,48 @@ ClientPool.prototype._onClientDisconnected = function(bridgedClient) {
     // the timeout below holds it in a closure, preventing it from being GC'd.
     bridgedClient = undefined;
     setTimeout(function() {
-        cli.connect().then(function() {
-            log.info(
-                "<%s> Reconnected %s@%s", cli._id, cli.nick, cli.server.domain
-            );
-            if (chanList.length > 0) {
-                log.info("<%s> Rejoining %s channels", cli._id, chanList.length);
-                chanList.forEach(function(c) {
-                    cli.joinChannel(c);
-                });
-            }
-            self._sendConnectionMetric(cli.server);
-        }, function(e) {
-            log.error(
-                "<%s> Failed to reconnect %s@%s", cli._id, cli.nick, cli.server.domain
-            );
-        });
+        self._reconnect(cli, chanList);
     }, RECONNECT_TIME_MS);
 };
+
+// Throttle
+function throttle (func, delay) {
+    let queue = [];
+    let handleQueue = function () {
+        if (queue.length > 0) {
+            func.apply(queue.shift());
+        }
+    }
+
+    setInterval(handleQueue, delay);
+
+    return function () {
+        queue.push(Array.from(arguments));
+    }
+}
+
+// Take a reconnection request from the FIFO and process it
+ClientPool.prototype._reconnect = throttle(function(cli, chanList) {
+    log.info('Throttled reconnect');
+
+    var self = this;
+    cli.connect().then(function() {
+        log.info(
+            "<%s> Reconnected %s@%s", cli._id, cli.nick, cli.server.domain
+        );
+        if (chanList.length > 0) {
+            log.info("<%s> Rejoining %s channels", cli._id, chanList.length);
+            chanList.forEach(function(c) {
+                cli.joinChannel(c);
+            });
+        }
+        self._sendConnectionMetric(cli.server);
+    }, function(e) {
+        log.error(
+            "<%s> Failed to reconnect %s@%s", cli._id, cli.nick, cli.server.domain
+        );
+    });
+}, RECONNECT_INTERVAL_MS);
 
 ClientPool.prototype._onNickChange = function(bridgedClient, oldNick, newNick) {
     this._virtualClients[bridgedClient.server.domain].nicks[oldNick] = undefined;

--- a/lib/irc/ClientPool.js
+++ b/lib/irc/ClientPool.js
@@ -10,25 +10,6 @@ var Promise = require("bluebird");
 
 const RECONNECT_TIME_MS = 1000;
 
-// Throttle
-function throttle (cp, func, delay) {
-    let queue = [];
-    let handleQueue = function () {
-        if (queue.length > 0) {
-            let args = queue.shift();
-            console.log('Doing call!');
-            func.apply(cp, args);
-        }
-    }
-
-    setInterval(handleQueue, delay);
-
-    return function () {
-        console.log('Queueing call!');
-        queue.push(Array.from(arguments));
-    }
-}
-
 function ClientPool(ircBridge) {
     this._ircBridge = ircBridge;
     // The list of bot clients on servers (not specific users)
@@ -47,8 +28,6 @@ function ClientPool(ircBridge) {
         //    }
         // }
     };
-
-    this._throttledReconnects = {};
 }
 
 ClientPool.prototype.addBot = function(server, client) {
@@ -259,28 +238,9 @@ ClientPool.prototype._onClientDisconnected = function(bridgedClient) {
     // the timeout below holds it in a closure, preventing it from being GC'd.
     bridgedClient = undefined;
     setTimeout(function() {
-        self._throttledReconnect(cli, chanList);
+        self._reconnect(cli, chanList);
     }, RECONNECT_TIME_MS);
 };
-
-ClientPool.prototype._throttledReconnect = function (cli, chanList) {
-    let serverDomain = cli.server.domain;
-    let throttleRate = cli.server.getReconnectionInterval();
-
-    if (throttleRate > 0) {
-        let throttledReconnect = this._throttledReconnects[serverDomain];
-        if (!throttledReconnect) {
-            // Create a new throttled reconnection function
-            throttledReconnect = new throttle(this, this._reconnect, throttleRate);
-            this._throttledReconnects[serverDomain] = throttledReconnect;
-        }
-        // Call the existing throttled reconnection function for this server
-        throttledReconnect(cli, chanList);
-    }
-    else {
-        this._reconnect(cli, chanList);
-    }
-}
 
 // Take a reconnection request from the FIFO and process it
 ClientPool.prototype._reconnect = function(cli, chanList) {

--- a/lib/irc/ConnectionInstance.js
+++ b/lib/irc/ConnectionInstance.js
@@ -3,6 +3,7 @@ var irc = require("irc");
 var promiseutil = require("../promiseutil");
 var logging = require("../logging");
 var log = logging.get("client-connection");
+var Scheduler = require("./Scheduler.js");
 
 // The time we're willing to wait for a connect callback when connecting to IRC.
 const CONNECT_TIMEOUT_MS = 30 * 1000; // 30s
@@ -256,7 +257,7 @@ ConnectionInstance.create = function(server, opts, onCreatedCallback) {
 
     var connAttempts = 0;
     function retryForever() {
-        retryConnection().then(returnClient, function(err) {
+        let reschedule = function(err) {
             connAttempts += 1;
             var retryTimeMs = 5000; // base retry time
             if (err.message === "throttled") {
@@ -265,10 +266,17 @@ ConnectionInstance.create = function(server, opts, onCreatedCallback) {
             // additional second for each attempt, jittered.
             retryTimeMs += ((1000 * connAttempts) * Math.random());
 
-            setTimeout(function() {
-                retryForever();
-            }, retryTimeMs);
-        });
+            // wait until scheduled
+            Scheduler.reschedule(server, retryTimeMs, retryConnection).then(
+                returnClient,
+                reschedule
+            );
+        };
+        // Schedule with no added delay
+        Scheduler.reschedule(server, 0, retryConnection).then(
+            returnClient,
+            reschedule
+        );
     }
     retryForever();
 

--- a/lib/irc/ConnectionInstance.js
+++ b/lib/irc/ConnectionInstance.js
@@ -60,7 +60,7 @@ ConnectionInstance.prototype.connect = function() {
         }
     }, CONNECT_TIMEOUT_MS);
 
-    self.client.connect(function() {
+    self.client.connect(1, function() {
         gotConnectedCallback = true;
         self.state = "connected";
         self._connectDefer.resolve(self);
@@ -141,6 +141,12 @@ ConnectionInstance.prototype._listenForErrors = function() {
         log.error(
             "Server: %s (%s) Network Error: %s", domain, nick,
             JSON.stringify(err, undefined, 2)
+        );
+        self.disconnect("net_error");
+    });
+    self.client.addListener("abort", function() {
+        log.error(
+            "Server: %s (%s) Connection Aborted", domain, nick
         );
         self.disconnect("net_error");
     });
@@ -237,7 +243,8 @@ ConnectionInstance.create = function(server, opts, onCreatedCallback) {
         floodProtectionDelay: FLOOD_PROTECTION_DELAY_MS,
         port: server.getPort(),
         secure: server.useSsl(),
-        selfSigned: server.useSslSelfSigned()
+        selfSigned: server.useSslSelfSigned(),
+        retryCount: 0
     };
     // TODO : coroutine this
     var d = promiseutil.defer();
@@ -256,24 +263,22 @@ ConnectionInstance.create = function(server, opts, onCreatedCallback) {
     };
 
     var connAttempts = 0;
+    var retryTimeMs = 0; // base retry time
     function retryForever() {
         let tryToConnect = function(err) {
             connAttempts += 1;
-            var retryTimeMs = 5000; // base retry time
             if (err.message === "throttled") {
                 retryTimeMs += THROTTLE_WAIT_MS;
             }
-            // additional second for each attempt, jittered.
-            retryTimeMs += ((1000 * connAttempts) * Math.random());
 
             // wait until scheduled
-            Scheduler.reschedule(server, retryTimeMs, retryConnection).then(
+            Scheduler.reschedule(server, retryTimeMs, retryConnection, opts.nick).then(
                 returnClient,
                 tryToConnect
             );
         };
         // Schedule with no added delay
-        Scheduler.reschedule(server, 0, retryConnection).then(
+        Scheduler.reschedule(server, 0, retryConnection, opts.nick).then(
             returnClient,
             tryToConnect
         );

--- a/lib/irc/ConnectionInstance.js
+++ b/lib/irc/ConnectionInstance.js
@@ -263,25 +263,43 @@ ConnectionInstance.create = function(server, opts, onCreatedCallback) {
     };
 
     var connAttempts = 0;
-    var retryTimeMs = 0; // base retry time
+    var retryTimeMs = 0;
+    var BASE_RETRY_TIME_MS = 1000;
     function retryForever() {
-        let tryToConnect = function(err) {
+        let retryFailed = function(err) {
             connAttempts += 1;
             if (err.message === "throttled") {
                 retryTimeMs += THROTTLE_WAIT_MS;
             }
 
-            // wait until scheduled
-            Scheduler.reschedule(server, retryTimeMs, retryConnection, opts.nick).then(
-                returnClient,
-                tryToConnect
-            );
+            if (server.getReconnectIntervalMs() > 0) {
+                // wait until scheduled
+                Scheduler.reschedule(server, retryTimeMs, retryConnection, opts.nick).then(
+                    returnClient,
+                    retryFailed
+                );
+            }
+            else {
+                let delay = BASE_RETRY_TIME_MS + retryTimeMs +
+                           Math.round((connAttempts * 1000) * Math.random());
+
+                log.info(`Scheduling disabled, retrying with delay ${delay}ms`);
+                retryConnection().then(
+                    returnClient,
+                    (e) => {
+                        setTimeout(
+                            () => {
+                                retryFailed(e);
+                            }
+                        , delay);
+                    }
+                );
+            }
+
         };
-        // Schedule with no added delay
-        Scheduler.reschedule(server, 0, retryConnection, opts.nick).then(
-            returnClient,
-            tryToConnect
-        );
+
+        // Initially, pretend to have failed in order to start things off
+        retryFailed({});
     }
     retryForever();
 

--- a/lib/irc/ConnectionInstance.js
+++ b/lib/irc/ConnectionInstance.js
@@ -257,7 +257,7 @@ ConnectionInstance.create = function(server, opts, onCreatedCallback) {
 
     var connAttempts = 0;
     function retryForever() {
-        let reschedule = function(err) {
+        let tryToConnect = function(err) {
             connAttempts += 1;
             var retryTimeMs = 5000; // base retry time
             if (err.message === "throttled") {
@@ -269,13 +269,13 @@ ConnectionInstance.create = function(server, opts, onCreatedCallback) {
             // wait until scheduled
             Scheduler.reschedule(server, retryTimeMs, retryConnection).then(
                 returnClient,
-                reschedule
+                tryToConnect
             );
         };
         // Schedule with no added delay
         Scheduler.reschedule(server, 0, retryConnection).then(
             returnClient,
-            reschedule
+            tryToConnect
         );
     }
     retryForever();

--- a/lib/irc/ConnectionInstance.js
+++ b/lib/irc/ConnectionInstance.js
@@ -283,7 +283,8 @@ ConnectionInstance.create = function(server, opts, onCreatedCallback) {
                 let delay = BASE_RETRY_TIME_MS + retryTimeMs +
                            Math.round((connAttempts * 1000) * Math.random());
 
-                log.info(`Scheduling disabled, retrying with delay ${delay}ms`);
+                log.info(`Scheduling disabled for ${opts.nick} on ${server.domain}, `+
+                         `retrying with delay ${delay}ms (attempts ${connAttempts})`);
                 retryConnection().then(
                     returnClient,
                     (e) => {

--- a/lib/irc/IrcServer.js
+++ b/lib/irc/IrcServer.js
@@ -68,7 +68,7 @@ IrcServer.prototype.getIdleTimeoutMs = function() {
     return this.config.ircClients.idleTimeout;
 };
 
-IrcServer.prototype.getReconnectionInterval = function() {
+IrcServer.prototype.getReconnectInterval = function() {
     return this.config.ircClients.reconnectInterval;
 };
 

--- a/lib/irc/IrcServer.js
+++ b/lib/irc/IrcServer.js
@@ -68,6 +68,10 @@ IrcServer.prototype.getIdleTimeoutMs = function() {
     return this.config.ircClients.idleTimeout;
 };
 
+IrcServer.prototype.getReconnectionInterval = function() {
+    return this.config.ircClients.reconnectInterval;
+};
+
 IrcServer.prototype.getMaxClients = function() {
     return this.config.ircClients.maxClients;
 };
@@ -362,6 +366,7 @@ IrcServer.DEFAULT_CONFIG = {
         nickTemplate: "M-$DISPLAY",
         maxClients: 30,
         idleTimeout: 172800,
+        reconnectInterval: 5000,
         allowNickChanges: false,
         ipv6: {},
         lineLimit: 3

--- a/lib/irc/IrcServer.js
+++ b/lib/irc/IrcServer.js
@@ -68,8 +68,8 @@ IrcServer.prototype.getIdleTimeoutMs = function() {
     return this.config.ircClients.idleTimeout;
 };
 
-IrcServer.prototype.getReconnectInterval = function() {
-    return this.config.ircClients.reconnectInterval;
+IrcServer.prototype.getReconnectIntervalMs = function() {
+    return this.config.ircClients.reconnectIntervalMs;
 };
 
 IrcServer.prototype.getMaxClients = function() {
@@ -366,7 +366,7 @@ IrcServer.DEFAULT_CONFIG = {
         nickTemplate: "M-$DISPLAY",
         maxClients: 30,
         idleTimeout: 172800,
-        reconnectInterval: 5000,
+        reconnectIntervalMs: 5000,
         allowNickChanges: false,
         ipv6: {},
         lineLimit: 3

--- a/lib/irc/Scheduler.js
+++ b/lib/irc/Scheduler.js
@@ -5,6 +5,55 @@ var Promise = require("bluebird");
 var logging = require("../logging");
 var log = logging.get("scheduler");
 
+function ScheduledQueue (server) {
+    this._queue = [];
+    this._processing = null;
+    this._server = server;
+
+    setInterval(this._consume.bind(this), server.getReconnectInterval());
+}
+
+ScheduledQueue.prototype._consume = Promise.coroutine(function*() {
+    if (this._processing) {
+        return;
+    }
+    this._processing = this._queue.shift();
+    if (!this._processing) {
+        return;
+    }
+    try {
+        let thing = this._procFn(this._processing);
+
+        let result = yield thing;
+        log.info(`Resolving scheduled promise for ${this._server.domain}`);
+        this._processing.defer.resolve(result);
+    }
+    catch (err) {
+        // log.info(
+        //     `Rejecting scheduled promise for ${this._server.domain} (${err.message})\n` +
+        //     `${err.stack}`
+        // );
+        this._processing.defer.reject(err);
+    }
+    finally {
+        this._processing = null;
+    }
+});
+
+ScheduledQueue.prototype._procFn = function (item) {
+    return item.fn();
+}
+
+ScheduledQueue.prototype.enqueue = function(item) {
+    this._queue.push(item);
+}
+
+ScheduledQueue.prototype.killAll = function() {
+    for (var i = 0; i < this._queue.length; i++) {
+        this._queue[i].reject();
+    }
+}
+
 /**
  * An IRC connection scheduler. Enables ConnectionInstance to reconnect
  * in a way that queues reconnection requests and services the FIFO queue at a
@@ -14,10 +63,8 @@ var log = logging.get("scheduler");
 var Scheduler = {
     _queueServers: [],
     _queues: {},
-    _processing : {},
     _getQueue: _getQueue,
     _newQueue: _newQueue,
-    _procFn: _procFn,
     reschedule: Promise.coroutine(function*(server, addedDelay, retryConnection) {
         var d = promiseutil.defer();
 
@@ -29,46 +76,19 @@ var Scheduler = {
         );
         yield Promise.delay(addedDelay);
 
-        q.push({defer: d, fn: retryConnection});
+        q.enqueue({defer: d, fn: retryConnection});
+
+        // Try to consume immediately.
+        q._consume();
 
         return d.promise;
     }),
     killAll: killAll
 };
 
-function _procFn (item) {
-    return item.fn();
-}
-
 function _newQueue (server) {
-    Scheduler._queues[server.domain] = [];
+    Scheduler._queues[server.domain] = new ScheduledQueue(server);
     Scheduler._queueServers.push(server.domain);
-
-    let handleQueue = Promise.coroutine(function*() {
-        if (Scheduler._processing[server.domain]) {
-            return;
-        }
-        Scheduler._processing[server.domain] = Scheduler._queues[server.domain].shift();
-        if (!Scheduler._processing[server.domain]) {
-            return;
-        }
-        try {
-            let thing = Scheduler._procFn(Scheduler._processing[server.domain]);
-
-            let result = yield thing;
-            log.info(`Resolving scheduled promise for ${server.domain}`);
-            Scheduler._processing[server.domain].defer.resolve(result);
-        }
-        catch (err) {
-            log.info(`Rejecting scheduled promise for ${server.domain}`);
-            Scheduler._processing[server.domain].defer.reject(err);
-        }
-        finally {
-            Scheduler._processing[server.domain] = null;
-        }
-    });
-
-    setInterval(handleQueue, server.getReconnectInterval());
 
     return Scheduler._queues[server.domain];
 }
@@ -87,9 +107,7 @@ function _getQueue (server) {
 function killAll() {
     for (var i = 0; i < Scheduler._queueServers.length; i++) {
         var q = Scheduler._queues[Scheduler._queueServers[i]];
-        for (var j = 0; j < q.length; j++) {
-            q[j].reject();
-        }
+        q.killAll();
     }
 }
 module.exports = Scheduler;

--- a/lib/irc/Scheduler.js
+++ b/lib/irc/Scheduler.js
@@ -44,7 +44,7 @@ var Scheduler = {
         );
 
         log.info(
-            `Tryed to queue scheduled promise for ${server.domain} ${nick}` +
+            `Queued scheduled promise for ${server.domain} ${nick}` +
             (addedDelayMs > 0 ? ` with ${Math.round(addedDelayMs)}ms added delay`:'')
         );
 

--- a/lib/irc/Scheduler.js
+++ b/lib/irc/Scheduler.js
@@ -9,7 +9,6 @@ function ScheduledQueue (server) {
     this._queue = [];
     this._processing = null;
     this._server = server;
-
     // Start consuming
     this._consume();
 }
@@ -21,7 +20,7 @@ ScheduledQueue.prototype._consume = Promise.coroutine(function*() {
     this._processing = this._queue.shift();
     if (!this._processing) {
         // Nothing in the queue, try to consume after interval
-        setTimeout(this._consume.bind(this), this._server.getReconnectInterval());
+        setTimeout(this._consume.bind(this), this._server.getReconnectIntervalMs());
         return;
     }
     try {
@@ -39,7 +38,7 @@ ScheduledQueue.prototype._consume = Promise.coroutine(function*() {
     finally {
         this._processing = null;
         // Processing done, try to consume after interval
-        setTimeout(this._consume.bind(this), this._server.getReconnectInterval());
+        setTimeout(this._consume.bind(this), this._server.getReconnectIntervalMs());
     }
 });
 
@@ -60,7 +59,7 @@ ScheduledQueue.prototype.killAll = function() {
 /**
  * An IRC connection scheduler. Enables ConnectionInstance to reconnect
  * in a way that queues reconnection requests and services the FIFO queue at a
- * rate determined by ircServer.getReconnectInterval().
+ * rate determined by ircServer.getReconnectIntervalMs().
  */
 
 var Scheduler = {

--- a/lib/irc/Scheduler.js
+++ b/lib/irc/Scheduler.js
@@ -11,13 +11,26 @@ var Queue = require("../util/Queue.js");
  * rate determined by ircServer.getReconnectIntervalMs().
  */
 
+ var _queues = {};
+
+function _newQueue (server) {
+    _queues[server.domain] = new Queue(procFn, server.getReconnectIntervalMs());
+
+    return _queues[server.domain];
+}
+
+function _getQueue (server) {
+    let q = _queues[server.domain];
+
+    if (!q) {
+        q = _newQueue(server);
+    }
+    return q;
+}
+
 var Scheduler = {
-    _queueServers: [],
-    _queues: {},
-    _getQueue: _getQueue,
-    _newQueue: _newQueue,
     reschedule: Promise.coroutine(function*(server, addedDelay, retryConnection) {
-        var q = Scheduler._getQueue(server);
+        var q = _getQueue(server);
 
         var promise = q.enqueue(
             `Scheduler.reschedule ${server.domain}`,
@@ -41,26 +54,12 @@ function procFn (item) {
     return Promise.delay(item.addedDelay).then(item.fn);
 }
 
-function _newQueue (server) {
-    Scheduler._queues[server.domain] = new Queue(procFn, server.getReconnectIntervalMs());
-    Scheduler._queueServers.push(server.domain);
-
-    return Scheduler._queues[server.domain];
-}
-
-function _getQueue (server) {
-    let q = Scheduler._queues[server.domain];
-
-    if (!q) {
-        q = Scheduler._newQueue(server);
-    }
-    return q;
-}
 
 // Reject all queued promises
 function killAll() {
-    for (var i = 0; i < Scheduler._queueServers.length; i++) {
-        var q = Scheduler._queues[Scheduler._queueServers[i]];
+    let queueKeys = Object.keys(_queues);
+    for (var i = 0; i < queueKeys.length; i++) {
+        var q = _queues[queueKeys[i]];
         q.killAll();
     }
 }

--- a/lib/irc/Scheduler.js
+++ b/lib/irc/Scheduler.js
@@ -11,29 +11,29 @@ var Queue = require("../util/Queue.js");
  * rate determined by ircServer.getReconnectIntervalMs().
  */
 
- var _queues = {};
+ var queues = {};
 
-function _newQueue (server) {
-    _queues[server.domain] = new Queue(procFn, server.getReconnectIntervalMs());
-
-    return _queues[server.domain];
+function procFn (item) {
+    return Promise.delay(item.addedDelay).then(item.fn);
 }
 
-function _getQueue (server) {
-    let q = _queues[server.domain];
+function getQueue (server) {
+    let q = queues[server.domain];
 
     if (!q) {
-        q = _newQueue(server);
+        q = new Queue(procFn, server.getReconnectIntervalMs());
+
+        queues[server.domain] = q;
     }
     return q;
 }
 
 var Scheduler = {
-    reschedule: Promise.coroutine(function*(server, addedDelay, retryConnection) {
-        var q = _getQueue(server);
+    reschedule: Promise.coroutine(function*(server, addedDelay, retryConnection, nick) {
+        var q = getQueue(server);
 
         var promise = q.enqueue(
-            `Scheduler.reschedule ${server.domain}`,
+            `Scheduler.reschedule ${server.domain} ${nick}`,
             {
                 fn: retryConnection,
                 addedDelay: addedDelay
@@ -41,7 +41,7 @@ var Scheduler = {
         );
 
         log.info(
-            `Queued new scheduled promise for ${server.domain}` +
+            `Tryed to queue scheduled promise for ${server.domain} ${nick}` +
             (addedDelay > 0 ? ` with ${Math.round(addedDelay)}ms added delay`:'')
         );
 
@@ -50,16 +50,11 @@ var Scheduler = {
     killAll: killAll
 };
 
-function procFn (item) {
-    return Promise.delay(item.addedDelay).then(item.fn);
-}
-
-
 // Reject all queued promises
 function killAll() {
-    let queueKeys = Object.keys(_queues);
+    let queueKeys = Object.keys(queues);
     for (var i = 0; i < queueKeys.length; i++) {
-        var q = _queues[queueKeys[i]];
+        var q = queues[queueKeys[i]];
         q.killAll();
     }
 }

--- a/lib/irc/Scheduler.js
+++ b/lib/irc/Scheduler.js
@@ -29,10 +29,7 @@ ScheduledQueue.prototype._consume = Promise.coroutine(function*() {
         this._processing.defer.resolve(result);
     }
     catch (err) {
-        log.info(
-            `Rejecting scheduled promise for ${this._server.domain} (${err.message})\n` +
-            `${err.stack}`
-        );
+        log.info(`Rejecting scheduled promise for ${this._server.domain} (${err.message})`);
         this._processing.defer.reject(err);
     }
     finally {

--- a/lib/irc/Scheduler.js
+++ b/lib/irc/Scheduler.js
@@ -1,60 +1,9 @@
 /*eslint no-invalid-this: 0*/
 "use strict"
-var promiseutil = require("../promiseutil");
 var Promise = require("bluebird");
 var logging = require("../logging");
 var log = logging.get("scheduler");
-
-function ScheduledQueue (server) {
-    this._queue = [];
-    this._processing = null;
-    this._server = server;
-    // Start consuming
-    this._consume();
-}
-
-ScheduledQueue.prototype._consume = Promise.coroutine(function*() {
-    if (this._processing) {
-        return;
-    }
-    this._processing = this._queue.shift();
-    if (!this._processing) {
-        // Nothing in the queue, try to consume after interval
-        setTimeout(this._consume.bind(this), this._server.getReconnectIntervalMs());
-        return;
-    }
-    try {
-        yield Promise.delay(this._processing.addedDelay);
-        let thing = this._procFn(this._processing);
-
-        let result = yield thing;
-        log.info(`Resolving scheduled promise for ${this._server.domain}`);
-        this._processing.defer.resolve(result);
-    }
-    catch (err) {
-        log.info(`Rejecting scheduled promise for ${this._server.domain} (${err.message})`);
-        this._processing.defer.reject(err);
-    }
-    finally {
-        this._processing = null;
-        // Processing done, try to consume after interval
-        setTimeout(this._consume.bind(this), this._server.getReconnectIntervalMs());
-    }
-});
-
-ScheduledQueue.prototype._procFn = function (item) {
-    return item.fn();
-}
-
-ScheduledQueue.prototype.enqueue = function (item) {
-    this._queue.push(item);
-}
-
-ScheduledQueue.prototype.killAll = function() {
-    for (var i = 0; i < this._queue.length; i++) {
-        this._queue[i].reject();
-    }
-}
+var Queue = require("../util/Queue.js");
 
 /**
  * An IRC connection scheduler. Enables ConnectionInstance to reconnect
@@ -68,39 +17,32 @@ var Scheduler = {
     _getQueue: _getQueue,
     _newQueue: _newQueue,
     reschedule: Promise.coroutine(function*(server, addedDelay, retryConnection) {
-        if (server.getReconnectIntervalMs() == 0) {
-            log.info(
-                `Server reconnectIntervalMs = 0, scheduling immediately for ${server.domain}` +
-                (addedDelay > 0 ? ` with ${Math.round(addedDelay)}ms added delay`:'')
-            );
-            yield Promise.delay(addedDelay);
-            try {
-                let thing = retryConnection();
-
-                let result = yield thing;
-                return Promise.resolve(result);
-            }
-            catch (err) {
-                return Promise.reject(err);
-            }
-        }
-        var d = promiseutil.defer();
-
         var q = Scheduler._getQueue(server);
 
-        q.enqueue({defer: d, fn: retryConnection, addedDelay: addedDelay});
+        var promise = q.enqueue(
+            `Scheduler.reschedule ${server.domain}`,
+            {
+                fn: retryConnection,
+                addedDelay: addedDelay
+            }
+        );
+
         log.info(
             `Queued new scheduled promise for ${server.domain}` +
             (addedDelay > 0 ? ` with ${Math.round(addedDelay)}ms added delay`:'')
         );
 
-        return d.promise;
+        return promise;
     }),
     killAll: killAll
 };
 
+function procFn (item) {
+    return Promise.delay(item.addedDelay).then(item.fn);
+}
+
 function _newQueue (server) {
-    Scheduler._queues[server.domain] = new ScheduledQueue(server);
+    Scheduler._queues[server.domain] = new Queue(procFn, server.getReconnectIntervalMs());
     Scheduler._queueServers.push(server.domain);
 
     return Scheduler._queues[server.domain];
@@ -114,7 +56,6 @@ function _getQueue (server) {
     }
     return q;
 }
-
 
 // Reject all queued promises
 function killAll() {

--- a/lib/irc/Scheduler.js
+++ b/lib/irc/Scheduler.js
@@ -50,15 +50,15 @@ var Scheduler = {
 
         return promise;
     }),
-    killAll: killAll
+
+    // Reject all queued promises
+    killAll: function () {
+        let queueKeys = Object.keys(queues);
+        for (var i = 0; i < queueKeys.length; i++) {
+            var q = queues[queueKeys[i]];
+            q.killAll();
+        }
+    }
 };
 
-// Reject all queued promises
-function killAll() {
-    let queueKeys = Object.keys(queues);
-    for (var i = 0; i < queueKeys.length; i++) {
-        var q = queues[queueKeys[i]];
-        q.killAll();
-    }
-}
 module.exports = Scheduler;

--- a/lib/irc/Scheduler.js
+++ b/lib/irc/Scheduler.js
@@ -29,6 +29,9 @@ function getQueue (server) {
 }
 
 var Scheduler = {
+    // Returns a promise that will be resolved when retryConnection returns a promise that
+    //  resolves, in other words, when the connection is made. The promise will reject if the
+    //  promise returned from retryConnection is rejected.
     reschedule: Promise.coroutine(function*(server, addedDelayMs, retryConnection, nick) {
         var q = getQueue(server);
 

--- a/lib/irc/Scheduler.js
+++ b/lib/irc/Scheduler.js
@@ -10,7 +10,8 @@ function ScheduledQueue (server) {
     this._processing = null;
     this._server = server;
 
-    setInterval(this._consume.bind(this), server.getReconnectInterval());
+    // Start consuming
+    this._consume();
 }
 
 ScheduledQueue.prototype._consume = Promise.coroutine(function*() {
@@ -19,9 +20,12 @@ ScheduledQueue.prototype._consume = Promise.coroutine(function*() {
     }
     this._processing = this._queue.shift();
     if (!this._processing) {
+        // Nothing in the queue, try to consume after interval
+        setTimeout(this._consume.bind(this), this._server.getReconnectInterval());
         return;
     }
     try {
+        yield Promise.delay(this._processing.addedDelay);
         let thing = this._procFn(this._processing);
 
         let result = yield thing;
@@ -34,6 +38,8 @@ ScheduledQueue.prototype._consume = Promise.coroutine(function*() {
     }
     finally {
         this._processing = null;
+        // Processing done, try to consume after interval
+        setTimeout(this._consume.bind(this), this._server.getReconnectInterval());
     }
 });
 
@@ -41,7 +47,7 @@ ScheduledQueue.prototype._procFn = function (item) {
     return item.fn();
 }
 
-ScheduledQueue.prototype.enqueue = function(item) {
+ScheduledQueue.prototype.enqueue = function (item) {
     this._queue.push(item);
 }
 
@@ -67,13 +73,11 @@ var Scheduler = {
 
         var q = Scheduler._getQueue(server);
 
+        q.enqueue({defer: d, fn: retryConnection, addedDelay: addedDelay});
         log.info(
             `Queued new scheduled promise for ${server.domain}` +
             (addedDelay > 0 ? ` with ${Math.round(addedDelay)}ms added delay`:'')
         );
-        yield Promise.delay(addedDelay);
-
-        q.enqueue({defer: d, fn: retryConnection});
 
         return d.promise;
     }),

--- a/lib/irc/Scheduler.js
+++ b/lib/irc/Scheduler.js
@@ -75,9 +75,6 @@ var Scheduler = {
 
         q.enqueue({defer: d, fn: retryConnection});
 
-        // Try to consume immediately.
-        // q._consume();
-
         return d.promise;
     }),
     killAll: killAll

--- a/lib/irc/Scheduler.js
+++ b/lib/irc/Scheduler.js
@@ -14,7 +14,7 @@ var Queue = require("../util/Queue.js");
  var queues = {};
 
 function procFn (item) {
-    return Promise.delay(item.addedDelay).then(item.fn);
+    return Promise.delay(item.addedDelayMs).then(item.fn);
 }
 
 function getQueue (server) {
@@ -29,20 +29,20 @@ function getQueue (server) {
 }
 
 var Scheduler = {
-    reschedule: Promise.coroutine(function*(server, addedDelay, retryConnection, nick) {
+    reschedule: Promise.coroutine(function*(server, addedDelayMs, retryConnection, nick) {
         var q = getQueue(server);
 
         var promise = q.enqueue(
             `Scheduler.reschedule ${server.domain} ${nick}`,
             {
                 fn: retryConnection,
-                addedDelay: addedDelay
+                addedDelayMs: addedDelayMs
             }
         );
 
         log.info(
             `Tryed to queue scheduled promise for ${server.domain} ${nick}` +
-            (addedDelay > 0 ? ` with ${Math.round(addedDelay)}ms added delay`:'')
+            (addedDelayMs > 0 ? ` with ${Math.round(addedDelayMs)}ms added delay`:'')
         );
 
         return promise;

--- a/lib/irc/Scheduler.js
+++ b/lib/irc/Scheduler.js
@@ -68,6 +68,22 @@ var Scheduler = {
     _getQueue: _getQueue,
     _newQueue: _newQueue,
     reschedule: Promise.coroutine(function*(server, addedDelay, retryConnection) {
+        if (server.getReconnectIntervalMs() == 0) {
+            log.info(
+                `Server reconnectIntervalMs = 0, scheduling immediately for ${server.domain}` +
+                (addedDelay > 0 ? ` with ${Math.round(addedDelay)}ms added delay`:'')
+            );
+            yield Promise.delay(addedDelay);
+            try {
+                let thing = retryConnection();
+
+                let result = yield thing;
+                return Promise.resolve(result);
+            }
+            catch (err) {
+                return Promise.reject(err);
+            }
+        }
         var d = promiseutil.defer();
 
         var q = Scheduler._getQueue(server);

--- a/lib/irc/Scheduler.js
+++ b/lib/irc/Scheduler.js
@@ -1,0 +1,95 @@
+/*eslint no-invalid-this: 0*/
+"use strict"
+var promiseutil = require("../promiseutil");
+var Promise = require("bluebird");
+var logging = require("../logging");
+var log = logging.get("scheduler");
+
+/**
+ * An IRC connection scheduler. Enables ConnectionInstance to reconnect
+ * in a way that queues reconnection requests and services the FIFO queue at a
+ * rate determined by ircServer.getReconnectInterval().
+ */
+
+var Scheduler = {
+    _queueServers: [],
+    _queues: {},
+    _processing : {},
+    _getQueue: _getQueue,
+    _newQueue: _newQueue,
+    _procFn: _procFn,
+    reschedule: Promise.coroutine(function*(server, addedDelay, retryConnection) {
+        var d = promiseutil.defer();
+
+        var q = Scheduler._getQueue(server);
+
+        log.info(
+            `Queued new scheduled promise for ${server.domain}` +
+            (addedDelay > 0 ? ` with ${Math.round(addedDelay)}ms added delay`:'')
+        );
+        yield Promise.delay(addedDelay);
+
+        q.push({defer: d, fn: retryConnection});
+
+        return d.promise;
+    }),
+    killAll: killAll
+};
+
+function _procFn (item) {
+    return item.fn();
+}
+
+function _newQueue (server) {
+    Scheduler._queues[server.domain] = [];
+    Scheduler._queueServers.push(server.domain);
+
+    let handleQueue = Promise.coroutine(function*() {
+        if (Scheduler._processing[server.domain]) {
+            return;
+        }
+        Scheduler._processing[server.domain] = Scheduler._queues[server.domain].shift();
+        if (!Scheduler._processing[server.domain]) {
+            return;
+        }
+        try {
+            let thing = Scheduler._procFn(Scheduler._processing[server.domain]);
+
+            let result = yield thing;
+            log.info(`Resolving scheduled promise for ${server.domain}`);
+            Scheduler._processing[server.domain].defer.resolve(result);
+        }
+        catch (err) {
+            log.info(`Rejecting scheduled promise for ${server.domain}`);
+            Scheduler._processing[server.domain].defer.reject(err);
+        }
+        finally {
+            Scheduler._processing[server.domain] = null;
+        }
+    });
+
+    setInterval(handleQueue, server.getReconnectInterval());
+
+    return Scheduler._queues[server.domain];
+}
+
+function _getQueue (server) {
+    let q = Scheduler._queues[server.domain];
+
+    if (!q) {
+        q = Scheduler._newQueue(server);
+    }
+    return q;
+}
+
+
+// Reject all queued promises
+function killAll() {
+    for (var i = 0; i < Scheduler._queueServers.length; i++) {
+        var q = Scheduler._queues[Scheduler._queueServers[i]];
+        for (var j = 0; j < q.length; j++) {
+            q[j].reject();
+        }
+    }
+}
+module.exports = Scheduler;

--- a/lib/irc/Scheduler.js
+++ b/lib/irc/Scheduler.js
@@ -11,7 +11,8 @@ var Queue = require("../util/Queue.js");
  * rate determined by ircServer.getReconnectIntervalMs().
  */
 
- var queues = {};
+// Maps domain => Queue
+var queues = {};
 
 function procFn (item) {
     return Promise.delay(item.addedDelayMs).then(item.fn);

--- a/lib/irc/Scheduler.js
+++ b/lib/irc/Scheduler.js
@@ -29,10 +29,10 @@ ScheduledQueue.prototype._consume = Promise.coroutine(function*() {
         this._processing.defer.resolve(result);
     }
     catch (err) {
-        // log.info(
-        //     `Rejecting scheduled promise for ${this._server.domain} (${err.message})\n` +
-        //     `${err.stack}`
-        // );
+        log.info(
+            `Rejecting scheduled promise for ${this._server.domain} (${err.message})\n` +
+            `${err.stack}`
+        );
         this._processing.defer.reject(err);
     }
     finally {
@@ -79,7 +79,7 @@ var Scheduler = {
         q.enqueue({defer: d, fn: retryConnection});
 
         // Try to consume immediately.
-        q._consume();
+        // q._consume();
 
         return d.promise;
     }),

--- a/lib/util/Queue.js
+++ b/lib/util/Queue.js
@@ -10,7 +10,8 @@ var promiseutil = require("../promiseutil");
  * The function should return a Promise which is resolved/rejected when the next item
  * can be taken from the queue.
  * @param {integer} intervalMs Optional. If provided and > 0, this queue will be serviced
- * at an interval of intervalMs. Otherwise, items will be processed imediately.
+ * at an interval of intervalMs. Otherwise, items will be processed as soon as they become
+ * the first item in the queue to be processed.
  */
 function Queue(processFn, intervalMs) {
     this._queue = [];

--- a/lib/util/Queue.js
+++ b/lib/util/Queue.js
@@ -17,6 +17,11 @@ function Queue(processFn, intervalMs) {
     this._queue = [];
     this._processing = null;
     this._procFn = processFn; // critical section Promise<result> = fn(item)
+
+    if (intervalMs !== undefined && !(Number.isInteger(intervalMs) && intervalMs >= 0) ) {
+        throw new Error('intervalMs must be a positive integer');
+    }
+
     this._intervalMs = intervalMs;
 
     if (this._intervalMs) {

--- a/lib/util/Queue.js
+++ b/lib/util/Queue.js
@@ -9,8 +9,8 @@ var promiseutil = require("../promiseutil");
  * is in its critical section. Only 1 item at any one time will be calling this function.
  * The function should return a Promise which is resolved/rejected when the next item
  * can be taken from the queue.
- * @param {integer} intervalMs Optional. If provided, this queue will be serviced
- * at an interval of intervalMs.
+ * @param {integer} intervalMs Optional. If provided and > 0, this queue will be serviced
+ * at an interval of intervalMs. Otherwise, items will be processed imediately.
  */
 function Queue(processFn, intervalMs) {
     this._queue = [];

--- a/lib/util/Queue.js
+++ b/lib/util/Queue.js
@@ -88,4 +88,11 @@ Queue.prototype._consume = Promise.coroutine(function*() {
     }
 });
 
+Queue.prototype.killAll = function() {
+    for (var i = 0; i < this._queue.length; i++) {
+        this._queue[i].defer.reject();
+    }
+}
+
+
 module.exports = Queue;

--- a/lib/util/Queue.js
+++ b/lib/util/Queue.js
@@ -9,11 +9,19 @@ var promiseutil = require("../promiseutil");
  * is in its critical section. Only 1 item at any one time will be calling this function.
  * The function should return a Promise which is resolved/rejected when the next item
  * can be taken from the queue.
+ * @param {integer} intervalMs Optional. If provided, this queue will be serviced
+ * at an interval of intervalMs.
  */
-function Queue(processFn) {
+function Queue(processFn, intervalMs) {
     this._queue = [];
     this._processing = null;
     this._procFn = processFn; // critical section Promise<result> = fn(item)
+    this._intervalMs = intervalMs;
+
+    if (this._intervalMs) {
+        // Start consuming
+        this._consume();
+    }
 }
 
 /**
@@ -37,12 +45,18 @@ Queue.prototype.enqueue = function(id, thing) {
         item: thing,
         defer: defer
     });
-    // always process stuff asyncly, never syncly.
-    process.nextTick(() => {
-        this._consume();
-    });
+    if (!this._intervalMs) {
+        // always process stuff asyncly, never syncly.
+        process.nextTick(() => {
+            this._consume();
+        });
+    }
     return defer.promise;
 };
+
+Queue.prototype._retry = function () {
+    setTimeout(this._consume.bind(this), this._intervalMs);
+}
 
 Queue.prototype._consume = Promise.coroutine(function*() {
     if (this._processing) {
@@ -50,6 +64,9 @@ Queue.prototype._consume = Promise.coroutine(function*() {
     }
     this._processing = this._queue.shift();
     if (!this._processing) {
+        if (this._intervalMs) {
+            this._retry();
+        }
         return;
     }
     try {
@@ -62,8 +79,13 @@ Queue.prototype._consume = Promise.coroutine(function*() {
     }
     finally {
         this._processing = null;
+        if (this._intervalMs) {
+            this._retry();
+        }
     }
-    this._consume();
+    if (!this._intervalMs) {
+        this._consume();
+    }
 });
 
 module.exports = Queue;

--- a/lib/util/Queue.js
+++ b/lib/util/Queue.js
@@ -90,7 +90,7 @@ Queue.prototype._consume = Promise.coroutine(function*() {
 
 Queue.prototype.killAll = function() {
     for (var i = 0; i < this._queue.length; i++) {
-        this._queue[i].defer.reject();
+        this._queue[i].defer.reject(new Error('Queue killed'));
     }
 }
 

--- a/spec/integ/irc-connections.spec.js
+++ b/spec/integ/irc-connections.spec.js
@@ -529,7 +529,6 @@ describe("IRC connections", function() {
         });
     });
 
-
     describe("reconnects", function() {
 
         beforeEach(function() {

--- a/spec/integ/irc-connections.spec.js
+++ b/spec/integ/irc-connections.spec.js
@@ -528,48 +528,4 @@ describe("IRC connections", function() {
             done();
         });
     });
-
-    describe("reconnects", function() {
-
-        beforeEach(function() {
-            jasmine.Clock.useMock();
-        });
-
-        it("should keep reconnecting clients FOREVER!", function(done) {
-            var connectCount = 0;
-
-            env.ircMock._whenClient(roomMapping.server, testUser.nick, "connect",
-            function(client, cb) {
-                connectCount += 1;
-            });
-
-            env.mockAppService._trigger("type:m.room.message", {
-                content: {
-                    body: "Another message",
-                    msgtype: "m.text"
-                },
-                user_id: testUser.id,
-                room_id: roomMapping.roomId,
-                type: "m.room.message"
-            });
-
-            var minutesDone = 0;
-            var minutesToDo = 120;
-
-            function nextCycle() {
-                setImmediate(function() {
-                    if (minutesDone === minutesToDo) {
-                        // expect at the slowest once per 4 min
-                        expect(connectCount).toBeGreaterThan(30);
-                        done();
-                        return;
-                    }
-                    minutesDone += 1;
-                    jasmine.Clock.tick(1000 * 60);
-                    nextCycle();
-                });
-            }
-            nextCycle();
-        });
-    });
 });

--- a/spec/util/test-config.json
+++ b/spec/util/test-config.json
@@ -66,7 +66,7 @@
                     "nickTemplate": "M-$DISPLAY",
                     "maxClients": 30,
                     "idleTimeout": 172800,
-                    "reconnectInterval": 0,
+                    "reconnectIntervalMs": 0,
                     "allowNickChanges": false
                 },
                 "membershipLists": {

--- a/spec/util/test-config.json
+++ b/spec/util/test-config.json
@@ -66,6 +66,7 @@
                     "nickTemplate": "M-$DISPLAY",
                     "maxClients": 30,
                     "idleTimeout": 172800,
+                    "reconnectInterval": 0,
                     "allowNickChanges": false
                 },
                 "membershipLists": {


### PR DESCRIPTION
To prevent the IRC bridge from being k-lined in light of too many reconnections (https://github.com/matrix-org/matrix-appservice-irc/issues/119), reconnections are scheduled on a per-server basis. Only one reconnect can be currently executed per IRC server.