### PR TITLE
Implement GET /_matrix/provision/queryLink

### DIFF
--- a/lib/provisioning/Provisioner.js
+++ b/lib/provisioning/Provisioner.js
@@ -148,6 +148,17 @@ function Provisioner(ircBridge, enabled, requestTimeoutSeconds) {
         }
     }));
 
+    as.app.get("/_matrix/provision/querylink", Promise.coroutine(function*(req, res) {
+        try {
+            let result = yield self.queryLink(req.body);
+            res.json(result);
+        }
+        catch (err) {
+            res.status(500).json({error: err.message});
+            throw err;
+        }
+    }));
+
     if (enabled) {
         log.info("Provisioning started");
     }
@@ -175,18 +186,8 @@ Provisioner.prototype._updateBridgingState = Promise.coroutine(
     }
 );
 
-Provisioner.prototype._authoriseProvisioning = Promise.coroutine(
-    function*(server, userId, ircChannel, roomId, opNick, key) {
-        let ircDomain = server.domain;
-
-        let existing = this._getRequest(server, opNick);
-        if (existing) {
-            let from = existing.userId;
-            throw new Error(`Bridging request already sent to `+
-                            `${opNick} on ${server.domain} from ${from}`);
-        }
-
-        // (Matrix) Check power level of user
+Provisioner.prototype._userHasProvisioningPower = Promise.coroutine(
+    function*(userId, roomId) {
         log.info(`Check power level of user`);
         let matrixClient = this._ircBridge.getAppServiceBridge().getClientFactory().getClientAs();
 
@@ -218,7 +219,24 @@ Provisioner.prototype._authoriseProvisioning = Promise.coroutine(
             requiredPower = powerState.state_default;
         }
 
-        if (actualPower < requiredPower) {
+        return actualPower >= requiredPower;
+    }
+);
+
+Provisioner.prototype._authoriseProvisioning = Promise.coroutine(
+    function*(server, userId, ircChannel, roomId, opNick, key) {
+        let ircDomain = server.domain;
+
+        let existing = this._getRequest(server, opNick);
+        if (existing) {
+            let from = existing.userId;
+            throw new Error(`Bridging request already sent to `+
+                            `${opNick} on ${server.domain} from ${from}`);
+        }
+
+        // (Matrix) Check power level of user
+        let hasPower = yield this._userHasProvisioningPower(userId, roomId);
+        if (!hasPower) {
             throw new Error('User does not possess high enough power level');
         }
 
@@ -329,6 +347,123 @@ Provisioner.prototype.handlePm = function(server, fromUser, text) {
     }
     log.warn(`Provisioner was not expecting PM from ${fromUser.nick} on ${server.domain}`);
 }
+
+
+// Get information that might be useful prior to calling requestLink
+//  with the same parameters
+Provisioner.prototype.queryLink = Promise.coroutine(function*(options) {
+    let ircDomain = options.remote_room_server;
+    let ircChannel = options.remote_room_channel;
+    let roomId = options.matrix_room_id;
+    let opNick = options.op_nick;
+    let key = options.key || undefined; // Optional key
+    let userId = options.user_id;
+
+    let queryInfo = {
+        // Map between options and info pertaining to them
+        // $parameter {
+        //      info: 'some information' ,
+        //      error: 'an error'
+        // }
+        parameter_info: {
+            remote_room_server: {},
+            remote_room_channel: {},
+            matrix_room_id: {},
+            op_nick: {},
+            user_id: {}
+        },
+        // General info and errors
+        infos: [],
+        errors: [],
+        // List of operators. Only defined if retrieved.
+        // operators: []
+    }
+
+    try {
+        this._linkValidator.validate(options);
+    }
+    catch (err) {
+        // .validate does not return any details of problems with parameters
+        console.log(err);
+        queryInfo.errors.push('Parameter(s) malformed');
+        return queryInfo;
+    }
+
+    // Try to find the domain requested for linking
+    //TODO: ircDomain might include protocol, i.e. irc://irc.freenode.net
+    let server = this._ircBridge.getServer(ircDomain);
+
+    if (!server) {
+        queryInfo.parameter_info['remote_room_server']
+                 .error = 'Server not found';
+        return queryInfo;
+    }
+
+    if (server.isExcludedChannel(ircChannel)) {
+        queryInfo.parameter_info['remote_room_channel']
+                 .error = 'Server is configured to exclude channel';
+    }
+
+    let entry = yield this._ircBridge.getStore().getRoom(roomId, ircDomain, ircChannel);
+    if (entry) {
+        queryInfo.errors.push('Mapping already exists');
+    }
+
+    // Errors with nick prevent further querying
+    if (queryInfo.parameter_info['op_nick'].error) {
+        return queryInfo;
+    }
+
+    let existing = this._getRequest(server, opNick);
+    if (existing) {
+        let from = existing.userId;
+        queryInfo.errors.push(`Bridging request already sent to this op from ${from}`);
+    }
+
+    let hasPower = null;
+    try {
+        hasPower = yield this._userHasProvisioningPower(userId, roomId);
+    }
+    catch (err) {
+        log.error(err.stack);
+        queryInfo.errors.push('Could not retrieve power levels');
+    }
+
+    if (!hasPower) {
+        queryInfo.errors.push('You do not possess enough power to bridge this room');
+    }
+
+    // There must be no error with the channel to continue
+    if (queryInfo.parameter_info['remote_room_channel'].error) {
+        return queryInfo;
+    }
+
+    let botClient = yield this._ircBridge.getBotClient(server);
+
+    try {
+        yield botClient.joinChannel(ircChannel, key);
+    }
+    catch (err) {
+        log.error(err.stack);
+        queryInfo.parameter_info['remote_room_channel'].error = 'Bot cannot join this channel';
+        return queryInfo;
+    }
+
+    let opsInfo = yield botClient.getOperators(ircChannel);
+
+    queryInfo.operators = opsInfo.operatorNicks;
+
+    if (opsInfo.operatorNicks.indexOf(opNick) == -1) {
+        queryInfo.parameter_info['op_nick'].error = 'Provided user is not a chan op in this '+
+                                                    'channel';
+    }
+
+    if (opsInfo.nicks.indexOf(opNick) == -1) {
+        queryInfo.parameter_info['op_nick'].error = 'Provided user is not in this channel';
+    }
+
+    return queryInfo;
+});
 
 // Link an IRC channel to a matrix room ID
 Provisioner.prototype.requestLink = Promise.coroutine(function*(options) {


### PR DESCRIPTION
This can be used to do a 'dummy' link request to check for errors with parameters. Currently, no further detail on the validation of parameters is given better than 'Parameters malformed'. This is an issue with ConfigValidator component of matrix-appservice-bridge. If the validation is a success, more interesting checks are done, possibly resulting in the following numerous errors:

- Server not found
- Server is configured to exclude channel
- Mapping already exists
- Bridging request already sent to this op
- Could not retrieve power levels
- You do not possess enough power to bridge this room
- Bot cannot join this channel
- Provided user is not a chan op in this channel (see example, below)
- Provided user is not in this channel

Results from this endpoint are given as a JSON blob, for example :

```JavaScript
{
    parameter_info: {
        remote_room_server: {},
        remote_room_channel: {},
        matrix_room_id: {},
        op_nick: {error : 'Provided user is not a chan op in this channel'},
        user_id: {}
    },
    // General info and errors
    infos: [],
    errors: [],
    // List of operators for the provided channel. Only defined if retrieved.
    operators: []
}
```

Any errors that occur in the querying process will be given in the normal way:
```JavaScript
{
    error: 'There was a problem querying for this link'
}
````