### PR TITLE
Pass an explicit object of controller methods to new Bridge()

### DIFF
--- a/lib/bridge/IrcBridge.js
+++ b/lib/bridge/IrcBridge.js
@@ -51,7 +51,12 @@ function IrcBridge(config, registration) {
         registration: this.registration,
         homeserverUrl: this.config.homeserver.url,
         domain: this.config.homeserver.domain,
-        controller: this,
+        controller: {
+            onEvent: this.onEvent.bind(this),
+            onUserQuery: this.onUserQuery.bind(this),
+            onAliasQuery: this.onAliasQuery.bind(this),
+            onLog: this.onLog.bind(this),
+        },
         roomStore: dirPath + "/rooms.db",
         userStore: dirPath + "/users.db",
         disableContext: true,

--- a/lib/bridge/IrcBridge.js
+++ b/lib/bridge/IrcBridge.js
@@ -55,6 +55,8 @@ function IrcBridge(config, registration) {
             onEvent: this.onEvent.bind(this),
             onUserQuery: this.onUserQuery.bind(this),
             onAliasQuery: this.onAliasQuery.bind(this),
+            onAliasQueried: this.onAliasQueried ?
+                this.onAliasQueried.bind(this) : null,
             onLog: this.onLog.bind(this),
         },
         roomStore: dirPath + "/rooms.db",


### PR DESCRIPTION
Rather than implying via `this` directly, because now it's much easier to extend with `thirdPartyLookup`. Also this way is easier to grep for and for casual readers to understand.