### PR TITLE
Better Provisioning 

### DIFF
--- a/lib/DataStore.js
+++ b/lib/DataStore.js
@@ -153,9 +153,7 @@ DataStore.prototype.removeRoom = function(roomId, ircDomain, ircChannel, origin)
         roomId, ircDomain, ircChannel, origin);
     return this._roomStore.delete({
         id: createMappingId(roomId, ircDomain, ircChannel),
-        data: {
-            origin: origin
-        }
+        'data.origin': origin
     });
 };
 

--- a/lib/irc/BridgedClient.js
+++ b/lib/irc/BridgedClient.js
@@ -232,8 +232,12 @@ BridgedClient.prototype.joinChannel = function(channel, key) {
 };
 
 BridgedClient.prototype.leaveChannel = function(channel, reason) {
-    reason = reason || "User left";
     if (this.disabled) { return Promise.resolve("disabled"); }
+    return this._leaveChannel(channel, reason);
+};
+
+BridgedClient.prototype._leaveChannel = function(channel, reason) {
+    reason = reason || "User left";
     if (!this.inst || this.inst.dead) {
         return Promise.resolve(); // we were never connected to the network.
     }
@@ -337,9 +341,14 @@ BridgedClient.prototype.whois = function(nick) {
 /**
  * Get the operators of a channel
  * @param {string} channel : The channel to call /names on
+ * @param {string} key : Optional. The key to use to join the channel.
  */
-BridgedClient.prototype.getOperators = function(channel) {
-    return this.getNicks(channel).then(function(nicksInfo) {
+BridgedClient.prototype.getOperators = function(channel, key) {
+    return this._joinChannel(channel, key).then(() => {
+        return this.getNicks(channel);
+    }).then((nicksInfo) => {
+        return this._leaveChannel(channel).then(() => nicksInfo);
+    }).then((nicksInfo) => {
         let nicks = nicksInfo.nicks;
 
         nicksInfo.operatorNicks = nicks.filter(

--- a/lib/provisioning/Provisioner.js
+++ b/lib/provisioning/Provisioner.js
@@ -39,6 +39,8 @@ var validationProperties = {
 
 function Provisioner(ircBridge, enabled, requestTimeoutSeconds) {
     this._ircBridge = ircBridge;
+    // Cache bot clients so as not to create duplicates
+    this._botClients = {};
     this._enabled = enabled;
     this._requestTimeoutSeconds = requestTimeoutSeconds;
     this._pendingRequests = {};
@@ -193,6 +195,15 @@ Provisioner.prototype.isProvisionRequest = function(req) {
             req.url === "/_matrix/provision/querylink"
 };
 
+// Returns a bridgedClient representing a bot for the given server
+Provisioner.prototype._getBotClientForServer = Promise.coroutine(
+    function*(server) {
+        if (!this._botClients[server.domain]) {
+            this._botClients[server.domain] = yield this._ircBridge.getBotClient(server);
+        }
+        return this._botClients[server.domain];
+});
+
 Provisioner.prototype._updateBridgingState = Promise.coroutine(
     function*(roomId, userId, status, skey) {
         let intent = this._ircBridge.getAppServiceBridge().getIntent();
@@ -272,8 +283,8 @@ Provisioner.prototype._authoriseProvisioning = Promise.coroutine(
 
         // (IRC) Check that op's nick is actually op
         log.info(`Check that op's nick is actually op`);
-        let botClient = yield this._ircBridge.getBotClient(server);
 
+        let botClient = yield this._getBotClientForServer(server);
         let info = yield botClient.getOperators(ircChannel, key);
 
         if (info.nicks.indexOf(opNick) === -1) {
@@ -308,22 +319,29 @@ Provisioner.prototype._authoriseProvisioning = Promise.coroutine(
     }
 );
 
+Provisioner.prototype._sendToUser = Promise.coroutine(
+    function*(receiverNick, server, message) {
+        let botClient = yield this._getBotClientForServer(server);
+        return this._ircBridge.sendIrcAction(
+            new IrcRoom(server, receiverNick),
+            botClient,
+            new IrcAction("message", message));
+    }
+);
+
 // Contact an operator, asking for authorisation for a mapping, and if they reply
 //  'yes' or 'y', create the mapping.
 Provisioner.prototype._createAuthorisedLink = Promise.coroutine(
     function*(botClient, server, opNick, ircChannel, key, roomId, userId, skey, timeoutSeconds) {
         let d = promiseutil.defer();
 
-        // Send PM to operator
-        let authRequestAction = new IrcAction("message",
+        this._setRequest(server, opNick, {userId: userId, defer: d});
+
+        yield this._sendToUser(opNick, server,
             `${userId} has requested to bridge ${roomId} with ${ircChannel} on this IRC ` +
             `network. Respond with 'yes' or 'y' to allow, or simply ignore this message to ` +
             `disallow. You have ${timeoutSeconds} seconds from when this message was sent.`);
-        let pmRoom = new IrcRoom(server, opNick);
 
-        this._setRequest(server, opNick, {userId: userId, defer: d});
-
-        this._ircBridge.sendIrcAction(pmRoom, botClient, authRequestAction);
         try {
             yield d.promise.timeout(timeoutSeconds * 1000);
             this._removeRequest(server, opNick);
@@ -366,20 +384,35 @@ Provisioner.prototype._setRequest = function (server, opNick, request) {
     this._pendingRequests[server.domain][opNick] = request;
 }
 
-Provisioner.prototype.handlePm = function(server, fromUser, text) {
+Provisioner.prototype.handlePm = Promise.coroutine(function*(server, fromUser, text) {
     if (['y', 'yes'].indexOf(text.trim().toLowerCase()) == -1) {
         log.warn(`Provisioner only handles text 'yes'/'y' ` +
                  `(from ${fromUser.nick} on ${server.domain})`);
+
+        this._sendToUser(
+            fromUser.nick, server,
+            'Please respond with "yes" or "y".'
+        );
         return;
     }
     let request = this._getRequest(server, fromUser.nick);
     if (request) {
         log.info(`${fromUser.nick} has authorised a new provisioning`);
         request.defer.resolve();
+
+        yield this._sendToUser(
+            fromUser.nick, server,
+            'Thanks for your response, bridge request authorised.'
+        );
+
         return;
     }
     log.warn(`Provisioner was not expecting PM from ${fromUser.nick} on ${server.domain}`);
-}
+    this._sendToUser(
+        fromUser.nick, server,
+        'The bot was not expecting a message from you. You might have already replied to a request.'
+    );
+});
 
 // Get information that might be useful prior to calling requestLink
 //  returns
@@ -417,7 +450,7 @@ Provisioner.prototype.queryLink = Promise.coroutine(function*(options) {
         throw new Error(`Server is configured to exclude channel ${ircChannel}`);
     }
 
-    let botClient = yield this._ircBridge.getBotClient(server);
+    let botClient = yield this._getBotClientForServer(server);
 
     let opsInfo = null;
 
@@ -513,8 +546,8 @@ Provisioner.prototype._doLink = Promise.coroutine(
         yield this._ircBridge.getStore().storeRoom(ircRoom, mxRoom, 'provision');
 
         // Cause the bot to join the new plumbed channel (if it is enabled (see joinChannel))
-        let botClient = yield this._ircBridge.getBotClient(server);
         // TODO: key not persisted on restart
+        let botClient = yield this._getBotClientForServer(server);
         botClient.joinChannel(ircChannel, key);
 
         // Cause the provisioner to join the IRC channel
@@ -572,7 +605,7 @@ Provisioner.prototype.unlink = Promise.coroutine(function*(options) {
     yield this._ircBridge.getStore().removeRoom(roomId, ircDomain, ircChannel, 'provision');
 
     // Cause the bot to part the channel (if it is enabled (see leaveChannel))
-    let botClient = yield this._ircBridge.getBotClient(server);
+    let botClient = yield this._getBotClientForServer(server);
     botClient.leaveChannel(ircChannel);
 });
 

--- a/lib/provisioning/Provisioner.js
+++ b/lib/provisioning/Provisioner.js
@@ -5,6 +5,8 @@ var IrcRoom = require("../models/IrcRoom");
 var IrcAction = require("../models/IrcAction");
 var MatrixRoom = require("matrix-appservice-bridge").MatrixRoom;
 var ConfigValidator = require("matrix-appservice-bridge").ConfigValidator;
+var MatrixUser = require("matrix-appservice-bridge").MatrixUser;
+var BridgeRequest = require("../models/BridgeRequest");
 
 var log = require("../logging").get("Provisioner");
 var promiseutil = require("../promiseutil.js");
@@ -271,9 +273,8 @@ Provisioner.prototype._authoriseProvisioning = Promise.coroutine(
         // (IRC) Check that op's nick is actually op
         log.info(`Check that op's nick is actually op`);
         let botClient = yield this._ircBridge.getBotClient(server);
-        yield botClient.joinChannel(ircChannel, key);
-        log.info(`Bot joined channel ${ircChannel}`);
-        let info = yield botClient.getOperators(ircChannel);
+
+        let info = yield botClient.getOperators(ircChannel, key);
 
         if (info.nicks.indexOf(opNick) === -1) {
             let knownOps = info.operatorNicks.join(', ');
@@ -302,7 +303,7 @@ Provisioner.prototype._authoriseProvisioning = Promise.coroutine(
         // Deliberately not yielding on this so that 200 OK is returned
         log.info(`Contacting operator`);
         this._createAuthorisedLink(
-            botClient, server, opNick, ircChannel,
+            botClient, server, opNick, ircChannel, key,
             roomId, userId, skey, timeoutSeconds);
     }
 );
@@ -310,7 +311,7 @@ Provisioner.prototype._authoriseProvisioning = Promise.coroutine(
 // Contact an operator, asking for authorisation for a mapping, and if they reply
 //  'yes' or 'y', create the mapping.
 Provisioner.prototype._createAuthorisedLink = Promise.coroutine(
-    function*(botClient, server, opNick, ircChannel, roomId, userId, skey, timeoutSeconds) {
+    function*(botClient, server, opNick, ircChannel, key, roomId, userId, skey, timeoutSeconds) {
         let d = promiseutil.defer();
 
         // Send PM to operator
@@ -334,7 +335,7 @@ Provisioner.prototype._createAuthorisedLink = Promise.coroutine(
             return;
         }
         try {
-            yield this._doLink(server, ircChannel, roomId);
+            yield this._doLink(server, ircChannel, key, roomId, userId);
         }
         catch (err) {
             log.info(`Failed to create link following authorisation (${err.message})`);
@@ -418,18 +419,10 @@ Provisioner.prototype.queryLink = Promise.coroutine(function*(options) {
 
     let botClient = yield this._ircBridge.getBotClient(server);
 
-    try {
-        yield botClient.joinChannel(ircChannel, key);
-    }
-    catch (err) {
-        log.error(err.stack);
-        throw new Error(`Bot cannot join channel ${ircChannel}`);
-    }
-
     let opsInfo = null;
 
     try {
-        opsInfo = yield botClient.getOperators(ircChannel);
+        opsInfo = yield botClient.getOperators(ircChannel, key);
     }
     catch (err) {
         log.error(err.stack);
@@ -503,7 +496,7 @@ Provisioner.prototype.requestLink = Promise.coroutine(function*(options) {
 });
 
 Provisioner.prototype._doLink = Promise.coroutine(
-    function*(server, ircChannel, roomId) {
+    function*(server, ircChannel, key, roomId, userId) {
         let ircDomain = server.domain;
         let mappingLogId = `${roomId} <---> ${ircDomain}/${ircChannel}`;
         log.info(`Provisioning link for room ${mappingLogId}`);
@@ -513,13 +506,35 @@ Provisioner.prototype._doLink = Promise.coroutine(
         let mxRoom = new MatrixRoom(roomId);
 
         let entry = yield this._ircBridge.getStore().getRoom(roomId, ircDomain, ircChannel);
-        if (!entry) {
-            yield this._ircBridge.getStore().storeRoom(ircRoom, mxRoom, 'provision');
-        }
-        else {
+        if (entry) {
             throw new Error(`Room mapping already exists (${mappingLogId},` +
                             `origin = ${entry.data.origin})`);
         }
+        yield this._ircBridge.getStore().storeRoom(ircRoom, mxRoom, 'provision');
+
+        // Cause the bot to join the new plumbed channel (if it is enabled (see joinChannel))
+        let botClient = yield this._ircBridge.getBotClient(server);
+        // TODO: key not persisted on restart
+        botClient.joinChannel(ircChannel, key);
+
+        // Cause the provisioner to join the IRC channel
+        var req = new BridgeRequest(
+            this._ircBridge._bridge.getRequestFactory().newRequest(), false
+        );
+        var target = new MatrixUser(userId);
+        // inject a fake join event which will do M->I connections and
+        // therefore sync the member list
+        return this._ircBridge.matrixHandler.onJoin(req, {
+            event_id: "$fake:membershiplist",
+            room_id: roomId,
+            state_key: userId,
+            user_id: userId,
+            content: {
+                membership: "join"
+            },
+            _injected: true,
+            _frontier: true,
+        }, target);
     }
 );
 

--- a/lib/provisioning/Provisioner.js
+++ b/lib/provisioning/Provisioner.js
@@ -285,6 +285,7 @@ Provisioner.prototype._authoriseProvisioning = Promise.coroutine(
         log.info(`Check that op's nick is actually op`);
 
         let botClient = yield this._getBotClientForServer(server);
+
         let info = yield botClient.getOperators(ircChannel, key);
 
         if (info.nicks.indexOf(opNick) === -1) {
@@ -356,6 +357,7 @@ Provisioner.prototype._createAuthorisedLink = Promise.coroutine(
             yield this._doLink(server, ircChannel, key, roomId, userId);
         }
         catch (err) {
+            log.error(err.stack);
             log.info(`Failed to create link following authorisation (${err.message})`);
             yield this._updateBridgingState(roomId, userId, 'failure', skey);
             this._removeRequest(server, opNick);
@@ -550,24 +552,30 @@ Provisioner.prototype._doLink = Promise.coroutine(
         let botClient = yield this._getBotClientForServer(server);
         botClient.joinChannel(ircChannel, key);
 
-        // Cause the provisioner to join the IRC channel
-        var req = new BridgeRequest(
-            this._ircBridge._bridge.getRequestFactory().newRequest(), false
-        );
-        var target = new MatrixUser(userId);
-        // inject a fake join event which will do M->I connections and
-        // therefore sync the member list
-        return this._ircBridge.matrixHandler.onJoin(req, {
-            event_id: "$fake:membershiplist",
-            room_id: roomId,
-            state_key: userId,
-            user_id: userId,
-            content: {
-                membership: "join"
-            },
-            _injected: true,
-            _frontier: true,
-        }, target);
+        try {
+            // Cause the provisioner to join the IRC channel
+            var req = new BridgeRequest(
+                this._ircBridge._bridge.getRequestFactory().newRequest(), false
+            );
+            var target = new MatrixUser(userId);
+            // inject a fake join event which will do M->I connections and
+            // therefore sync the member list
+            yield this._ircBridge.matrixHandler.onJoin(req, {
+                event_id: "$fake:membershiplist",
+                room_id: roomId,
+                state_key: userId,
+                user_id: userId,
+                content: {
+                    membership: "join"
+                },
+                _injected: true,
+                _frontier: true,
+            }, target);
+        }
+        catch (err) {
+            // Not fatal, so log error and return success
+            log.error(err);
+        }
     }
 );
 

--- a/lib/provisioning/Provisioner.js
+++ b/lib/provisioning/Provisioner.js
@@ -566,12 +566,14 @@ Provisioner.prototype.unlink = Promise.coroutine(function*(options) {
     let entry = yield this._ircBridge.getStore()
         .getRoom(roomId, ircDomain, ircChannel, 'provision');
 
-    if (entry) {
-        yield this._ircBridge.getStore().removeRoom(roomId, ircDomain, ircChannel, 'provision');
-    }
-    else {
+    if (!entry) {
         throw new Error(`Provisioned room mapping does not exist (${mappingLogId})`);
     }
+    yield this._ircBridge.getStore().removeRoom(roomId, ircDomain, ircChannel, 'provision');
+
+    // Cause the bot to part the channel (if it is enabled (see leaveChannel))
+    let botClient = yield this._ircBridge.getBotClient(server);
+    botClient.leaveChannel(ircChannel);
 });
 
 // List all mappings currently provisioned with the given matrix_room_id


### PR DESCRIPTION
- MatrixBot will now join and then part an IRC channel to get the operator nicks in a room.
- MatrixBot will now join and stay in a provisioned channel
- The provisioning matrix user will be 'fake joined' into the IRC channel
- The provisioner will respond to 'yes' or 'no' or any message the IRC chanop sends it with something a bit more useful, like confirmation of the provisioned mapping.
- Unlinking actually unlinks

TODO:
-  ```m.room.bridging```: Recall pending states so long as the ```sender``` is the same as the bridge bot **see #157**
- [x] Make the tests pass - tests really don't like injecting a fake event to join the provisioner to the bridged room
