### PR TITLE
Improved Provisioning

### DIFF
--- a/lib/irc/BridgedClient.js
+++ b/lib/irc/BridgedClient.js
@@ -349,7 +349,7 @@ BridgedClient.prototype.whois = function(nick) {
  * @param {integer} cacheDurationMs : Optional. The duration of time to keep a
  * list of operator nicks cached. If > 0, the operator nicks will be returned
  * whilst the cache is still valid and it will become invalid after cacheDurationMs
- * milliseconds.
+ * milliseconds. Cache will not be used if left undefined.
  */
 BridgedClient.prototype.getOperators = function(channel, key, cacheDurationMs) {
     if (typeof key !== 'string') {
@@ -366,11 +366,10 @@ BridgedClient.prototype.getOperators = function(channel, key, cacheDurationMs) {
         if (!(Number.isInteger(cacheDurationMs) && cacheDurationMs > 0)) {
             throw new Error('cacheDurationMs must be a positive integer');
         }
-    }
-
-    // If cached previously, use cache
-    if (typeof this._cachedOperatorNicksInfo[channel] !== 'undefined') {
-        return this._cachedOperatorNicksInfo[channel];
+        // If cached previously, use cache
+        if (typeof this._cachedOperatorNicksInfo[channel] !== 'undefined') {
+            return this._cachedOperatorNicksInfo[channel];
+        }
     }
 
     return this._joinChannel(channel, key).then(() => {

--- a/lib/irc/BridgedClient.js
+++ b/lib/irc/BridgedClient.js
@@ -68,6 +68,10 @@ function BridgedClient(server, ircClientConfig, matrixUser, isBot, eventBroker, 
             log.error.apply(log, arguments);
         }
     };
+
+    this._cachedOperatorNicksInfo = {
+        // $channel : info
+    };
 }
 util.inherits(BridgedClient, EventEmitter);
 
@@ -342,8 +346,33 @@ BridgedClient.prototype.whois = function(nick) {
  * Get the operators of a channel
  * @param {string} channel : The channel to call /names on
  * @param {string} key : Optional. The key to use to join the channel.
+ * @param {integer} cacheDurationMs : Optional. The duration of time to keep a
+ * list of operator nicks cached. If > 0, the operator nicks will be returned
+ * whilst the cache is still valid and it will become invalid after cacheDurationMs
+ * milliseconds.
  */
-BridgedClient.prototype.getOperators = function(channel, key) {
+BridgedClient.prototype.getOperators = function(channel, key, cacheDurationMs) {
+    if (typeof key !== 'string') {
+        if (!cacheDurationMs) {
+            cacheDurationMs = key;
+            key = undefined;
+        }
+        else {
+            throw new Error('key must be a string');
+        }
+    }
+
+    if (typeof cacheDurationMs !== 'undefined') {
+        if (!(Number.isInteger(cacheDurationMs) && cacheDurationMs > 0)) {
+            throw new Error('cacheDurationMs must be a positive integer');
+        }
+    }
+
+    // If cached previously, use cache
+    if (typeof this._cachedOperatorNicksInfo[channel] !== 'undefined') {
+        return this._cachedOperatorNicksInfo[channel];
+    }
+
     return this._joinChannel(channel, key).then(() => {
         return this.getNicks(channel);
     }).then((nicksInfo) => {
@@ -356,6 +385,15 @@ BridgedClient.prototype.getOperators = function(channel, key) {
                 return nicksInfo.names[nick] === '@'
             }
         );
+
+        if (typeof cacheDurationMs !== 'undefined') {
+            this._cachedOperatorNicksInfo[channel] = nicksInfo;
+            setTimeout(()=>{
+                //Invalidate the cache
+                delete this._cachedOperatorNicksInfo[channel];
+            }, cacheDurationMs);
+        }
+
         return nicksInfo;
     });
 };

--- a/lib/irc/BridgedClient.js
+++ b/lib/irc/BridgedClient.js
@@ -352,14 +352,17 @@ BridgedClient.prototype.whois = function(nick) {
  * milliseconds. Cache will not be used if left undefined.
  */
 BridgedClient.prototype.getOperators = function(channel, key, cacheDurationMs) {
-    if (typeof key !== 'string') {
-        if (!cacheDurationMs) {
+
+    // Two arguments provided, the second is cacheDurationMs if it is an integer
+    if (cacheDurationMs === undefined) {
+        if (key !== undefined && Number.isInteger(key)) {
             cacheDurationMs = key;
             key = undefined;
         }
-        else {
-            throw new Error('key must be a string');
-        }
+    }
+
+    if (key !== undefined && typeof key !== 'string') {
+        throw new Error('key must be string');
     }
 
     if (typeof cacheDurationMs !== 'undefined') {
@@ -368,7 +371,7 @@ BridgedClient.prototype.getOperators = function(channel, key, cacheDurationMs) {
         }
         // If cached previously, use cache
         if (typeof this._cachedOperatorNicksInfo[channel] !== 'undefined') {
-            return this._cachedOperatorNicksInfo[channel];
+            return Promise.resolve(this._cachedOperatorNicksInfo[channel]);
         }
     }
 

--- a/lib/irc/BridgedClient.js
+++ b/lib/irc/BridgedClient.js
@@ -345,24 +345,19 @@ BridgedClient.prototype.whois = function(nick) {
 /**
  * Get the operators of a channel
  * @param {string} channel : The channel to call /names on
- * @param {string} key : Optional. The key to use to join the channel.
- * @param {integer} cacheDurationMs : Optional. The duration of time to keep a
- * list of operator nicks cached. If > 0, the operator nicks will be returned
- * whilst the cache is still valid and it will become invalid after cacheDurationMs
- * milliseconds. Cache will not be used if left undefined.
+ * @param {object} opts: Optional. An object containing the following key-value pairs:
+ *     @param {string} key : Optional. The key to use to join the channel.
+ *     @param {integer} cacheDurationMs : Optional. The duration of time to keep a
+ *         list of operator nicks cached. If > 0, the operator nicks will be returned
+ *         whilst the cache is still valid and it will become invalid after cacheDurationMs
+ *         milliseconds. Cache will not be used if left undefined.
  */
-BridgedClient.prototype.getOperators = function(channel, key, cacheDurationMs) {
+BridgedClient.prototype.getOperators = function(channel, opts) {
+    let key = opts.key;
+    let cacheDurationMs = opts.cacheDurationMs;
 
-    // Two arguments provided, the second is cacheDurationMs if it is an integer
-    if (cacheDurationMs === undefined) {
-        if (key !== undefined && Number.isInteger(key)) {
-            cacheDurationMs = key;
-            key = undefined;
-        }
-    }
-
-    if (key !== undefined && typeof key !== 'string') {
-        throw new Error('key must be string');
+    if (typeof key !== 'undefined' && typeof key !== 'string') {
+        throw new Error('key must be a string');
     }
 
     if (typeof cacheDurationMs !== 'undefined') {

--- a/lib/provisioning/Provisioner.js
+++ b/lib/provisioning/Provisioner.js
@@ -689,9 +689,14 @@ Provisioner.prototype.unlink = Promise.coroutine(function*(options) {
     }
     yield this._ircBridge.getStore().removeRoom(roomId, ircDomain, ircChannel, 'provision');
 
-    // Cause the bot to part the channel (if it is enabled (see leaveChannel))
-    let botClient = yield this._getBotClientForServer(server);
-    yield botClient.leaveChannel(ircChannel);
+    // Cause the bot to part the channel if there are no other rooms being mapped to this channel
+    //  (and if it is enabled (see leaveChannel))
+
+    yield mappings = this._ircBridge.getStore().getMatrixRoomsForChannel(ircChannel);
+    if (mappings.length === 0) {
+        let botClient = yield this._getBotClientForServer(server);
+        yield botClient.leaveChannel(ircChannel);
+    }
 });
 
 // List all mappings currently provisioned with the given matrix_room_id

--- a/lib/provisioning/Provisioner.js
+++ b/lib/provisioning/Provisioner.js
@@ -578,8 +578,16 @@ Provisioner.prototype.requestLink = Promise.coroutine(function*(options) {
         this._linkValidator.validate(options);
     }
     catch (err) {
-        log.error(err);
-        throw new Error("Malformed parameters");
+        if (err._validationErrors) {
+            let s = err._validationErrors.map((e)=>{
+                return `${e.instanceContext} is malformed`;
+            }).join(', ');
+            throw new Error(s);
+        }
+        else {
+            log.error(err);
+            throw new Error('Malformed parameters');
+        }
     }
 
     let ircDomain = options.remote_room_server;
@@ -674,8 +682,16 @@ Provisioner.prototype.unlink = Promise.coroutine(function*(options) {
         this._unlinkValidator.validate(options);
     }
     catch (err) {
-        log.error(err);
-        throw new Error("Malformed parameters");
+        if (err._validationErrors) {
+            let s = err._validationErrors.map((e)=>{
+                return `${e.instanceContext} is malformed`;
+            }).join(', ');
+            throw new Error(s);
+        }
+        else {
+            log.error(err);
+            throw new Error('Malformed parameters');
+        }
     }
 
     let ircDomain = options.remote_room_server;
@@ -704,7 +720,7 @@ Provisioner.prototype.unlink = Promise.coroutine(function*(options) {
     // Cause the bot to part the channel if there are no other rooms being mapped to this channel
     //  (and if it is enabled (see leaveChannel))
 
-    yield mappings = this._ircBridge.getStore().getMatrixRoomsForChannel(ircChannel);
+    let mappings = yield this._ircBridge.getStore().getMatrixRoomsForChannel(server, ircChannel);
     if (mappings.length === 0) {
         let botClient = yield this._getBotClientForServer(server);
         yield botClient.leaveChannel(ircChannel);

--- a/lib/provisioning/Provisioner.js
+++ b/lib/provisioning/Provisioner.js
@@ -546,7 +546,7 @@ Provisioner.prototype.queryLink = Promise.coroutine(function*(options) {
     let opsInfo = null;
 
     try {
-        opsInfo = yield botClient.getOperators(ircChannel, key);
+        opsInfo = yield botClient.getOperators(ircChannel, key, 10000);
     }
     catch (err) {
         log.error(err.stack);

--- a/lib/provisioning/Provisioner.js
+++ b/lib/provisioning/Provisioner.js
@@ -291,15 +291,11 @@ Provisioner.prototype._authoriseProvisioning = Promise.coroutine(
         let info = yield botClient.getOperators(ircChannel, key);
 
         if (info.nicks.indexOf(opNick) === -1) {
-            let knownOps = info.operatorNicks.join(', ');
-            throw new Error(`Provided user is not in channel ${ircChannel}. ` +
-                            `Known ops in this channel: ${knownOps}`);
+            throw new Error(`Provided user is not in channel ${ircChannel}.`);
         }
 
         if (info.operatorNicks.indexOf(opNick) === -1) {
-            let knownOps = info.operatorNicks.join(', ');
-            throw new Error(`Provided user is not an op of ${ircChannel}. ` +
-                            `Known ops in this channel: ${knownOps}`);
+            throw new Error(`Provided user is not an op of ${ircChannel}.`);
         }
 
         // State key for m.room.bridging
@@ -349,8 +345,17 @@ Provisioner.prototype._authoriseProvisioning = Promise.coroutine(
                         // This indicates success, so check that the mapping exists in the
                         //  database
 
-                        let entry = yield this._ircBridge.getStore()
-                            .getRoom(roomId, ircDomain, ircChannel, 'provision');
+                        let entry = null;
+                        try {
+                            entry = yield this._ircBridge.getStore()
+                                .getRoom(roomId, ircDomain, ircChannel, 'provision');
+                        }
+                        catch (err) {
+                            console.error(err);
+                            throw new Error(`Error whilst checking for previously ` +
+                                            `successful provisioning of ` +
+                                            `${roomId}<-->${ircChannel}`);
+                        }
 
                         if (!entry) {
                             // Update the bridging state to be a failure
@@ -358,7 +363,15 @@ Provisioner.prototype._authoriseProvisioning = Promise.coroutine(
                                      `but the bridge is not aware of provisioning. The ` +
                                      `bridge will update the state in the room to failure ` +
                                      `and continue with the provisioning request.`);
-                            yield this._updateBridgingState(roomId, userId, 'failure', skey);
+                            try {
+                                yield this._updateBridgingState(roomId, userId, 'failure', skey);
+                            }
+                            catch (err) {
+                                console.error(err);
+                                throw new Error(`Bridging state success and mapping does not ` +
+                                                `exist, but could not update bridging state ` +
+                                                `${skey} of ${roomId} to failure.`);
+                            }
                         }
                     } // If pending, resend the message to the op as if it were the original
                     else if (bridgingState.status === 'pending') {
@@ -597,8 +610,7 @@ Provisioner.prototype.requestLink = Promise.coroutine(function*(options) {
         }
         catch (err) {
             console.error(err.stack);
-            // TODO: Provide more interesting errors back to the requester
-            throw new Error('Failed to authorise provisioning');
+            throw err;
         }
     }
     else {

--- a/lib/provisioning/Provisioner.js
+++ b/lib/provisioning/Provisioner.js
@@ -288,7 +288,7 @@ Provisioner.prototype._authoriseProvisioning = Promise.coroutine(
 
         let botClient = yield this._getBotClientForServer(server);
 
-        let info = yield botClient.getOperators(ircChannel, key);
+        let info = yield botClient.getOperators(ircChannel, {key : key});
 
         if (info.nicks.indexOf(opNick) === -1) {
             throw new Error(`Provided user is not in channel ${ircChannel}.`);
@@ -546,7 +546,7 @@ Provisioner.prototype.queryLink = Promise.coroutine(function*(options) {
     let opsInfo = null;
 
     try {
-        opsInfo = yield botClient.getOperators(ircChannel, key, 10000);
+        opsInfo = yield botClient.getOperators(ircChannel, {key: key, cacheDurationMs: 10000});
     }
     catch (err) {
         log.error(err.stack);


### PR DESCRIPTION
- Bot only leaves when it the bridge no longer maps that IRC channel
- Better error messages given when linking
- Cache operator nicks per channel for 10s when using ```queryLink```