### PR TITLE
Improve pastebin message

### DIFF
--- a/lib/bridge/MatrixHandler.js
+++ b/lib/bridge/MatrixHandler.js
@@ -947,6 +947,9 @@ MatrixHandler.prototype._sendIrcAction = Promise.coroutine(
         .splice(0, 2)
         .join('_') + '.txt';
 
+    // somenick_2016-08-03_10:40:48
+    fileName = ircClient.nick + '_' + fileName;
+
     let result = {};
 
     try {
@@ -974,7 +977,7 @@ MatrixHandler.prototype._sendIrcAction = Promise.coroutine(
         let bigFileIrcAction = IrcAction.fromMatrixAction(mAction);
 
         // Replace "Posted a File with..."
-        bigFileIrcAction.text = 'Posted a long message: ' + mAction.text;
+        bigFileIrcAction.text = mAction.text;
 
         // Notify the IRC side of the uploaded text file
         yield this.ircBridge.sendIrcAction(ircRoom, ircClient, bigFileIrcAction);

--- a/lib/bridge/MatrixHandler.js
+++ b/lib/bridge/MatrixHandler.js
@@ -947,7 +947,7 @@ MatrixHandler.prototype._sendIrcAction = Promise.coroutine(
         .splice(0, 2)
         .join('_') + '.txt';
 
-    // somenick_2016-08-03_10:40:48
+    // somenick_2016-08-03_10:40:48.txt
     fileName = ircClient.nick + '_' + fileName;
 
     let result = {};


### PR DESCRIPTION
The IRC side will now see ```'someuser[m]_2016-08-03_10:40:48.txt'``` as the attachment
name in light of too many lines being sent. The entire message has been modified to: 
```
http://localhost:8080/_matrix/media/v1/download/localhost:8480/YFhhUNwzyzZwovXpAGMQdBmA - lukeb[m]_2016-08-24_16:34:52.txt
```

This refers to #142 