### PR TITLE
Use 3PL to get provisioning queryNetworks info

### DIFF
--- a/lib/bridge/IrcBridge.js
+++ b/lib/bridge/IrcBridge.js
@@ -428,11 +428,11 @@ IrcBridge.prototype.getThirdPartyProtocol = function(protocol) {
     var servers = this.getServers();
 
     return Promise.resolve({
-        "bot_user_id": this.getAppServiceUserId(),
         "user_fields": ["domain", "nick"],
         "location_fields": ["domain", "channel"],
         "instances": servers.map(function (server) {
             return {
+                bot_user_id: this.getAppServiceUserId(),
                 desc: server.config.description || server.domain,
                 icon: server.config.icon,
                 fields: {

--- a/lib/bridge/IrcBridge.js
+++ b/lib/bridge/IrcBridge.js
@@ -428,6 +428,7 @@ IrcBridge.prototype.getThirdPartyProtocol = function(protocol) {
     var servers = this.getServers();
 
     return Promise.resolve({
+        "bot_user_id": this.getAppServiceUserId(),
         "user_fields": ["domain", "nick"],
         "location_fields": ["domain", "channel"],
         "instances": servers.map(function (server) {

--- a/lib/bridge/IrcBridge.js
+++ b/lib/bridge/IrcBridge.js
@@ -430,7 +430,7 @@ IrcBridge.prototype.getThirdPartyProtocol = function(protocol) {
     return Promise.resolve({
         "user_fields": ["domain", "nick"],
         "location_fields": ["domain", "channel"],
-        "instances": servers.map(function (server) {
+        "instances": servers.map((server) => {
             return {
                 bot_user_id: this.getAppServiceUserId(),
                 desc: server.config.description || server.domain,

--- a/lib/provisioning/Provisioner.js
+++ b/lib/provisioning/Provisioner.js
@@ -565,10 +565,13 @@ Provisioner.prototype.queryLink = Promise.coroutine(function*(options) {
     return queryInfo;
 });
 
-// Get the list of currently configured networks (from the config)
+// Get the list of currently network instances
 Provisioner.prototype.queryNetworks = Promise.coroutine(function*() {
+    let thirdParty = yield this._ircBridge.getThirdPartyProtocol();
+
     return {
-        servers: this._ircBridge.ircServers.map((server) => {return server.domain})
+        bot_user_id: thirdParty.bot_user_id,
+        servers: thirdParty.instances
     };
 });
 

--- a/lib/provisioning/Provisioner.js
+++ b/lib/provisioning/Provisioner.js
@@ -570,7 +570,6 @@ Provisioner.prototype.queryNetworks = Promise.coroutine(function*() {
     let thirdParty = yield this._ircBridge.getThirdPartyProtocol();
 
     return {
-        bot_user_id: thirdParty.bot_user_id,
         servers: thirdParty.instances
     };
 });


### PR DESCRIPTION
Also, pass ```bot_user_id``` when acquiring 3PL