### PR TITLE
Prevent route loops when provisioning new mappings

### DIFF
--- a/lib/irc/BridgedClient.js
+++ b/lib/irc/BridgedClient.js
@@ -396,7 +396,7 @@ BridgedClient.prototype._getValidNick = function(nick, throwOnInvalid) {
 
 BridgedClient.prototype._keepAlive = function() {
     this.lastActionTs = Date.now();
-    var idleTimeout = this.server.getIdleTimeoutMs();
+    var idleTimeout = this.server.getIdleTimeout();
     if (idleTimeout > 0) {
         if (this._idleTimeout) {
             // stop the timeout

--- a/lib/irc/IrcServer.js
+++ b/lib/irc/IrcServer.js
@@ -64,7 +64,7 @@ IrcServer.prototype.useSslSelfSigned = function() {
     return Boolean(this.config.sslselfsign);
 };
 
-IrcServer.prototype.getIdleTimeoutMs = function() {
+IrcServer.prototype.getIdleTimeout = function() {
     return this.config.ircClients.idleTimeout;
 };
 

--- a/lib/provisioning/Provisioner.js
+++ b/lib/provisioning/Provisioner.js
@@ -181,6 +181,8 @@ Provisioner.prototype._updateBridgingState = Promise.coroutine(
 // The checks done are the following:
 //  - (Matrix) Check power level of user is high enough
 //  - (IRC) Check that op's nick is actually a channel op
+//  - (Matrix) check room state to prevent route looping: don't bridge the same
+//    room-channel pair
 //  - (Matrix) update room state m.room.brdiging
 Provisioner.prototype._authoriseProvisioning = Promise.coroutine(
     function*(server, userId, ircChannel, roomId, opNick, key) {
@@ -248,11 +250,46 @@ Provisioner.prototype._authoriseProvisioning = Promise.coroutine(
                             `Known ops in this channel: ${knownOps}`);
         }
 
-        // (Matrix) update room state
         // State key for m.room.bridging
         let skey = `irc://${ircDomain}/${ircChannel}`;
+
+        // (Matrix) check room state to prevent route looping
+        try {
+            let bridgingState = yield matrixClient.getStateEvent(roomId, 'm.room.bridging', skey);
+            // Bridging state exists and is either success or pending (ignore failures)
+            if (bridgingState && bridgingState.status !== 'failure') {
+                // If bridging state sender is the bridge matrix user
+                if (bridgingState.user_id === userId) {
+                    // Success, already pending/success
+                    log.info(`Bridging state already exists in room ${roomId} ` +
+                             `(status = ${bridgingState.status},` +
+                             ` bridger = ${bridgingState.user_id}. Ignoring request.`);
+                    return;
+                }// If it is from a different sender, fail
+                throw new Error(`A request to create this mapping has already been sent ` +
+                         `(status = ${bridgingState.status},` +
+                         ` bridger = ${bridgingState.user_id}. Ignoring request.`);
+            }
+        }
+        catch (err) {
+            // The request to discover bridging state has failed
+
+            // http-api error indicated by errcode
+            if (err.errcode) {
+                //  ignore M_NOT_FOUND: this bridging does not exist
+                console.error(err);
+                if (err.errcode !== 'M_NOT_FOUND') {
+                    throw new Error(err.data.error);
+                }
+            }
+            else {
+                throw err;
+            }
+        }
+
         log.info(`Sending m.room.bridging to ${roomId}, state key = ${skey}`);
 
+        // (Matrix) update room state
         // Send pending m.room.bridging
         yield this._updateBridgingState(roomId, userId, 'pending', skey);
 

--- a/lib/provisioning/Provisioner.js
+++ b/lib/provisioning/Provisioner.js
@@ -255,10 +255,13 @@ Provisioner.prototype._authoriseProvisioning = Promise.coroutine(
 
         // (Matrix) check room state to prevent route looping
         try {
-            let bridgingState = yield matrixClient.getStateEvent(roomId, 'm.room.bridging', skey);
+            let wholeBridgingState = yield matrixClient.getWholeStateEvent(
+                roomId, 'm.room.bridging', skey
+            );
+            let bridgingState = wholeBridgingState.content;
             // Bridging state exists and is either success or pending (ignore failures)
             if (bridgingState && bridgingState.status !== 'failure') {
-                // If bridging state sender is the bridge matrix user
+                // If bridging state sender is the provisioner
                 if (bridgingState.user_id === userId) {
                     // Success, already pending/success
                     log.info(`Bridging state already exists in room ${roomId} ` +

--- a/lib/provisioning/Provisioner.js
+++ b/lib/provisioning/Provisioner.js
@@ -308,8 +308,11 @@ Provisioner.prototype._authoriseProvisioning = Promise.coroutine(
         let matrixClient = this._ircBridge.getAppServiceBridge().getClientFactory().getClientAs();
         // (Matrix) check room state to prevent route looping
         try {
-            let wholeBridgingState = yield matrixClient.getWholeStateEvent(
-                roomId, 'm.room.bridging', skey
+            let roomState = yield matrixClient.roomState(roomId);
+            let wholeBridgingState = roomState.find(
+                (e) => {
+                    return e.type === 'm.room.bridging' && e.state_key === skey
+                }
             );
             // Bridging state exists and is either success or pending (ignore failures)
             if (wholeBridgingState &&
@@ -593,6 +596,7 @@ Provisioner.prototype.requestLink = Promise.coroutine(function*(options) {
         }
         catch (err) {
             console.error(err.stack);
+            // TODO: Provide more interesting errors back to the requester
             throw new Error('Failed to authorise provisioning');
         }
     }

--- a/lib/provisioning/Provisioner.js
+++ b/lib/provisioning/Provisioner.js
@@ -467,7 +467,7 @@ Provisioner.prototype.handlePm = Promise.coroutine(function*(server, fromUser, t
         log.warn(`Provisioner only handles text 'yes'/'y' ` +
                  `(from ${fromUser.nick} on ${server.domain})`);
 
-        this._sendToUser(
+        yield this._sendToUser(
             fromUser.nick, server,
             'Please respond with "yes" or "y".'
         );
@@ -486,7 +486,7 @@ Provisioner.prototype.handlePm = Promise.coroutine(function*(server, fromUser, t
         return;
     }
     log.warn(`Provisioner was not expecting PM from ${fromUser.nick} on ${server.domain}`);
-    this._sendToUser(
+    yield this._sendToUser(
         fromUser.nick, server,
         'The bot was not expecting a message from you. You might have already replied to a request.'
     );
@@ -627,7 +627,7 @@ Provisioner.prototype._doLink = Promise.coroutine(
         // Cause the bot to join the new plumbed channel (if it is enabled (see joinChannel))
         // TODO: key not persisted on restart
         let botClient = yield this._getBotClientForServer(server);
-        botClient.joinChannel(ircChannel, key);
+        yield botClient.joinChannel(ircChannel, key);
 
         try {
             // Cause the provisioner to join the IRC channel
@@ -691,7 +691,7 @@ Provisioner.prototype.unlink = Promise.coroutine(function*(options) {
 
     // Cause the bot to part the channel (if it is enabled (see leaveChannel))
     let botClient = yield this._getBotClientForServer(server);
-    botClient.leaveChannel(ircChannel);
+    yield botClient.leaveChannel(ircChannel);
 });
 
 // List all mappings currently provisioned with the given matrix_room_id

--- a/lib/provisioning/Provisioner.js
+++ b/lib/provisioning/Provisioner.js
@@ -305,25 +305,57 @@ Provisioner.prototype._authoriseProvisioning = Promise.coroutine(
         // State key for m.room.bridging
         let skey = `irc://${ircDomain}/${ircChannel}`;
 
+        let matrixClient = this._ircBridge.getAppServiceBridge().getClientFactory().getClientAs();
         // (Matrix) check room state to prevent route looping
         try {
             let wholeBridgingState = yield matrixClient.getWholeStateEvent(
                 roomId, 'm.room.bridging', skey
             );
-            let bridgingState = wholeBridgingState.content;
             // Bridging state exists and is either success or pending (ignore failures)
-            if (bridgingState && bridgingState.status !== 'failure') {
-                // If bridging state sender is the provisioner
-                if (bridgingState.user_id === userId) {
+            if (wholeBridgingState &&
+                wholeBridgingState.content) {
+                let bridgingState = wholeBridgingState.content;
+
+            if (bridgingState.status !== 'failure') {
+                // If bridging state sender is this bot
+                if (wholeBridgingState.sender === matrixClient.credentials.userId) {
                     // Success, already pending/success
                     log.info(`Bridging state already exists in room ${roomId} ` +
                              `(status = ${bridgingState.status},` +
+                             ` bridger = ${bridgingState.user_id}.)`);
+
+                    // If pending, resend the message to the op as if it were the original
+                    if (bridgingState.status === 'success') {
+                        // This indicates the event shows success, so check that the mapping
+                        //  exists in the database
+
+                        let entry = yield this._ircBridge.getStore()
+                            .getRoom(roomId, ircDomain, ircChannel, 'provision');
+
+                        if (!entry) {
+                            // Update the bridging state to be a failure
+                            log.warn(`Bridging state in room states successful mapping, `+
+                                     `but the bridge is not aware of provisioning. The ` +
+                                     `bridge will update the state in the room to failure ` +
+                                     `and continue with the provisioning request.`);
+                            yield this._updateBridgingState(roomId, userId, 'pending', skey);
+                        }
+                    }
+                    else if (bridgingState.status === 'pending') {
+                        // _getRequest has not returned a pending request (see previously)
+                        log.warn(`Bridging state in room states pending mapping, ` +
+                                 `but the bridge is not waiting for a reply from ` +
+                                 `an op. The bridge will continue with the ` +
+                                 `provisioning request, sending another message ` +
+                                 `to the op in case the server was restarted`);
+                    }
+                }
+                else {// If it is from a different sender, fail
+                    throw new Error(`A request to create this mapping has already been sent ` +
+                             `(status = ${bridgingState.status},` +
                              ` bridger = ${bridgingState.user_id}. Ignoring request.`);
-                    return;
-                }// If it is from a different sender, fail
-                throw new Error(`A request to create this mapping has already been sent ` +
-                         `(status = ${bridgingState.status},` +
-                         ` bridger = ${bridgingState.user_id}. Ignoring request.`);
+                }
+            }
             }
         }
         catch (err) {
@@ -342,7 +374,7 @@ Provisioner.prototype._authoriseProvisioning = Promise.coroutine(
             }
         }
 
-        log.info(`Sending m.room.bridging to ${roomId}, state key = ${skey}`);
+        log.info(`Sending pending m.room.bridging to ${roomId}, state key = ${skey}`);
 
         // (Matrix) update room state
         // Send pending m.room.bridging

--- a/lib/provisioning/Provisioner.js
+++ b/lib/provisioning/Provisioner.js
@@ -338,7 +338,7 @@ Provisioner.prototype._authoriseProvisioning = Promise.coroutine(
                                      `but the bridge is not aware of provisioning. The ` +
                                      `bridge will update the state in the room to failure ` +
                                      `and continue with the provisioning request.`);
-                            yield this._updateBridgingState(roomId, userId, 'pending', skey);
+                            yield this._updateBridgingState(roomId, userId, 'failure', skey);
                         }
                     }
                     else if (bridgingState.status === 'pending') {

--- a/lib/provisioning/Provisioner.js
+++ b/lib/provisioning/Provisioner.js
@@ -315,50 +315,49 @@ Provisioner.prototype._authoriseProvisioning = Promise.coroutine(
                 }
             );
             // Bridging state exists and is either success or pending (ignore failures)
-            if (wholeBridgingState &&
-                wholeBridgingState.content) {
+            if (wholeBridgingState && wholeBridgingState.content) {
                 let bridgingState = wholeBridgingState.content;
 
-            if (bridgingState.status !== 'failure') {
-                // If bridging state sender is this bot
-                if (wholeBridgingState.sender === matrixClient.credentials.userId) {
-                    // Success, already pending/success
-                    log.info(`Bridging state already exists in room ${roomId} ` +
-                             `(status = ${bridgingState.status},` +
-                             ` bridger = ${bridgingState.user_id}.)`);
+                if (bridgingState.status !== 'failure') {
+                    // If bridging state sender is this bot
+                    if (wholeBridgingState.sender === matrixClient.credentials.userId) {
+                        // Success, already pending/success
+                        log.info(`Bridging state already exists in room ${roomId} ` +
+                                 `(status = ${bridgingState.status},` +
+                                 ` bridger = ${bridgingState.user_id}.)`);
 
-                    // If pending, resend the message to the op as if it were the original
-                    if (bridgingState.status === 'success') {
-                        // This indicates the event shows success, so check that the mapping
-                        //  exists in the database
+                        // If pending, resend the message to the op as if it were the original
+                        if (bridgingState.status === 'success') {
+                            // This indicates the event shows success, so check that the mapping
+                            //  exists in the database
 
-                        let entry = yield this._ircBridge.getStore()
-                            .getRoom(roomId, ircDomain, ircChannel, 'provision');
+                            let entry = yield this._ircBridge.getStore()
+                                .getRoom(roomId, ircDomain, ircChannel, 'provision');
 
-                        if (!entry) {
-                            // Update the bridging state to be a failure
-                            log.warn(`Bridging state in room states successful mapping, `+
-                                     `but the bridge is not aware of provisioning. The ` +
-                                     `bridge will update the state in the room to failure ` +
-                                     `and continue with the provisioning request.`);
-                            yield this._updateBridgingState(roomId, userId, 'failure', skey);
+                            if (!entry) {
+                                // Update the bridging state to be a failure
+                                log.warn(`Bridging state in room states successful mapping, `+
+                                         `but the bridge is not aware of provisioning. The ` +
+                                         `bridge will update the state in the room to failure ` +
+                                         `and continue with the provisioning request.`);
+                                yield this._updateBridgingState(roomId, userId, 'failure', skey);
+                            }
+                        }
+                        else if (bridgingState.status === 'pending') {
+                            // _getRequest has not returned a pending request (see previously)
+                            log.warn(`Bridging state in room states pending mapping, ` +
+                                     `but the bridge is not waiting for a reply from ` +
+                                     `an op. The bridge will continue with the ` +
+                                     `provisioning request, sending another message ` +
+                                     `to the op in case the server was restarted`);
                         }
                     }
-                    else if (bridgingState.status === 'pending') {
-                        // _getRequest has not returned a pending request (see previously)
-                        log.warn(`Bridging state in room states pending mapping, ` +
-                                 `but the bridge is not waiting for a reply from ` +
-                                 `an op. The bridge will continue with the ` +
-                                 `provisioning request, sending another message ` +
-                                 `to the op in case the server was restarted`);
+                    else {// If it is from a different sender, fail
+                        throw new Error(`A request to create this mapping has already been sent ` +
+                                 `(status = ${bridgingState.status},` +
+                                 ` bridger = ${bridgingState.user_id}. Ignoring request.`);
                     }
                 }
-                else {// If it is from a different sender, fail
-                    throw new Error(`A request to create this mapping has already been sent ` +
-                             `(status = ${bridgingState.status},` +
-                             ` bridger = ${bridgingState.user_id}. Ignoring request.`);
-                }
-            }
             }
         }
         catch (err) {

--- a/lib/provisioning/Provisioner.js
+++ b/lib/provisioning/Provisioner.js
@@ -326,10 +326,9 @@ Provisioner.prototype._authoriseProvisioning = Promise.coroutine(
                                  `(status = ${bridgingState.status},` +
                                  ` bridger = ${bridgingState.user_id}.)`);
 
-                        // If pending, resend the message to the op as if it were the original
                         if (bridgingState.status === 'success') {
-                            // This indicates the event shows success, so check that the mapping
-                            //  exists in the database
+                            // This indicates success, so check that the mapping exists in the
+                            //  database
 
                             let entry = yield this._ircBridge.getStore()
                                 .getRoom(roomId, ircDomain, ircChannel, 'provision');
@@ -342,7 +341,7 @@ Provisioner.prototype._authoriseProvisioning = Promise.coroutine(
                                          `and continue with the provisioning request.`);
                                 yield this._updateBridgingState(roomId, userId, 'failure', skey);
                             }
-                        }
+                        } // If pending, resend the message to the op as if it were the original
                         else if (bridgingState.status === 'pending') {
                             // _getRequest has not returned a pending request (see previously)
                             log.warn(`Bridging state in room states pending mapping, ` +

--- a/lib/provisioning/Provisioner.js
+++ b/lib/provisioning/Provisioner.js
@@ -306,58 +306,16 @@ Provisioner.prototype._authoriseProvisioning = Promise.coroutine(
         let skey = `irc://${ircDomain}/${ircChannel}`;
 
         let matrixClient = this._ircBridge.getAppServiceBridge().getClientFactory().getClientAs();
+        let wholeBridgingState = null;
+
         // (Matrix) check room state to prevent route looping
         try {
             let roomState = yield matrixClient.roomState(roomId);
-            let wholeBridgingState = roomState.find(
+            wholeBridgingState = roomState.find(
                 (e) => {
                     return e.type === 'm.room.bridging' && e.state_key === skey
                 }
             );
-            // Bridging state exists and is either success or pending (ignore failures)
-            if (wholeBridgingState && wholeBridgingState.content) {
-                let bridgingState = wholeBridgingState.content;
-
-                if (bridgingState.status !== 'failure') {
-                    // If bridging state sender is this bot
-                    if (wholeBridgingState.sender === matrixClient.credentials.userId) {
-                        // Success, already pending/success
-                        log.info(`Bridging state already exists in room ${roomId} ` +
-                                 `(status = ${bridgingState.status},` +
-                                 ` bridger = ${bridgingState.user_id}.)`);
-
-                        if (bridgingState.status === 'success') {
-                            // This indicates success, so check that the mapping exists in the
-                            //  database
-
-                            let entry = yield this._ircBridge.getStore()
-                                .getRoom(roomId, ircDomain, ircChannel, 'provision');
-
-                            if (!entry) {
-                                // Update the bridging state to be a failure
-                                log.warn(`Bridging state in room states successful mapping, `+
-                                         `but the bridge is not aware of provisioning. The ` +
-                                         `bridge will update the state in the room to failure ` +
-                                         `and continue with the provisioning request.`);
-                                yield this._updateBridgingState(roomId, userId, 'failure', skey);
-                            }
-                        } // If pending, resend the message to the op as if it were the original
-                        else if (bridgingState.status === 'pending') {
-                            // _getRequest has not returned a pending request (see previously)
-                            log.warn(`Bridging state in room states pending mapping, ` +
-                                     `but the bridge is not waiting for a reply from ` +
-                                     `an op. The bridge will continue with the ` +
-                                     `provisioning request, sending another message ` +
-                                     `to the op in case the server was restarted`);
-                        }
-                    }
-                    else {// If it is from a different sender, fail
-                        throw new Error(`A request to create this mapping has already been sent ` +
-                                 `(status = ${bridgingState.status},` +
-                                 ` bridger = ${bridgingState.user_id}. Ignoring request.`);
-                    }
-                }
-            }
         }
         catch (err) {
             // The request to discover bridging state has failed
@@ -372,6 +330,51 @@ Provisioner.prototype._authoriseProvisioning = Promise.coroutine(
             }
             else {
                 throw err;
+            }
+        }
+
+        // Bridging state exists and is either success or pending (ignore failures)
+        if (wholeBridgingState && wholeBridgingState.content) {
+            let bridgingState = wholeBridgingState.content;
+
+            if (bridgingState.status !== 'failure') {
+                // If bridging state sender is this bot
+                if (wholeBridgingState.sender === matrixClient.credentials.userId) {
+                    // Success, already pending/success
+                    log.info(`Bridging state already exists in room ${roomId} ` +
+                             `(status = ${bridgingState.status},` +
+                             ` bridger = ${bridgingState.user_id}.)`);
+
+                    if (bridgingState.status === 'success') {
+                        // This indicates success, so check that the mapping exists in the
+                        //  database
+
+                        let entry = yield this._ircBridge.getStore()
+                            .getRoom(roomId, ircDomain, ircChannel, 'provision');
+
+                        if (!entry) {
+                            // Update the bridging state to be a failure
+                            log.warn(`Bridging state in room states successful mapping, `+
+                                     `but the bridge is not aware of provisioning. The ` +
+                                     `bridge will update the state in the room to failure ` +
+                                     `and continue with the provisioning request.`);
+                            yield this._updateBridgingState(roomId, userId, 'failure', skey);
+                        }
+                    } // If pending, resend the message to the op as if it were the original
+                    else if (bridgingState.status === 'pending') {
+                        // _getRequest has not returned a pending request (see previously)
+                        log.warn(`Bridging state in room states pending mapping, ` +
+                                 `but the bridge is not waiting for a reply from ` +
+                                 `an op. The bridge will continue with the ` +
+                                 `provisioning request, sending another message ` +
+                                 `to the op in case the server was restarted`);
+                    }
+                }
+                else {// If it is from a different sender, fail
+                    throw new Error(`A request to create this mapping has already been sent ` +
+                             `(status = ${bridgingState.status},` +
+                             ` bridger = ${bridgingState.user_id}. Ignoring request.`);
+                }
             }
         }
 


### PR DESCRIPTION
The provisioner will fail to request for a mapping if the m.room.bridging status in a room for the same channel (i.e. with the same state key) is not = 'failure'. Meaning, if it is either pending or a success, the request will fail (unless the bridging requester is the same as the ```user_id``` in the ```m.room.bridging```).

Maybe the check for ```user_id``` should really be with the sender, meaning the bridge checks that its own matrix bot was the one to send the bridging. But currently, when you get an event, you don't get it's original sender, so we may have to add extra state to the content of the ```m.room.bridging``` indicating the matrix id of the bridge that set it.