### PR TITLE
Ask IRC chanop for Bridging

### DIFF
--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -286,3 +286,8 @@ ircService:
   provisioning:
     # True to enable the provisioning HTTP endpoint. Default: true.
     enabled: true
+    # Number of seconds to wait before giving up on getting a response from
+    # an IRC operator. If the operator does not respond within the alloted
+    # time period, the provisioning request will fail.
+    # Default: 300 seconds (5 mins)
+    requestTimeoutSeconds: 300

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -286,8 +286,8 @@ ircService:
   provisioning:
     # True to enable the provisioning HTTP endpoint. Default: true.
     enabled: true
-    # Number of seconds to wait before giving up on getting a response from
-    # an IRC operator. If the operator does not respond within the alloted
-    # time period, the provisioning request will fail.
+    # The number of seconds to wait before giving up on getting a response from
+    # an IRC channel operator. If the channel operator does not respond within the
+    # allotted time period, the provisioning request will fail.
     # Default: 300 seconds (5 mins)
     requestTimeoutSeconds: 300

--- a/lib/bridge/IrcBridge.js
+++ b/lib/bridge/IrcBridge.js
@@ -259,7 +259,8 @@ IrcBridge.prototype.run = Promise.coroutine(function*(port) {
     });
 
     let provisioningEnabled = this.config.ircService.provisioning.enabled;
-    this._provisioner = new Provisioner(this, provisioningEnabled);
+    let requestTimeoutSeconds = this.config.ircService.provisioning.requestTimeoutSeconds;
+    this._provisioner = new Provisioner(this, provisioningEnabled, requestTimeoutSeconds);
 
     log.info("Connecting to IRC networks...");
     yield this.connectToIrcNetworks();

--- a/lib/bridge/IrcBridge.js
+++ b/lib/bridge/IrcBridge.js
@@ -105,6 +105,10 @@ IrcBridge.prototype.getClientPool = function() {
     return this._clientPool;
 };
 
