### PR TITLE
Only respond to room alias requests that embed a valid IRC channel name

### DIFF
--- a/lib/irc/IrcServer.js
+++ b/lib/irc/IrcServer.js
@@ -237,7 +237,7 @@ IrcServer.prototype.claimsAlias = function(alias) {
             "$SERVER": this.domain
         },
         {
-            "$CHANNEL": "(.*)"
+            "$CHANNEL": "#(.*)"
         },
         ":.*"
     );


### PR DESCRIPTION
I.e. channel names that start with a # (fixes #161)