+IrcBridge.prototype.getProvisioner = function() {
+    return this._provisioner;
+};
+
 IrcBridge.prototype.createBridgedClient = function(ircClientConfig, matrixUser, isBot) {
     let server = this.ircServers.filter((s) => {
         return s.domain === ircClientConfig.getDomain();

--- a/lib/bridge/IrcHandler.js
+++ b/lib/bridge/IrcHandler.js
@@ -105,7 +105,8 @@ IrcHandler.prototype.onPrivateMessage = Promise.coroutine(function*(req, server,
         return;
     }
     if (bridgedIrcClient.isBot) {
-        req.log.debug("Ignoring PM directed to the bot from %s", fromUser);
+        req.log.debug("Rerouting PM directed to the bot from %s to provisioning", fromUser);
+        this.ircBridge.getProvisioner().handlePm(server, fromUser, action.text);
         return;
     }
 

--- a/lib/config/schema.yml
+++ b/lib/config/schema.yml
@@ -83,6 +83,8 @@ properties:
                 properties:
                     enabled:
                         type: "boolean"
+                    requestTimeoutSeconds:
+                        type: "number"
             servers:
                 type: "object"
                 # all properties must follow the following

--- a/lib/irc/BridgedClient.js
+++ b/lib/irc/BridgedClient.js
@@ -339,7 +339,7 @@ BridgedClient.prototype.whois = function(nick) {
  * @param {string} channel : The channel to call /names on
  */
 BridgedClient.prototype.getOperators = function(channel) {
-    return this.getNicks(channel).then(function (nicksInfo) {
+    return this.getNicks(channel).then(function(nicksInfo) {
         let nicks = nicksInfo.nicks;
 
         nicksInfo.operatorNicks = nicks.filter(

--- a/lib/irc/BridgedClient.js
+++ b/lib/irc/BridgedClient.js
@@ -339,27 +339,39 @@ BridgedClient.prototype.whois = function(nick) {
  * @param {string} channel : The channel to call /names on
  */
 BridgedClient.prototype.getOperators = function(channel) {
+    let modify = function (nicksInfo) {
+        let nicks = nicksInfo.nicks;
+
+        nicksInfo.operatorNicks = nicks.filter(
+            (index) => {
+                return nicksInfo.names[index] === '@'
+            }
+        );
+        return nicksInfo;
+    }
+    return this.getNicks(channel).then(modify);
+};
+
+/**
+ * Get the nicks of the users in a channel
+ * @param {string} channel : The channel to call /names on
+ */
+BridgedClient.prototype.getNicks = function(channel) {
     if (this.disabled) {
         return Promise.resolve({
             server: this.server,
             channel: channel,
-            operatorNicks: []
+            names: {}
         });
     }
     var self = this;
     return new Promise(function(resolve, reject) {
         self.unsafeClient.names(channel, function(channelName, names) {
-
-            let operatorNicks = Object.keys(names).filter(
-                (index) => {
-                    return names[index] === '@'
-                }
-            );
-
             resolve({
                 server: self.server,
                 channel: channelName,
-                operatorNicks: operatorNicks
+                nicks: Object.keys(names),
+                names: names,
             });
         });
     }).timeout(5000);

--- a/lib/irc/BridgedClient.js
+++ b/lib/irc/BridgedClient.js
@@ -333,29 +333,6 @@ BridgedClient.prototype.whois = function(nick) {
     });
 };
 
-/**
- * Get the operator status of an IRC user
- * @param {string} mask : The mask to call /who on
- */
-BridgedClient.prototype.who = function(mask) {
-    if (this.disabled) {
-        return Promise.resolve({
-            server: this.server,
-            mask: mask
-        });
-    }
-    var self = this;
-    return new Promise(function(resolve, reject) {
-        self.unsafeClient.who(mask, function(who) {
-            resolve({
-                server: self.server,
-                mask: mask,
-                who: who
-            });
-        });
-    });
-};
-
 
 /**
  * Get the operators of a channel

--- a/lib/irc/BridgedClient.js
+++ b/lib/irc/BridgedClient.js
@@ -327,6 +327,7 @@ BridgedClient.prototype.whois = function(nick) {
             resolve({
                 server: self.server,
                 nick: nick,
+                isOp: whois.operator !== undefined,
                 msg: `Whois info for '${nick}': ${info}`
             });
         });

--- a/lib/irc/BridgedClient.js
+++ b/lib/irc/BridgedClient.js
@@ -343,8 +343,8 @@ BridgedClient.prototype.getOperators = function(channel) {
         let nicks = nicksInfo.nicks;
 
         nicksInfo.operatorNicks = nicks.filter(
-            (index) => {
-                return nicksInfo.names[index] === '@'
+            (nick) => {
+                return nicksInfo.names[nick] === '@'
             }
         );
         return nicksInfo;

--- a/lib/irc/BridgedClient.js
+++ b/lib/irc/BridgedClient.js
@@ -327,12 +327,67 @@ BridgedClient.prototype.whois = function(nick) {
             resolve({
                 server: self.server,
                 nick: nick,
-                isOp: whois.operator !== undefined,
                 msg: `Whois info for '${nick}': ${info}`
             });
         });
     });
 };
+
+/**
+ * Get the operator status of an IRC user
+ * @param {string} mask : The mask to call /who on
+ */
+BridgedClient.prototype.who = function(mask) {
+    if (this.disabled) {
+        return Promise.resolve({
+            server: this.server,
+            mask: mask
+        });
+    }
+    var self = this;
+    return new Promise(function(resolve, reject) {
+        self.unsafeClient.who(mask, function(who) {
+            resolve({
+                server: self.server,
+                mask: mask,
+                who: who
+            });
+        });
+    });
+};
+
+
+/**
+ * Get the operators of a channel
+ * @param {string} channel : The channel to call /names on
+ */
+BridgedClient.prototype.getOperators = function(channel) {
+    if (this.disabled) {
+        return Promise.resolve({
+            server: this.server,
+            channel: channel,
+            operatorNicks: []
+        });
+    }
+    var self = this;
+    return new Promise(function(resolve, reject) {
+        self.unsafeClient.names(channel, function(channelName, names) {
+
+            let operatorNicks = Object.keys(names).filter(
+                (index) => {
+                    return names[index] === '@'
+                }
+            );
+
+            resolve({
+                server: self.server,
+                channel: channelName,
+                operatorNicks: operatorNicks
+            });
+        });
+    });
+};
+
 
 /**
  * Convert the given nick into a valid nick. This involves length and character

--- a/lib/irc/BridgedClient.js
+++ b/lib/irc/BridgedClient.js
@@ -339,7 +339,7 @@ BridgedClient.prototype.whois = function(nick) {
  * @param {string} channel : The channel to call /names on
  */
 BridgedClient.prototype.getOperators = function(channel) {
-    let modify = function (nicksInfo) {
+    return this.getNicks(channel).then(function (nicksInfo) {
         let nicks = nicksInfo.nicks;
 
         nicksInfo.operatorNicks = nicks.filter(
@@ -348,8 +348,7 @@ BridgedClient.prototype.getOperators = function(channel) {
             }
         );
         return nicksInfo;
-    }
-    return this.getNicks(channel).then(modify);
+    });
 };
 
 /**

--- a/lib/irc/BridgedClient.js
+++ b/lib/irc/BridgedClient.js
@@ -362,7 +362,7 @@ BridgedClient.prototype.getOperators = function(channel) {
                 operatorNicks: operatorNicks
             });
         });
-    });
+    }).timeout(5000);
 };
 
 

--- a/lib/irc/BridgedClient.js
+++ b/lib/irc/BridgedClient.js
@@ -367,6 +367,8 @@ BridgedClient.prototype.getNicks = function(channel) {
     var self = this;
     return new Promise(function(resolve, reject) {
         self.unsafeClient.names(channel, function(channelName, names) {
+            // names maps nicks to chan op status, where '@' indicates chan op
+            // names = {'nick1' : '', 'nick2' : '@', ...}
             resolve({
                 server: self.server,
                 channel: channelName,

--- a/lib/irc/IrcEventBroker.js
+++ b/lib/irc/IrcEventBroker.js
@@ -266,43 +266,39 @@ IrcEventBroker.prototype.addHooks = function(client, connInst) {
 
     // === Attach client listeners ===
     // We want to listen for PMs for individual clients regardless of whether the
-    // bot is enabled or disabled, as only they will receive the event. We don't
-    // currently handle any PMs directed at the bot itself (e.g. for admin stuff)
-    // but we could in the future (abusing the fact that the BridgedClient
-    // connection is still made to the IRCd)
-    if (!client.isBot) {
+    // bot is enabled or disabled, as only they will receive the event. We handle
+    // PMs to the bot now for provisioning.
         // listen for PMs for clients. If you listen for rooms, you'll get
         // duplicates since the bot will also invoke the callback fn!
-        connInst.addListener("message", function(from, to, text) {
-            if (to.indexOf("#") === 0) { return; }
+    connInst.addListener("message", function(from, to, text) {
+        if (to.indexOf("#") === 0) { return; }
+        var req = createRequest();
+        complete(req, ircHandler.onPrivateMessage(
+            req,
+            server, createUser(from), createUser(to),
+            new IrcAction("message", text)
+        ));
+    });
+    connInst.addListener("notice", function(from, to, text) {
+        if (!from || to.indexOf("#") === 0) { return; }
+        var req = createRequest();
+        complete(req, ircHandler.onPrivateMessage(
+            req,
+            server, createUser(from), createUser(to),
+            new IrcAction("notice", text)
+        ));
+    });
+    connInst.addListener("ctcp-privmsg", function(from, to, text) {
+        if (to.indexOf("#") === 0) { return; }
+        if (text.indexOf("ACTION ") === 0) {
             var req = createRequest();
             complete(req, ircHandler.onPrivateMessage(
                 req,
                 server, createUser(from), createUser(to),
-                new IrcAction("message", text)
+                new IrcAction("emote", text.substring("ACTION ".length))
             ));
-        });
-        connInst.addListener("notice", function(from, to, text) {
-            if (!from || to.indexOf("#") === 0) { return; }
-            var req = createRequest();
-            complete(req, ircHandler.onPrivateMessage(
-                req,
-                server, createUser(from), createUser(to),
-                new IrcAction("notice", text)
-            ));
-        });
-        connInst.addListener("ctcp-privmsg", function(from, to, text) {
-            if (to.indexOf("#") === 0) { return; }
-            if (text.indexOf("ACTION ") === 0) {
-                var req = createRequest();
-                complete(req, ircHandler.onPrivateMessage(
-                    req,
-                    server, createUser(from), createUser(to),
-                    new IrcAction("emote", text.substring("ACTION ".length))
-                ));
-            }
-        });
-    }
+        }
+    });
 
     // Listen for other events
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -41,7 +41,8 @@ module.exports.defaultConfig = function() {
             statsd: {},
             debugApi: {},
             provisioning: {
-                enabled:true
+                enabled: true,
+                requestTimeoutSeconds: 60 * 5
             }
         }
     };

--- a/lib/provisioning/Provisioner.js
+++ b/lib/provisioning/Provisioner.js
@@ -56,7 +56,7 @@ function Provisioner(ircBridge, enabled, requestTimeoutSeconds) {
             "remote_room_channel",
             "remote_room_server",
             "op_nick",
-            // "user_id"
+            "user_id"
         ]
     });
     this._unlinkValidator = new ConfigValidator({
@@ -337,7 +337,7 @@ Provisioner.prototype.requestLink = Promise.coroutine(function*(options) {
     let roomId = options.matrix_room_id;
     let opNick = options.op_nick;
     let key = options.key || undefined; // Optional key
-    let userId = options.user_id || "@lukeA:localhost:8480";
+    let userId = options.user_id;
     let mappingLogId = `${roomId} <---> ${ircDomain}/${ircChannel}`;
 
     // Try to find the domain requested for linking

--- a/lib/provisioning/Provisioner.js
+++ b/lib/provisioning/Provisioner.js
@@ -30,7 +30,7 @@ var validationProperties = {
     "key" : {
         "type": "string"
     },
-    "bridger_id" : {
+    "user_id" : {
         "type": "string"
     }
 };
@@ -42,7 +42,7 @@ function Provisioner(ircBridge, enabled) {
     // {
     //   $domain: {
     //     $nick: {
-    //        bridgerId : string
+    //        userId : string
     //        defer: Deferred
     //     }
     //   }
@@ -55,7 +55,7 @@ function Provisioner(ircBridge, enabled) {
             "remote_room_channel",
             "remote_room_server",
             "op_nick",
-            "bridger_id"
+            "user_id"
         ]
     });
     this._unlinkValidator = new ConfigValidator({
@@ -159,11 +159,11 @@ Provisioner.prototype.isProvisionRequest = function(req) {
 };
 
 Provisioner.prototype._updateBridgingState = Promise.coroutine(
-    function*(roomId, bridgerId, status, skey) {
+    function*(roomId, userId, status, skey) {
         let intent = this._ircBridge.getAppServiceBridge().getIntent();
         try {
             yield intent.client.sendStateEvent(roomId, 'm.room.bridging', {
-                bridger_id: bridgerId,
+                user_id: userId,
                 status: status // pending, success, failure
             }, skey);
         }
@@ -175,12 +175,12 @@ Provisioner.prototype._updateBridgingState = Promise.coroutine(
 );
 
 Provisioner.prototype._authoriseProvisioning = Promise.coroutine(
-    function*(server, bridgerId, ircChannel, roomId, opNick, key) {
+    function*(server, userId, ircChannel, roomId, opNick, key) {
         let ircDomain = server.domain;
 
         let existing = this._getRequest(server, opNick);
         if (existing) {
-            let from = existing.bridgerId;
+            let from = existing.userId;
             throw new Error(`Bridging request already sent to `+
                             `${opNick} on ${server.domain} from ${from}`);
         }
@@ -195,7 +195,7 @@ Provisioner.prototype._authoriseProvisioning = Promise.coroutine(
             throw new Error('Power levels not available');
         }
 
-        let actualPower = powerState.users[bridgerId] || powerState.users_default || 0;
+        let actualPower = powerState.users[userId] || powerState.users_default || 0;
         let requiredPower = powerState.events["m.room.power_levels"];
         requiredPower = requiredPower || powerState.state_default || 50;
 
@@ -204,7 +204,6 @@ Provisioner.prototype._authoriseProvisioning = Promise.coroutine(
         }
 
         // (IRC) Check that op's nick is actually op
-        // TODO: Do something with the key here
         log.info(`Check that op's nick is actually op`);
         let botClient = yield this._ircBridge.getBotClient(server);
         yield botClient.joinChannel(ircChannel, key);
@@ -221,7 +220,7 @@ Provisioner.prototype._authoriseProvisioning = Promise.coroutine(
         let skey = `irc://${ircDomain}/${ircChannel}`;
 
         // Send pending m.room.bridging
-        yield this._updateBridgingState(roomId, bridgerId, 'pending', skey);
+        yield this._updateBridgingState(roomId, userId, 'pending', skey);
 
         // (IRC) Ask operator for authorisation
         // Time that operator has to respond before giving up
@@ -230,22 +229,22 @@ Provisioner.prototype._authoriseProvisioning = Promise.coroutine(
         log.info(`Contacting operator`);
         this._contactOperator(
             botClient, server, opNick, ircChannel,
-            roomId, bridgerId, skey, timeoutSeconds);
+            roomId, userId, skey, timeoutSeconds);
     }
 );
 
 Provisioner.prototype._contactOperator = Promise.coroutine(
-    function*(botClient, server, opNick, ircChannel, roomId, bridgerId, skey, timeoutSeconds) {
+    function*(botClient, server, opNick, ircChannel, roomId, userId, skey, timeoutSeconds) {
         let d = promiseutil.defer();
 
         // Send PM to operator
         let authRequestAction = new IrcAction("message",
-            `${bridgerId} has requested to bridge ${roomId} with ${ircChannel} on this IRC ` +
+            `${userId} has requested to bridge ${roomId} with ${ircChannel} on this IRC ` +
             `network. Respond with 'yes' or 'y' to allow, or simply ignore this message to ` +
             `dissallow. You have ${timeoutSeconds} seconds from when this message was sent.`);
         let pmRoom = new IrcRoom(server, opNick);
 
-        this._setRequest(server, opNick, {bridgerId: bridgerId, defer: d});
+        this._setRequest(server, opNick, {userId: userId, defer: d});
 
         this._ircBridge.sendIrcAction(pmRoom, botClient, authRequestAction);
         try {
@@ -254,13 +253,13 @@ Provisioner.prototype._contactOperator = Promise.coroutine(
         }
         catch (err) {
             log.info(`Operator ${opNick} did not respond (${err.message})`);
-            this._updateBridgingState(roomId, bridgerId, 'failure', skey);
+            this._updateBridgingState(roomId, userId, 'failure', skey);
             this._removeRequest(server, opNick);
             return Promise.reject(err);
         }
 
         yield this._dolink(server, ircChannel, roomId);
-        yield this._updateBridgingState(roomId, bridgerId, 'success', skey);
+        yield this._updateBridgingState(roomId, userId, 'success', skey);
     }
 );
 
@@ -311,7 +310,7 @@ Provisioner.prototype.requestLink = Promise.coroutine(function*(options) {
     let roomId = options.matrix_room_id;
     let opNick = options.op_nick;
     let key = options.key || undefined; // Optional key
-    let bridgerId = options.bridger_id;
+    let userId = options.user_id;
     let mappingLogId = `${roomId} <---> ${ircDomain}/${ircChannel}`;
 
     // Try to find the domain requested for linking
@@ -330,7 +329,7 @@ Provisioner.prototype.requestLink = Promise.coroutine(function*(options) {
     if (!entry) {
         // Ask OP for provisioning authentication
         try {
-            yield this._authoriseProvisioning(server, bridgerId, ircChannel, roomId, opNick, key);
+            yield this._authoriseProvisioning(server, userId, ircChannel, roomId, opNick, key);
         }
         catch (err) {
             console.error(err.stack);

--- a/lib/provisioning/Provisioner.js
+++ b/lib/provisioning/Provisioner.js
@@ -4,7 +4,6 @@ var Promise = require("bluebird");
 var IrcRoom = require("../models/IrcRoom");
 var IrcAction = require("../models/IrcAction");
 var MatrixRoom = require("matrix-appservice-bridge").MatrixRoom;
-var StateLookup = require('matrix-appservice-bridge').StateLookup;
 
 var log = require("../logging").get("Provisioner");
 var promiseutil = require("../promiseutil.js");
@@ -159,11 +158,11 @@ Provisioner.prototype._validateAll = function(parameters, parameterNames) {
 };
 
 Provisioner.prototype._updateBridgingState = Promise.coroutine(
-    function*(roomId, bridger, status, skey) {
+    function*(roomId, bridger_id, status, skey) {
         let intent = this._ircBridge.getAppServiceBridge().getIntent();
         try {
             yield intent.client.sendStateEvent(roomId, 'm.room.bridging', {
-                bridger: bridger,
+                bridger_id: bridger_id,
                 status: status // pending, success, failure
             }, skey);
         }
@@ -174,25 +173,20 @@ Provisioner.prototype._updateBridgingState = Promise.coroutine(
 );
 
 Provisioner.prototype._authoriseProvisioning = Promise.coroutine(
-    function*(server, bridger, ircChannel, roomId, opNick, key) {
+    function*(server, bridger_id, ircChannel, roomId, opNick, key) {
         let ircDomain = server.domain;
 
         // (Matrix) Check power level of user
         let matrixClient = this._ircBridge.getAppServiceBridge().getClientFactory().getClientAs();
-        var lookup = new StateLookup({
-            client : matrixClient,
-            eventTypes: ['m.room.power_levels']
-        });
 
-        yield lookup.trackRoom(roomId);
+        let powerState = yield matrixClient.getStateEvent(roomId, 'm.room.power_levels');
 
-        let powerState = lookup.getState(
-            roomId,
-            'm.room.power_levels'
-        )[0];
+        if (!powerState) {
+            throw new Error('Power levels not available');
+        }
 
-        let actualPower = powerState.content.users[bridger];
-        let requiredPower = powerState.content.events["m.room.power_levels"];
+        let actualPower = powerState.users[bridger_id];
+        let requiredPower = powerState.events["m.room.power_levels"];
 
         if (actualPower < requiredPower) {
             throw new Error('User does not possess high enough power level');
@@ -210,7 +204,7 @@ Provisioner.prototype._authoriseProvisioning = Promise.coroutine(
         let skey = `${ircDomain}${ircChannel}`;
 
         // Send pending m.room.bridging
-        this._updateBridgingState(roomId, bridger, 'pending', skey);
+        this._updateBridgingState(roomId, bridger_id, 'pending', skey);
 
         // (IRC) Ask operator for authorisation
         // Time that operator has to respond before giving up
@@ -219,7 +213,7 @@ Provisioner.prototype._authoriseProvisioning = Promise.coroutine(
         // Send PM to Bob
         let botClient = yield this._ircBridge.getBotClient(server);
         let authRequestAction = new IrcAction("message",
-            `${bridger} has requested to bridge ${roomId} with ${ircChannel} on this IRC ` +
+            `${bridger_id} has requested to bridge ${roomId} with ${ircChannel} on this IRC ` +
             `network. Respond with 'yes' to allow, or simply ignore this message to ` +
             `dissallow. You have ${timeout} seconds from when this message was sent.`);
         let pmRoom = yield botClient.joinChannel(opNick, key);
@@ -234,12 +228,12 @@ Provisioner.prototype._authoriseProvisioning = Promise.coroutine(
                 return this._dolink(server, ircChannel, roomId)
             }, (err) => {
                 log.info(`Operator ${opNick} did not respond (${err.message})`);
-                this._updateBridgingState(roomId, bridger, 'failure', skey);
+                this._updateBridgingState(roomId, bridger_id, 'failure', skey);
                 return Promise.reject(err);
             }
         ).then(
             () => {
-                this._updateBridgingState(roomId, bridger, 'success', skey);
+                this._updateBridgingState(roomId, bridger_id, 'success', skey);
             }
         );
 
@@ -304,7 +298,7 @@ Provisioner.prototype.requestLink = Promise.coroutine(function*(options) {
     let roomId = options.matrix_room_id;
     let opNick = options.op_nick;
     let key = options.key || undefined; // Optional key
-    let bridger = options.bridger;
+    let bridger_id = options.bridger_id;
     let mappingLogId = `${roomId} <---> ${ircDomain}/${ircChannel}`;
 
     // Try to find the domain requested for linking
@@ -322,7 +316,7 @@ Provisioner.prototype.requestLink = Promise.coroutine(function*(options) {
     let entry = yield this._ircBridge.getStore().getRoom(roomId, ircDomain, ircChannel);
     if (!entry) {
         // Ask OP for provisioning authentication
-        yield this._authoriseProvisioning(server, bridger, ircChannel, roomId, opNick, key);
+        yield this._authoriseProvisioning(server, bridger_id, ircChannel, roomId, opNick, key);
     }
     else {
         throw new Error(`Room mapping already exists (${mappingLogId},` +

--- a/lib/provisioning/Provisioner.js
+++ b/lib/provisioning/Provisioner.js
@@ -28,7 +28,10 @@ function Provisioner(ircBridge, enabled) {
     if (!enabled) {
         as.app.use(function(req, res, next) {
             if (self.isProvisionRequest(req)) {
-                res.status(500);
+                res.header("Access-Control-Allow-Origin", "*");
+                res.header("Access-Control-Allow-Headers",
+                    "Origin, X-Requested-With, Content-Type, Accept");
+                res.status(200);
                 res.json({error : 'Provisioning is not enabled.'});
             }
             else {

--- a/lib/provisioning/Provisioner.js
+++ b/lib/provisioning/Provisioner.js
@@ -2,13 +2,17 @@
 "use strict";
 var Promise = require("bluebird");
 var IrcRoom = require("../models/IrcRoom");
+var IrcAction = require("../models/IrcAction");
 var MatrixRoom = require("matrix-appservice-bridge").MatrixRoom;
+var StateLookup = require('matrix-appservice-bridge').StateLookup;
 
 var log = require("../logging").get("Provisioner");
+var promiseutil = require("../promiseutil.js");
 
 function Provisioner(ircBridge, enabled) {
     this._ircBridge = ircBridge;
     this._enabled = enabled;
+    this._expectations = [];
 
     if (enabled) {
         log.info("Starting provisioning...");
@@ -52,7 +56,7 @@ function Provisioner(ircBridge, enabled) {
 
     as.app.post("/_matrix/provision/link", Promise.coroutine(function*(req, res) {
         try {
-            yield self.link(req.body);
+            yield self.requestLink(req.body);
             res.json({});
         }
         catch (err) {
@@ -101,6 +105,10 @@ var parameterValidation = {
         {regex : /^([#+&]|(![A-Z0-9]{5}))[^\s:,]+$/, example : '#roomname'},
     remote_room_server :
         {regex : /^[a-z\.0-9:-]+$/, example : 'example.com or localhost'},
+    op_nick :
+        {regex : /^.+$/, example : 'bob'},
+    key :
+        {regex : /^.+$/, example : '1234567890', optional : true}
 };
 
 Provisioner.prototype._validate = function(actual, parameterName) {
@@ -113,6 +121,9 @@ Provisioner.prototype._validate = function(actual, parameterName) {
     }
 
     if (!actual) {
+        if (valid.optional) {
+            return;
+        }
         throw new Error(
             `${parameterName} not provided (like '${valid.example}').`
         );
@@ -132,23 +143,169 @@ Provisioner.prototype._validate = function(actual, parameterName) {
 };
 
 // Validate parameters for use in linking/unlinking
-Provisioner.prototype._validateAll = function(parameters) {
-    let parameterNames = ['matrix_room_id', 'remote_room_channel', 'remote_room_server'];
+Provisioner.prototype._validateAll = function(parameters, parameterNames) {
+    if (!parameterNames) {
+        parameterNames = [
+            'matrix_room_id',
+            'remote_room_channel',
+            'remote_room_server',
+            'op_nick',
+            'key'
+        ];
+    }
     for (var i = 0; i < parameterNames.length; i++) {
         this._validate(parameters[parameterNames[i]], parameterNames[i]);
     }
 };
 
+Provisioner.prototype._updateBridgingState = Promise.coroutine(
+    function*(roomId, bridger, status, skey) {
+        let intent = this._ircBridge.getAppServiceBridge().getIntent();
+        try {
+            yield intent.client.sendStateEvent(roomId, 'm.room.bridging', {
+                bridger: bridger,
+                status: status // pending, success, failure
+            }, skey);
+        }
+        catch (err) {
+            throw new Error(`Could not update m.room.bridging state in this room ($err.message)`);
+        }
+    }
+);
+
+Provisioner.prototype._authoriseProvisioning = Promise.coroutine(
+    function*(server, bridger, ircChannel, roomId, opNick, key) {
+        let ircDomain = server.domain;
+
+        // (Matrix) Check power level of user
+        let matrixClient = this._ircBridge.getAppServiceBridge().getClientFactory().getClientAs();
+        var lookup = new StateLookup({
+            client : matrixClient,
+            eventTypes: ['m.room.power_levels']
+        });
+
+        yield lookup.trackRoom(roomId);
+
+        let powerState = lookup.getState(
+            roomId,
+            'm.room.power_levels'
+        )[0];
+
+        let actualPower = powerState.content.users[bridger];
+        let requiredPower = powerState.content.events["m.room.power_levels"];
+
+        if (actualPower < requiredPower) {
+            throw new Error('User does not possess high enough power level');
+        }
+
+        // (IRC) Check that op's nick is actually op
+        let info = yield this._ircBridge.checkNickExists(server, opNick);
+
+        if (!info.isOp) {
+            throw new Error('Provided user is not an Op');
+        }
+
+        // (Matrix) update room state
+        // State key for m.room.bridging
+        let skey = `${ircDomain}${ircChannel}`;
+
+        // Send pending m.room.bridging
+        this._updateBridgingState(roomId, bridger, 'pending', skey);
+
+        // (IRC) Ask operator for authorisation
+        // Time that operator has to respond before giving up
+        let timeout = 10;
+
+        // Send PM to Bob
+        let botClient = yield this._ircBridge.getBotClient(server);
+        let authRequestAction = new IrcAction("message",
+            `${bridger} has requested to bridge ${roomId} with ${ircChannel} on this IRC ` +
+            `network. Respond with 'yes' to allow, or simply ignore this message to ` +
+            `dissallow. You have ${timeout} seconds from when this message was sent.`);
+        let pmRoom = yield botClient.joinChannel(opNick, key);
+
+        // Promise to receive PM from Bob or timeout
+        let opReplyPromise = this.expectPm(server, opNick, timeout);
+
+        this._ircBridge.sendIrcAction(pmRoom, botClient, authRequestAction);
+
+        opReplyPromise.then(
+            () => {
+                return this._dolink(server, ircChannel, roomId)
+            }, (err) => {
+                log.info(`Operator ${opNick} did not respond (${err.message})`);
+                this._updateBridgingState(roomId, bridger, 'failure', skey);
+                return Promise.reject(err);
+            }
+        ).then(
+            () => {
+                this._updateBridgingState(roomId, bridger, 'success', skey);
+            }
+        );
+
+        return Promise.resolve();
+    }
+);
+
+Provisioner.prototype._removeExpectation = function (expectation) {
+    expectation.defer = null;
+    this._expectations = this._expectations.filter((exp) => {
+        return exp.defer !== null;
+    });
+}
+
+Provisioner.prototype.expectPm = function(server, fromNick, timeout) {
+    var d = promiseutil.defer();
+    let existingExpectation = this._expectations.find(
+        (expectation) => {
+            return expectation.server.domain === server.domain &&
+                   expectation.fromNick === fromNick;
+        }
+    );
+
+    if (existingExpectation) {
+        throw new Error(`Bridging request already sent to this op`+
+                        ` (${fromNick} on ${server.domain})`);
+    }
+
+    let expectation = {server : server, fromNick : fromNick, defer: d};
+    this._expectations.push(expectation);
+
+    return d.promise.timeout(timeout * 1000).then(
+        () => {this._removeExpectation(expectation)},
+        (err) => {this._removeExpectation(expectation); return Promise.reject(err);}
+    );
+}
+
+Provisioner.prototype.handlePm = function(server, fromUser, text) {
+    if (text.trim() !== 'yes') {
+        return;
+    }
+    let foundExpectation = this._expectations.find(
+        (expectation) => {
+            return expectation.server.domain === server.domain &&
+                   expectation.fromNick === fromUser.nick;
+        }
+    );
+    if (foundExpectation) {
+        log.info(`${fromUser.nick} has authorised a new provisioning`);
+        foundExpectation.defer.resolve();
+        return;
+    }
+    log.warn(`Provisioner was not expecting PM from ${fromUser.nick} on ${server.domain}`);
+}
+
 // Link an IRC channel to a matrix room ID
-Provisioner.prototype.link = Promise.coroutine(function*(options) {
+Provisioner.prototype.requestLink = Promise.coroutine(function*(options) {
     this._validateAll(options);
 
     let ircDomain = options.remote_room_server;
     let ircChannel = options.remote_room_channel;
     let roomId = options.matrix_room_id;
+    let opNick = options.op_nick;
+    let key = options.key || undefined; // Optional key
+    let bridger = options.bridger;
     let mappingLogId = `${roomId} <---> ${ircDomain}/${ircChannel}`;
-
-    log.info(`Provisioning link for room ${mappingLogId}`);
 
     // Try to find the domain requested for linking
     //TODO: ircDomain might include protocol, i.e. irc://irc.freenode.net
@@ -162,13 +319,10 @@ Provisioner.prototype.link = Promise.coroutine(function*(options) {
         throw new Error(`Server is configured to exclude given channel ('${ircChannel}')`);
     }
 
-    // Create rooms for the link
-    let ircRoom = new IrcRoom(server, ircChannel);
-    let mxRoom = new MatrixRoom(roomId);
-
     let entry = yield this._ircBridge.getStore().getRoom(roomId, ircDomain, ircChannel);
     if (!entry) {
-        yield this._ircBridge.getStore().storeRoom(ircRoom, mxRoom, 'provision');
+        // Ask OP for provisioning authentication
+        yield this._authoriseProvisioning(server, bridger, ircChannel, roomId, opNick, key);
     }
     else {
         throw new Error(`Room mapping already exists (${mappingLogId},` +
@@ -176,9 +330,34 @@ Provisioner.prototype.link = Promise.coroutine(function*(options) {
     }
 });
 
+Provisioner.prototype._dolink = Promise.coroutine(
+    function*(server, ircChannel, roomId) {
+        let ircDomain = server.domain;
+        let mappingLogId = `${roomId} <---> ${ircDomain}/${ircChannel}`;
+        log.info(`Provisioning link for room ${mappingLogId}`);
+
+        // Create rooms for the link
+        let ircRoom = new IrcRoom(server, ircChannel);
+        let mxRoom = new MatrixRoom(roomId);
+
+        let entry = yield this._ircBridge.getStore().getRoom(roomId, ircDomain, ircChannel);
+        if (!entry) {
+            yield this._ircBridge.getStore().storeRoom(ircRoom, mxRoom, 'provision');
+        }
+        else {
+            throw new Error(`Room mapping already exists (${mappingLogId},` +
+                            `origin = ${entry.data.origin})`);
+        }
+    }
+);
+
 // Unlink an IRC channel from a matrix room ID
 Provisioner.prototype.unlink = Promise.coroutine(function*(options) {
-    this._validateAll(options);
+    this._validateAll(options, [
+        'matrix_room_id',
+        'remote_room_channel',
+        'remote_room_server'
+    ]);
 
     let ircDomain = options.remote_room_server;
     let ircChannel = options.remote_room_channel;

--- a/lib/provisioning/Provisioner.js
+++ b/lib/provisioning/Provisioner.js
@@ -262,7 +262,7 @@ Provisioner.prototype._authoriseProvisioning = Promise.coroutine(
 
         // Deliberately not yielding on this so that 200 OK is returned
         log.info(`Contacting operator`);
-        this._contactOperator(
+        this._createAuthorisedLink(
             botClient, server, opNick, ircChannel,
             roomId, userId, skey, timeoutSeconds);
     }
@@ -270,7 +270,7 @@ Provisioner.prototype._authoriseProvisioning = Promise.coroutine(
 
 // Contact an operator, asking for authorisation for a mapping, and if they reply
 //  'yes' or 'y', create the mapping.
-Provisioner.prototype._contactOperator = Promise.coroutine(
+Provisioner.prototype._createAuthorisedLink = Promise.coroutine(
     function*(botClient, server, opNick, ircChannel, roomId, userId, skey, timeoutSeconds) {
         let d = promiseutil.defer();
 

--- a/lib/provisioning/Provisioner.js
+++ b/lib/provisioning/Provisioner.js
@@ -271,7 +271,7 @@ Provisioner.prototype._contactOperator = Promise.coroutine(
             return;
         }
         try {
-            yield this._dolink(server, ircChannel, roomId);
+            yield this._doLink(server, ircChannel, roomId);
         }
         catch (err) {
             log.info(`Failed to create link following authorisation (${err.message})`);
@@ -362,7 +362,7 @@ Provisioner.prototype.requestLink = Promise.coroutine(function*(options) {
     }
 });
 
-Provisioner.prototype._dolink = Promise.coroutine(
+Provisioner.prototype._doLink = Promise.coroutine(
     function*(server, ircChannel, roomId) {
         let ircDomain = server.domain;
         let mappingLogId = `${roomId} <---> ${ircDomain}/${ircChannel}`;

--- a/lib/provisioning/Provisioner.js
+++ b/lib/provisioning/Provisioner.js
@@ -278,7 +278,7 @@ Provisioner.prototype._createAuthorisedLink = Promise.coroutine(
         let authRequestAction = new IrcAction("message",
             `${userId} has requested to bridge ${roomId} with ${ircChannel} on this IRC ` +
             `network. Respond with 'yes' or 'y' to allow, or simply ignore this message to ` +
-            `dissallow. You have ${timeoutSeconds} seconds from when this message was sent.`);
+            `disallow. You have ${timeoutSeconds} seconds from when this message was sent.`);
         let pmRoom = new IrcRoom(server, opNick);
 
         this._setRequest(server, opNick, {userId: userId, defer: d});

--- a/lib/provisioning/Provisioner.js
+++ b/lib/provisioning/Provisioner.js
@@ -308,7 +308,9 @@ Provisioner.prototype._createAuthorisedLink = Promise.coroutine(
 );
 
 Provisioner.prototype._removeRequest = function (server, opNick) {
-    delete this._pendingRequests[server.domain][opNick];
+    if (this._pendingRequests[server.domain]) {
+        delete this._pendingRequests[server.domain][opNick];
+    }
 }
 
 Provisioner.prototype._getRequest = function (server, opNick) {

--- a/lib/provisioning/Provisioner.js
+++ b/lib/provisioning/Provisioner.js
@@ -35,9 +35,10 @@ var validationProperties = {
     }
 };
 
-function Provisioner(ircBridge, enabled) {
+function Provisioner(ircBridge, enabled, requestTimeoutSeconds) {
     this._ircBridge = ircBridge;
     this._enabled = enabled;
+    this._requestTimeoutSeconds = requestTimeoutSeconds;
     this._pendingRequests = {};
     // {
     //   $domain: {
@@ -242,7 +243,7 @@ Provisioner.prototype._authoriseProvisioning = Promise.coroutine(
 
         // (IRC) Ask operator for authorisation
         // Time that operator has to respond before giving up
-        let timeoutSeconds = 1;
+        let timeoutSeconds = this._requestTimeoutSeconds;
 
         // Deliberately not yielding on this so that 200 OK is returned
         log.info(`Contacting operator`);

--- a/lib/provisioning/Provisioner.js
+++ b/lib/provisioning/Provisioner.js
@@ -175,6 +175,13 @@ Provisioner.prototype._updateBridgingState = Promise.coroutine(
     }
 );
 
+// Do a series of checks before contacting an operator for permission to create
+//  a provisioned mapping. If the operator responds with 'yes' or 'y', the mapping
+//  is created.
+// The checks done are the following:
+//  - (Matrix) Check power level of user is high enough
+//  - (IRC) Check that op's nick is actually a channel op
+//  - (Matrix) update room state m.room.brdiging
 Provisioner.prototype._authoriseProvisioning = Promise.coroutine(
     function*(server, userId, ircChannel, roomId, opNick, key) {
         let ircDomain = server.domain;
@@ -261,6 +268,8 @@ Provisioner.prototype._authoriseProvisioning = Promise.coroutine(
     }
 );
 
+// Contact an operator, asking for authorisation for a mapping, and if they reply
+//  'yes' or 'y', create the mapping.
 Provisioner.prototype._contactOperator = Promise.coroutine(
     function*(botClient, server, opNick, ircChannel, roomId, userId, skey, timeoutSeconds) {
         let d = promiseutil.defer();

--- a/lib/provisioning/Provisioner.js
+++ b/lib/provisioning/Provisioner.js
@@ -194,7 +194,7 @@ Provisioner.prototype._authoriseProvisioning = Promise.coroutine(
         }
 
         // (Matrix) Check power level of user
-        log.info(`Check power level of user`);
+        log.info(`Check power level of ${userId} in ${roomId}`);
         let matrixClient = this._ircBridge.getAppServiceBridge().getClientFactory().getClientAs();
 
         let powerState = null;
@@ -236,13 +236,13 @@ Provisioner.prototype._authoriseProvisioning = Promise.coroutine(
         log.info(`Bot joined channel ${ircChannel}`);
         let info = yield botClient.getOperators(ircChannel);
 
-        if (info.nicks.indexOf(opNick) == -1) {
+        if (info.nicks.indexOf(opNick) === -1) {
             let knownOps = info.operatorNicks.join(', ');
             throw new Error(`Provided user is not in channel ${ircChannel}. ` +
                             `Known ops in this channel: ${knownOps}`);
         }
 
-        if (info.operatorNicks.indexOf(opNick) == -1) {
+        if (info.operatorNicks.indexOf(opNick) === -1) {
             let knownOps = info.operatorNicks.join(', ');
             throw new Error(`Provided user is not an op of ${ircChannel}. ` +
                             `Known ops in this channel: ${knownOps}`);

--- a/lib/provisioning/Provisioner.js
+++ b/lib/provisioning/Provisioner.js
@@ -4,14 +4,75 @@ var Promise = require("bluebird");
 var IrcRoom = require("../models/IrcRoom");
 var IrcAction = require("../models/IrcAction");
 var MatrixRoom = require("matrix-appservice-bridge").MatrixRoom;
+var ConfigValidator = require("matrix-appservice-bridge").ConfigValidator;
 
 var log = require("../logging").get("Provisioner");
 var promiseutil = require("../promiseutil.js");
 
+var matrixRoomIdValidation = {
+    "type": "string",
+    "pattern": "^!.*:.*$"
+};
+
+var validationProperties = {
+    "matrix_room_id" : matrixRoomIdValidation,
+    "remote_room_channel" : {
+        "type": "string",
+        "pattern": "^([#+&]|(![A-Z0-9]{5}))[^\\s:,]+$"
+    },
+    "remote_room_server" : {
+        "type": "string",
+        "pattern": "^[a-z\\.0-9:-]+$"
+    },
+    "op_nick" : {
+        "type": "string"
+    },
+    "key" : {
+        "type": "string"
+    },
+    "bridger_id" : {
+        "type": "string"
+    }
+};
+
 function Provisioner(ircBridge, enabled) {
     this._ircBridge = ircBridge;
     this._enabled = enabled;
-    this._expectations = [];
+    this._pendingRequests = {};
+    // {
+    //   $domain: {
+    //     $nick: {
+    //        bridgerId : string
+    //        defer: Deferred
+    //     }
+    //   }
+
+    this._linkValidator = new ConfigValidator({
+        "type": "object",
+        "properties": validationProperties,
+        "required": [
+            "matrix_room_id",
+            "remote_room_channel",
+            "remote_room_server",
+            "op_nick",
+            "bridger_id"
+        ]
+    });
+    this._unlinkValidator = new ConfigValidator({
+        "type": "object",
+        "properties": validationProperties,
+        "required": [
+            "matrix_room_id",
+            "remote_room_channel",
+            "remote_room_server"
+        ]
+    });
+    this._roomIdValidator = new ConfigValidator({
+        "type": "object",
+        "properties": {
+            "matrix_room_id" : matrixRoomIdValidation
+        }
+    });
 
     if (enabled) {
         log.info("Starting provisioning...");
@@ -97,84 +158,32 @@ Provisioner.prototype.isProvisionRequest = function(req) {
             req.url.match(/^\/_matrix\/provision\/listlinks/)
 };
 
-var parameterValidation = {
-    matrix_room_id :
-        {regex : /^!.*:.*$/, example : '!Abcdefg:example.com[:8080]'},
-    remote_room_channel :
-        {regex : /^([#+&]|(![A-Z0-9]{5}))[^\s:,]+$/, example : '#roomname'},
-    remote_room_server :
-        {regex : /^[a-z\.0-9:-]+$/, example : 'example.com or localhost'},
-    op_nick :
-        {regex : /^.+$/, example : 'bob'},
-    key :
-        {regex : /^.+$/, example : '1234567890', optional : true}
-};
-
-Provisioner.prototype._validate = function(actual, parameterName) {
-    let valid = parameterValidation[parameterName];
-
-    if (!valid) {
-        throw new Error(
-            `Parameter name not recognised (${parameterName}).`
-        );
-    }
-
-    if (!actual) {
-        if (valid.optional) {
-            return;
-        }
-        throw new Error(
-            `${parameterName} not provided (like '${valid.example}').`
-        );
-    }
-
-    if (typeof actual !== 'string') {
-        throw new Error(
-            `${parameterName} should be a string (like '${valid.example}').`
-        );
-    }
-
-    if (!actual.match(valid.regex)) {
-        throw new Error(
-            `Malformed ${parameterName} ('${actual}'), should look like '${valid.example}'.`
-        );
-    }
-};
-
-// Validate parameters for use in linking/unlinking
-Provisioner.prototype._validateAll = function(parameters, parameterNames) {
-    if (!parameterNames) {
-        parameterNames = [
-            'matrix_room_id',
-            'remote_room_channel',
-            'remote_room_server',
-            'op_nick',
-            'key'
-        ];
-    }
-    for (var i = 0; i < parameterNames.length; i++) {
-        this._validate(parameters[parameterNames[i]], parameterNames[i]);
-    }
-};
-
 Provisioner.prototype._updateBridgingState = Promise.coroutine(
-    function*(roomId, bridger_id, status, skey) {
+    function*(roomId, bridgerId, status, skey) {
         let intent = this._ircBridge.getAppServiceBridge().getIntent();
         try {
             yield intent.client.sendStateEvent(roomId, 'm.room.bridging', {
-                bridger_id: bridger_id,
+                bridger_id: bridgerId,
                 status: status // pending, success, failure
             }, skey);
         }
         catch (err) {
-            throw new Error(`Could not update m.room.bridging state in this room ($err.message)`);
+            log.error(err);
+            throw new Error(`Could not update m.room.bridging state in this room`);
         }
     }
 );
 
 Provisioner.prototype._authoriseProvisioning = Promise.coroutine(
-    function*(server, bridger_id, ircChannel, roomId, opNick, key) {
+    function*(server, bridgerId, ircChannel, roomId, opNick, key) {
         let ircDomain = server.domain;
+
+        let existing = this._getRequest(server, opNick);
+        if (existing) {
+            let from = existing.bridgerId;
+            throw new Error(`Bridging request already sent to `+
+                            `${opNick} on ${server.domain} from ${from}`);
+        }
 
         // (Matrix) Check power level of user
         let matrixClient = this._ircBridge.getAppServiceBridge().getClientFactory().getClientAs();
@@ -185,105 +194,97 @@ Provisioner.prototype._authoriseProvisioning = Promise.coroutine(
             throw new Error('Power levels not available');
         }
 
-        let actualPower = powerState.users[bridger_id];
+        let actualPower = powerState.users[bridgerId] || powerState.users_default || 0;
         let requiredPower = powerState.events["m.room.power_levels"];
+        requiredPower = requiredPower || powerState.state_default || 50;
 
         if (actualPower < requiredPower) {
             throw new Error('User does not possess high enough power level');
         }
 
         // (IRC) Check that op's nick is actually op
-        let info = yield this._ircBridge.checkNickExists(server, opNick);
+        let botClient = yield this._ircBridge.getBotClient(server);
+        yield botClient.joinChannel(ircChannel, key);
+        let info = yield botClient.getOperators(ircChannel);
 
-        if (!info.isOp) {
-            throw new Error('Provided user is not an Op');
+        if (info.operatorNicks.indexOf(opNick) == -1) {
+            throw new Error(`Provided user is not an op of ${ircChannel}`);
         }
 
         // (Matrix) update room state
         // State key for m.room.bridging
-        let skey = `${ircDomain}${ircChannel}`;
+        let skey = `irc://${ircDomain}/${ircChannel}`;
 
         // Send pending m.room.bridging
-        this._updateBridgingState(roomId, bridger_id, 'pending', skey);
+        yield this._updateBridgingState(roomId, bridgerId, 'pending', skey);
 
         // (IRC) Ask operator for authorisation
         // Time that operator has to respond before giving up
-        let timeout = 10;
+        let timeoutSeconds = 10;
 
-        // Send PM to Bob
-        let botClient = yield this._ircBridge.getBotClient(server);
-        let authRequestAction = new IrcAction("message",
-            `${bridger_id} has requested to bridge ${roomId} with ${ircChannel} on this IRC ` +
-            `network. Respond with 'yes' to allow, or simply ignore this message to ` +
-            `dissallow. You have ${timeout} seconds from when this message was sent.`);
-        let pmRoom = yield botClient.joinChannel(opNick, key);
-
-        // Promise to receive PM from Bob or timeout
-        let opReplyPromise = this.expectPm(server, opNick, timeout);
-
-        this._ircBridge.sendIrcAction(pmRoom, botClient, authRequestAction);
-
-        opReplyPromise.then(
-            () => {
-                return this._dolink(server, ircChannel, roomId)
-            }, (err) => {
-                log.info(`Operator ${opNick} did not respond (${err.message})`);
-                this._updateBridgingState(roomId, bridger_id, 'failure', skey);
-                return Promise.reject(err);
-            }
-        ).then(
-            () => {
-                this._updateBridgingState(roomId, bridger_id, 'success', skey);
-            }
-        );
-
-        return Promise.resolve();
+        this._contactOperator(
+            botClient, server, opNick, ircChannel,
+            roomId, bridgerId, skey, timeoutSeconds);
     }
 );
 
-Provisioner.prototype._removeExpectation = function (expectation) {
-    expectation.defer = null;
-    this._expectations = this._expectations.filter((exp) => {
-        return exp.defer !== null;
-    });
+Provisioner.prototype._contactOperator = Promise.coroutine(
+    function*(botClient, server, opNick, ircChannel, roomId, bridgerId, skey, timeoutSeconds) {
+        let d = promiseutil.defer();
+
+        // Send PM to operator
+        let authRequestAction = new IrcAction("message",
+            `${bridgerId} has requested to bridge ${roomId} with ${ircChannel} on this IRC ` +
+            `network. Respond with 'yes' or 'y' to allow, or simply ignore this message to ` +
+            `dissallow. You have ${timeoutSeconds} seconds from when this message was sent.`);
+        let pmRoom = new IrcRoom(server, opNick);
+
+        this._setRequest(server, opNick, {bridgerId: bridgerId, defer: d});
+
+        this._ircBridge.sendIrcAction(pmRoom, botClient, authRequestAction);
+        try {
+            yield d.promise.timeout(timeoutSeconds * 1000);
+            this._removeRequest(server, opNick);
+        }
+        catch (err) {
+            log.info(`Operator ${opNick} did not respond (${err.message})`);
+            this._updateBridgingState(roomId, bridgerId, 'failure', skey);
+            this._removeRequest(server, opNick);
+            return Promise.reject(err);
+        }
+
+        yield this._dolink(server, ircChannel, roomId);
+        yield this._updateBridgingState(roomId, bridgerId, 'success', skey);
+    }
+);
+
+Provisioner.prototype._removeRequest = function (server, opNick) {
+    delete this._pendingRequests[server.domain][opNick];
 }
 
-Provisioner.prototype.expectPm = function(server, fromNick, timeout) {
-    var d = promiseutil.defer();
-    let existingExpectation = this._expectations.find(
-        (expectation) => {
-            return expectation.server.domain === server.domain &&
-                   expectation.fromNick === fromNick;
-        }
-    );
-
-    if (existingExpectation) {
-        throw new Error(`Bridging request already sent to this op`+
-                        ` (${fromNick} on ${server.domain})`);
+Provisioner.prototype._getRequest = function (server, opNick) {
+    if (this._pendingRequests[server.domain]) {
+        return this._pendingRequests[server.domain][opNick];
     }
+}
 
-    let expectation = {server : server, fromNick : fromNick, defer: d};
-    this._expectations.push(expectation);
-
-    return d.promise.timeout(timeout * 1000).then(
-        () => {this._removeExpectation(expectation)},
-        (err) => {this._removeExpectation(expectation); return Promise.reject(err);}
-    );
+Provisioner.prototype._setRequest = function (server, opNick, request) {
+    if (!this._pendingRequests[server.domain]) {
+        this._pendingRequests[server.domain] = {};
+    }
+    this._pendingRequests[server.domain][opNick] = request;
 }
 
 Provisioner.prototype.handlePm = function(server, fromUser, text) {
-    if (text.trim() !== 'yes') {
+    if (['y', 'yes'].indexOf(text.trim().toLowerCase()) == -1) {
+        log.warn(`Provisioner only handles text 'yes'/'y' ` +
+                 `(from ${fromUser.nick} on ${server.domain})`);
         return;
     }
-    let foundExpectation = this._expectations.find(
-        (expectation) => {
-            return expectation.server.domain === server.domain &&
-                   expectation.fromNick === fromUser.nick;
-        }
-    );
-    if (foundExpectation) {
+    let request = this._getRequest(server, fromUser.nick);
+    if (request) {
         log.info(`${fromUser.nick} has authorised a new provisioning`);
-        foundExpectation.defer.resolve();
+        request.defer.resolve();
         return;
     }
     log.warn(`Provisioner was not expecting PM from ${fromUser.nick} on ${server.domain}`);
@@ -291,14 +292,20 @@ Provisioner.prototype.handlePm = function(server, fromUser, text) {
 
 // Link an IRC channel to a matrix room ID
 Provisioner.prototype.requestLink = Promise.coroutine(function*(options) {
-    this._validateAll(options);
+    try {
+        this._linkValidator.validate(options);
+    }
+    catch (err) {
+        log.error(err);
+        throw new Error("Malformed parameters");
+    }
 
     let ircDomain = options.remote_room_server;
     let ircChannel = options.remote_room_channel;
     let roomId = options.matrix_room_id;
     let opNick = options.op_nick;
     let key = options.key || undefined; // Optional key
-    let bridger_id = options.bridger_id;
+    let bridgerId = options.bridger_id;
     let mappingLogId = `${roomId} <---> ${ircDomain}/${ircChannel}`;
 
     // Try to find the domain requested for linking
@@ -316,7 +323,13 @@ Provisioner.prototype.requestLink = Promise.coroutine(function*(options) {
     let entry = yield this._ircBridge.getStore().getRoom(roomId, ircDomain, ircChannel);
     if (!entry) {
         // Ask OP for provisioning authentication
-        yield this._authoriseProvisioning(server, bridger_id, ircChannel, roomId, opNick, key);
+        try {
+            yield this._authoriseProvisioning(server, bridgerId, ircChannel, roomId, opNick, key);
+        }
+        catch (err) {
+            console.error(err.stack);
+            throw new Error(err.message);
+        }
     }
     else {
         throw new Error(`Room mapping already exists (${mappingLogId},` +
@@ -347,11 +360,13 @@ Provisioner.prototype._dolink = Promise.coroutine(
 
 // Unlink an IRC channel from a matrix room ID
 Provisioner.prototype.unlink = Promise.coroutine(function*(options) {
-    this._validateAll(options, [
-        'matrix_room_id',
-        'remote_room_channel',
-        'remote_room_server'
-    ]);
+    try {
+        this._unlinkValidator.validate(options);
+    }
+    catch (err) {
+        log.error(err);
+        throw new Error("Malformed parameters");
+    }
 
     let ircDomain = options.remote_room_server;
     let ircChannel = options.remote_room_channel;
@@ -381,7 +396,13 @@ Provisioner.prototype.unlink = Promise.coroutine(function*(options) {
 
 // List all mappings currently provisioned with the given matrix_room_id
 Provisioner.prototype.listings = function(roomId) {
-    this._validate(roomId, 'matrix_room_id');
+    try {
+        this._roomIdValidator.validate({"matrix_room_id": roomId});
+    }
+    catch (err) {
+        log.error(err);
+        throw new Error("Malformed parameters");
+    }
 
     return this._ircBridge.getStore()
         .getProvisionedMappings(roomId)

--- a/lib/provisioning/Provisioner.js
+++ b/lib/provisioning/Provisioner.js
@@ -55,7 +55,7 @@ function Provisioner(ircBridge, enabled) {
             "remote_room_channel",
             "remote_room_server",
             "op_nick",
-            "user_id"
+            // "user_id"
         ]
     });
     this._unlinkValidator = new ConfigValidator({
@@ -189,10 +189,16 @@ Provisioner.prototype._authoriseProvisioning = Promise.coroutine(
         log.info(`Check power level of user`);
         let matrixClient = this._ircBridge.getAppServiceBridge().getClientFactory().getClientAs();
 
-        let powerState = yield matrixClient.getStateEvent(roomId, 'm.room.power_levels');
+        let powerState = null;
+        try {
+            powerState = yield matrixClient.getStateEvent(roomId, 'm.room.power_levels');
+        }
+        catch (err) {
+            log.error(`Error retrieving power levels (${err.data.error})`);
+        }
 
         if (!powerState) {
-            throw new Error('Power levels not available');
+            throw new Error('Could not retrieve your power levels for the room');
         }
 
         let actualPower = 0;
@@ -330,7 +336,7 @@ Provisioner.prototype.requestLink = Promise.coroutine(function*(options) {
     let roomId = options.matrix_room_id;
     let opNick = options.op_nick;
     let key = options.key || undefined; // Optional key
-    let userId = options.user_id;
+    let userId = options.user_id || "@lukeA:localhost:8480";
     let mappingLogId = `${roomId} <---> ${ircDomain}/${ircChannel}`;
 
     // Try to find the domain requested for linking

--- a/lib/provisioning/Provisioner.js
+++ b/lib/provisioning/Provisioner.js
@@ -168,7 +168,7 @@ Provisioner.prototype._updateBridgingState = Promise.coroutine(
             }, skey);
         }
         catch (err) {
-            log.error(err);
+            console.error(err);
             throw new Error(`Could not update m.room.bridging state in this room`);
         }
     }
@@ -186,6 +186,7 @@ Provisioner.prototype._authoriseProvisioning = Promise.coroutine(
         }
 
         // (Matrix) Check power level of user
+        log.info(`Check power level of user`);
         let matrixClient = this._ircBridge.getAppServiceBridge().getClientFactory().getClientAs();
 
         let powerState = yield matrixClient.getStateEvent(roomId, 'm.room.power_levels');
@@ -203,8 +204,11 @@ Provisioner.prototype._authoriseProvisioning = Promise.coroutine(
         }
 
         // (IRC) Check that op's nick is actually op
+        // TODO: Do something with the key here
+        log.info(`Check that op's nick is actually op`);
         let botClient = yield this._ircBridge.getBotClient(server);
         yield botClient.joinChannel(ircChannel, key);
+        log.info(`Bot joined channel ${ircChannel}`);
         let info = yield botClient.getOperators(ircChannel);
 
         if (info.operatorNicks.indexOf(opNick) == -1) {
@@ -212,6 +216,7 @@ Provisioner.prototype._authoriseProvisioning = Promise.coroutine(
         }
 
         // (Matrix) update room state
+        log.info(`Sending m.room.bridging`);
         // State key for m.room.bridging
         let skey = `irc://${ircDomain}/${ircChannel}`;
 
@@ -222,6 +227,7 @@ Provisioner.prototype._authoriseProvisioning = Promise.coroutine(
         // Time that operator has to respond before giving up
         let timeoutSeconds = 10;
 
+        log.info(`Contacting operator`);
         this._contactOperator(
             botClient, server, opNick, ircChannel,
             roomId, bridgerId, skey, timeoutSeconds);

--- a/lib/provisioning/Provisioner.js
+++ b/lib/provisioning/Provisioner.js
@@ -226,6 +226,7 @@ Provisioner.prototype._authoriseProvisioning = Promise.coroutine(
         // Time that operator has to respond before giving up
         let timeoutSeconds = 10;
 
+        // Deliberately not yielding on this so that 200 OK is returned
         log.info(`Contacting operator`);
         this._contactOperator(
             botClient, server, opNick, ircChannel,

--- a/lib/provisioning/Provisioner.js
+++ b/lib/provisioning/Provisioner.js
@@ -249,9 +249,9 @@ Provisioner.prototype._authoriseProvisioning = Promise.coroutine(
         }
 
         // (Matrix) update room state
-        log.info(`Sending m.room.bridging`);
         // State key for m.room.bridging
         let skey = `irc://${ircDomain}/${ircChannel}`;
+        log.info(`Sending m.room.bridging to ${roomId}, state key = ${skey}`);
 
         // Send pending m.room.bridging
         yield this._updateBridgingState(roomId, userId, 'pending', skey);

--- a/lib/provisioning/Provisioner.js
+++ b/lib/provisioning/Provisioner.js
@@ -195,9 +195,21 @@ Provisioner.prototype._authoriseProvisioning = Promise.coroutine(
             throw new Error('Power levels not available');
         }
 
-        let actualPower = powerState.users[userId] || powerState.users_default || 0;
-        let requiredPower = powerState.events["m.room.power_levels"];
-        requiredPower = requiredPower || powerState.state_default || 50;
+        let actualPower = 0;
+        if (powerState.users[userId] !== undefined) {
+            actualPower = powerState.users[userId];
+        }
+        else if (powerState.users_default !== undefined) {
+            actualPower = powerState.users_default;
+        }
+
+        let requiredPower = 50;
+        if (powerState.events["m.room.power_levels"] !== undefined) {
+            requiredPower = powerState.events["m.room.power_levels"]
+        }
+        else if (powerState.state_default !== undefined) {
+            requiredPower = powerState.state_default;
+        }
 
         if (actualPower < requiredPower) {
             throw new Error('User does not possess high enough power level');
@@ -224,7 +236,7 @@ Provisioner.prototype._authoriseProvisioning = Promise.coroutine(
 
         // (IRC) Ask operator for authorisation
         // Time that operator has to respond before giving up
-        let timeoutSeconds = 10;
+        let timeoutSeconds = 1;
 
         // Deliberately not yielding on this so that 200 OK is returned
         log.info(`Contacting operator`);
@@ -254,12 +266,19 @@ Provisioner.prototype._contactOperator = Promise.coroutine(
         }
         catch (err) {
             log.info(`Operator ${opNick} did not respond (${err.message})`);
-            this._updateBridgingState(roomId, userId, 'failure', skey);
+            yield this._updateBridgingState(roomId, userId, 'failure', skey);
             this._removeRequest(server, opNick);
-            return Promise.reject(err);
+            return;
         }
-
-        yield this._dolink(server, ircChannel, roomId);
+        try {
+            yield this._dolink(server, ircChannel, roomId);
+        }
+        catch (err) {
+            log.info(`Failed to create link following authorisation (${err.message})`);
+            yield this._updateBridgingState(roomId, userId, 'failure', skey);
+            this._removeRequest(server, opNick);
+            return;
+        }
         yield this._updateBridgingState(roomId, userId, 'success', skey);
     }
 );

--- a/lib/provisioning/Provisioner.js
+++ b/lib/provisioning/Provisioner.js
@@ -229,8 +229,16 @@ Provisioner.prototype._authoriseProvisioning = Promise.coroutine(
         log.info(`Bot joined channel ${ircChannel}`);
         let info = yield botClient.getOperators(ircChannel);
 
+        if (info.nicks.indexOf(opNick) == -1) {
+            let knownOps = info.operatorNicks.join(', ');
+            throw new Error(`Provided user is not in channel ${ircChannel}. ` +
+                            `Known ops in this channel: ${knownOps}`);
+        }
+
         if (info.operatorNicks.indexOf(opNick) == -1) {
-            throw new Error(`Provided user is not an op of ${ircChannel}`);
+            let knownOps = info.operatorNicks.join(', ');
+            throw new Error(`Provided user is not an op of ${ircChannel}. ` +
+                            `Known ops in this channel: ${knownOps}`);
         }
 
         // (Matrix) update room state
@@ -360,7 +368,7 @@ Provisioner.prototype.requestLink = Promise.coroutine(function*(options) {
         }
         catch (err) {
             console.error(err.stack);
-            throw new Error(err.message);
+            throw new Error('Failed to authorise provisioning');
         }
     }
     else {

--- a/spec/integ/provisioning.spec.js
+++ b/spec/integ/provisioning.spec.js
@@ -50,8 +50,8 @@ describe("Provisioning API", function() {
             if (!parameters.op_nick) {
                 parameters.op_nick = receivingOp.nick;
             }
-            if (!parameters.bridger_id) {
-                parameters.bridger_id = mxUser.id;
+            if (!parameters.user_id) {
+                parameters.user_id = mxUser.id;
             }
 
             let isLinked = promiseutil.defer();
@@ -318,7 +318,7 @@ describe("Provisioning API", function() {
                     remote_room_server : "irc.example",
                     remote_room_channel : "#provisionedchannel",
                     op_nick : receivingOp.nick,
-                    bridger_id : mxUser.id
+                    user_id : mxUser.id
                 };
 
                 let roomMapping = {
@@ -410,7 +410,7 @@ describe("Provisioning API", function() {
                     remote_room_server : "irc.example",
                     remote_room_channel : "#provisionedchannel",
                     op_nick : receivingOp.nick,
-                    bridger_id : mxUser.id
+                    user_id : mxUser.id
                 };
 
                 let roomMapping = {
@@ -579,7 +579,7 @@ describe("Provisioning API", function() {
                     remote_room_server : "irc.example",
                     remote_room_channel : "#provisionedchannel",
                     op_nick : receivingOp.nick,
-                    bridger_id : mxUser.id
+                    user_id : mxUser.id
                 };
 
                 let isLinked = promiseutil.defer();
@@ -620,13 +620,13 @@ describe("Provisioning API", function() {
                     remote_room_server : "irc.example",
                     remote_room_channel : "#provisionedchannel1",
                     op_nick : receivingOp.nick,
-                    bridger_id : mxUser.id
+                    user_id : mxUser.id
                 }, {
                     matrix_room_id : roomId,
                     remote_room_server : "irc.example",
                     remote_room_channel : "#provisionedchannel2",
                     op_nick : receivingOp.nick,
-                    bridger_id : mxUser.id
+                    user_id : mxUser.id
                 }];
 
                 let listings = parameters.map((mapping) => {
@@ -680,13 +680,13 @@ describe("Provisioning API", function() {
                     remote_room_server : "irc.example",
                     remote_room_channel : "#provisionedchannel1",
                     op_nick : receivingOp.nick,
-                    bridger_id : mxUser.id
+                    user_id : mxUser.id
                 }, {
                     matrix_room_id : roomId,
                     remote_room_server : "irc.example",
                     remote_room_channel : "#provisionedchannel2",
                     op_nick : receivingOp.nick,
-                    bridger_id : mxUser.id
+                    user_id : mxUser.id
                 }];
 
                 let listings = parameters.map((mapping) => {

--- a/spec/integ/provisioning.spec.js
+++ b/spec/integ/provisioning.spec.js
@@ -65,15 +65,15 @@ describe("Provisioning API", function() {
         );
 
         // Use these to determine what bridging state has been sent to the room
+        //  these effectively represent the status of the entire provisioning process
+        //  and NOT just the sending of the link request to the op
         env.isPending = promiseutil.defer();
         env.isFailed = promiseutil.defer();
         env.isSuccess = promiseutil.defer();
 
-        // Listen for m.room.bridging filure
+        // Listen for m.room.bridging
         var sdk = env.clientMock._client(config._botUserId);
         sdk.sendStateEvent.andCallFake((roomId, kind, content) => {
-            // Status of m.room.bridging is a success
-            // console.log(roomId, kind, content);
             console.log(roomId, kind, content);
             if (kind === "m.room.bridging") {
                 if (content.status === "pending") {
@@ -203,13 +203,14 @@ describe("Provisioning API", function() {
                     return resolve();
                 }
 
-                // Wait for the link to be successful before unlinking
+                // If a link was made
                 if (doLinkBeforeUnlink) {
+                    // Wait for the link to be success or failure
                     if (shouldSucceed) {
                         yield env.isSuccess.promise;
                     }
                     else {
-                        yield env.isFailed.promise; // Could be wrong
+                        yield env.isFailed.promise;
                     }
                 }
 

--- a/spec/integ/provisioning.spec.js
+++ b/spec/integ/provisioning.spec.js
@@ -534,7 +534,9 @@ describe("Provisioning API", function() {
             // Bot now joins the provisioned channel to check for ops
             env.ircMock._autoJoinChannels(
                 config._server, config._botnick,
-                ['#provisionedchannel','#provisionedchannel1','#provisionedchannel2']
+                ['#provisionedchannel',
+                '#provisionedchannel1',
+                '#provisionedchannel2']
             );
 
             // Allow receiving of names by bot
@@ -644,7 +646,7 @@ describe("Provisioning API", function() {
                     // Listen for m.room.bridging success
                     console.log('Waiting for m.room.bridging');
                     var sdk = env.clientMock._client(config._botUserId);
-                    sdk.sendStateEvent.andCallFake((roomId, kind, content) => {
+                    sdk.sendStateEvent.andCallFake((stateRoomId, kind, content) => {
                         // Status of m.room.bridging is a success
                         if (kind === "m.room.bridging" && content.status === "success") {
                             isLinked[i++].resolve();
@@ -703,7 +705,7 @@ describe("Provisioning API", function() {
                 env.ircMock._whenClient(config._server, config._botnick, 'say', (self) => {
                     // Listen for m.room.bridging success
                     var sdk = env.clientMock._client(config._botUserId);
-                    sdk.sendStateEvent.andCallFake((roomId, kind, content) => {
+                    sdk.sendStateEvent.andCallFake((stateRoomId, kind, content) => {
                         // Status of m.room.bridging is a success
                         if (kind === "m.room.bridging" && content.status === "success") {
                             isLinked[i++].resolve();

--- a/spec/integ/provisioning.spec.js
+++ b/spec/integ/provisioning.spec.js
@@ -202,33 +202,31 @@ describe("Provisioning API", function() {
                 mockLink({remote_room_channel : 'coffe####e'}, false, true));
 
             // See dynamicChannels.exclude in config file
-            it("should not create a M<--->I link when remote_room_channel is " +
-                "excluded by the config",
+            it("should not create a M<--->I link when remote_room_channel is excluded by the " +
+                "config",
                 mockLink({remote_room_channel : '#excluded_channel'}, false, true));
 
-            it("should not create a M<--->I link when matrix_room_id is " +
-                "not defined",
+            it("should not create a M<--->I link when matrix_room_id is not defined",
                 mockLink({matrix_room_id : null}, false, true));
 
-            it("should not create a M<--->I link when remote_room_server is " +
-                "not defined",
+            it("should not create a M<--->I link when remote_room_server is not defined",
                 mockLink({remote_room_server : null}, false, true));
 
-            it("should not create a M<--->I link when remote_room_channel is " +
-                "not defined",
+            it("should not create a M<--->I link when remote_room_channel is not defined",
                 mockLink({remote_room_channel : null}, false, true));
 
-            it("should not create a M<--->I link when op_nick is " +
-                "not defined",
+            it("should not create a M<--->I link when op_nick is not defined",
                 mockLink({op_nick : null}, false, true));
 
-            it("should not create a M<--->I link when op_nick is " +
-                "not in the room",
+            it("should not create a M<--->I link when op_nick is not in the room",
                 mockLink({op_nick : 'somenonexistantop'}, false, true));
 
-            it("should not create a M<--->I link when op_nick is " +
-                "not an operator, but is in the room",
+            it("should not create a M<--->I link when op_nick is not an operator, but is in the " +
+                "room",
                 mockLink({op_nick : notOp.nick}, false, true));
+
+            it("should not create a M<--->I link when user does not have enough power in room",
+                mockLink({user_id: 'powerless'}, false, true));
         });
 
         describe("unlink endpoint", function() {

--- a/spec/integ/provisioning.spec.js
+++ b/spec/integ/provisioning.spec.js
@@ -38,21 +38,28 @@ describe("Provisioning API", function() {
             });
 
             // Defaults
-            if (!parameters.matrix_room_id) {
+            if (parameters.matrix_room_id === undefined) {
                 parameters.matrix_room_id = "!foo:bar";
             }
-            if (!parameters.remote_room_server) {
+            if (parameters.remote_room_server === undefined) {
                 parameters.remote_room_server = "irc.example";
             }
-            if (!parameters.remote_room_channel) {
+            if (parameters.remote_room_channel === undefined) {
                 parameters.remote_room_channel = "#provisionedchannel";
             }
-            if (!parameters.op_nick) {
+            if (parameters.op_nick === undefined) {
                 parameters.op_nick = receivingOp.nick;
             }
-            if (!parameters.user_id) {
+            if (parameters.user_id === undefined) {
                 parameters.user_id = mxUser.id;
             }
+
+            for (var p in parameters) {
+                if (parameters[p] === null) {
+                    parameters[p] = undefined;
+                }
+            }
+
 
             let isLinked = promiseutil.defer();
 
@@ -196,7 +203,7 @@ describe("Provisioning API", function() {
 
             it("should not create a M<--->I link when op_nick is " +
                 "not defined",
-                mockLink({remote_room_channel : '#excluded_channel'}, false, true));
+                mockLink({op_nick : null}, false, true));
         });
 
         describe("unlink endpoint", function() {

--- a/spec/integ/provisioning.spec.js
+++ b/spec/integ/provisioning.spec.js
@@ -21,6 +21,10 @@ describe("Provisioning API", function() {
         nick: "oprah"
     };
 
+    var notOp = {
+        nick: "notoprah"
+    };
+
     // Create a coroutine to test certain API parameters.
     //  parameters {object} - the API parameters
     //  shouldSucceed {boolean} - true if the request should succeed
@@ -166,6 +170,7 @@ describe("Provisioning API", function() {
                 function(client, chan, cb) {
                     let names = {};
                     names[receivingOp.nick] = '@'; // is op
+                    names[notOp.nick] = ''; // is not op
                     cb(chan, names);
                 }
             );
@@ -220,6 +225,10 @@ describe("Provisioning API", function() {
             it("should not create a M<--->I link when op_nick is " +
                 "not in the room",
                 mockLink({op_nick : 'somenonexistantop'}, false, true));
+
+            it("should not create a M<--->I link when op_nick is " +
+                "not an operator, but is in the room",
+                mockLink({op_nick : notOp.nick}, false, true));
         });
 
         describe("unlink endpoint", function() {
@@ -297,6 +306,7 @@ describe("Provisioning API", function() {
                 function(client, chan, cb) {
                     let names = {};
                     names[receivingOp.nick] = '@'; // is op
+                    names[notOp.nick] = ''; // is not op
                     cb(chan, names);
                 }
             );
@@ -332,6 +342,7 @@ describe("Provisioning API", function() {
                 function(client, chan, cb) {
                     let names = {};
                     names[receivingOp.nick] = '@'; // is op
+                    names[notOp.nick] = ''; // is not op
                     cb(chan, names);
                 }
             );
@@ -579,6 +590,7 @@ describe("Provisioning API", function() {
                 function(client, chan, cb) {
                     let names = {};
                     names[receivingOp.nick] = '@'; // is op
+                    names[notOp.nick] = ''; // is not op
                     cb(chan, names);
                 }
             );

--- a/spec/integ/provisioning.spec.js
+++ b/spec/integ/provisioning.spec.js
@@ -201,9 +201,25 @@ describe("Provisioning API", function() {
                 "excluded by the config",
                 mockLink({remote_room_channel : '#excluded_channel'}, false, true));
 
+            it("should not create a M<--->I link when matrix_room_id is " +
+                "not defined",
+                mockLink({matrix_room_id : null}, false, true));
+
+            it("should not create a M<--->I link when remote_room_server is " +
+                "not defined",
+                mockLink({remote_room_server : null}, false, true));
+
+            it("should not create a M<--->I link when remote_room_channel is " +
+                "not defined",
+                mockLink({remote_room_channel : null}, false, true));
+
             it("should not create a M<--->I link when op_nick is " +
                 "not defined",
                 mockLink({op_nick : null}, false, true));
+
+            it("should not create a M<--->I link when op_nick is " +
+                "not in the room",
+                mockLink({op_nick : 'somenonexistantop'}, false, true));
         });
 
         describe("unlink endpoint", function() {

--- a/spec/integ/provisioning.spec.js
+++ b/spec/integ/provisioning.spec.js
@@ -243,6 +243,18 @@ describe("Provisioning API", function() {
 
             it("should not remove a M<--->I link when remote_room_channel is malformed",
                 mockLink({remote_room_channel : 'coffe####e'}, false, false));
+
+            it("should not remove a M<--->I link when matrix_room_id is " +
+                "not defined",
+                mockLink({matrix_room_id : null}, false, true));
+
+            it("should not remove a M<--->I link when remote_room_server is " +
+                "not defined",
+                mockLink({remote_room_server : null}, false, true));
+
+            it("should not remove a M<--->I link when remote_room_channel is " +
+                "not defined",
+                mockLink({remote_room_channel : null}, false, true));
         });
     });
 

--- a/spec/util/client-sdk-mock.js
+++ b/spec/util/client-sdk-mock.js
@@ -48,7 +48,9 @@ function MockClient(config) {
         if (type === 'm.room.power_levels') {
             result = {
                 users_default: 100,
-                users : {},
+                users : {
+                    'powerless': 0
+                },
                 events : {
                     'm.room.power_levels' : 100
                 }

--- a/spec/util/client-sdk-mock.js
+++ b/spec/util/client-sdk-mock.js
@@ -34,10 +34,27 @@ function MockClient(config) {
         return Promise.resolve({});
     });
 
+    // mock up sendStateEvent
+    this.sendStateEvent.andCallFake(function() {
+        return Promise.resolve({});
+    });
+
     // mock up getStateEvent immediately since it is called for every new IRC
     // connection.
-    this.getStateEvent.andCallFake(function() {
-        return Promise.resolve({});
+    this.getStateEvent.andCallFake(function(roomId, type, skey, callback) {
+        let result = {};
+
+        // Mocks a user having the ability to change power levels
+        if (type === 'm.room.power_levels') {
+            result = {
+                users_default: 100,
+                users : {},
+                events : {
+                    'm.room.power_levels' : 100
+                }
+            };
+        }
+        return Promise.resolve(result);
     });
 
     // mock up registration since we make them if they aren't in the DB (which they won't be

--- a/spec/util/irc-client-mock.js
+++ b/spec/util/irc-client-mock.js
@@ -182,9 +182,3 @@ module.exports._autoConnectNetworks = function(addr, nick, networks) {
         }
     });
 };
-
-// For imitating events received by the client (such as an IRC op replying
-//  to a request for plumbing)
-module.exports.getClientEmitter = function () {
-    return clientEmitter;
-}

--- a/spec/util/irc-client-mock.js
+++ b/spec/util/irc-client-mock.js
@@ -54,7 +54,7 @@ function Client(addr, nick, opts) {
 
     var spies = [
         "connect", "whois", "join", "send", "action", "ctcp", "say",
-        "disconnect", "notice", "part"
+        "disconnect", "notice", "part", "names"
     ];
     spies.forEach(function(fnName) {
         self[fnName] = jasmine.createSpy("Client." + fnName);
@@ -182,3 +182,9 @@ module.exports._autoConnectNetworks = function(addr, nick, networks) {
         }
     });
 };
+
+// For imitating events received by the client (such as an IRC op replying
+//  to a request for plumbing)
+module.exports.getClientEmitter = function () {
+    return clientEmitter;
+}

--- a/spec/util/test-config.json
+++ b/spec/util/test-config.json
@@ -89,7 +89,8 @@
             }
         },
         "provisioning": {
-            "enabled": true
+            "enabled": true,
+            "requestTimeoutSeconds": 1
         }
     }
 }


### PR DESCRIPTION
Link provisioning now requires that the nick of a valid IRC operator is given with a requested link. The bridge sends a message to the op asking to respond 'yes' if they would like to authorise a given
bridging.

Determining whether someone is an op uses whois, which required tweaking on the ```BridgedClient``` to use the operator field that was so far unused.

```m.room.bridging``` room state is used in the room in the new mapping to signal whether the status of the bridging is 'pending', 'success', or 'failure'.

 ```JS
{
    content: {
        bridger: 'nick',
        status: 'pending'
    }
}