### PR TITLE
Prevent admin room from being created when plumbing

### DIFF
--- a/lib/bridge/MatrixHandler.js
+++ b/lib/bridge/MatrixHandler.js
@@ -40,6 +40,25 @@ MatrixHandler.prototype._handleAdminRoomInvite = Promise.coroutine(function*(req
     // Real MX user inviting BOT to a private chat
     let mxRoom = new MatrixRoom(event.room_id);
     yield this.ircBridge.getAppServiceBridge().getIntent().join(event.room_id);
+
+    // Do not create an admin room if the room is marked as 'plumbed'
+    let matrixClient = this._ircBridge.getAppServiceBridge().getClientFactory().getClientAs();
+
+    try {
+        let plumbedState = yield matrixClient.getStateEvent(event.room_id, 'm.room.plumbing');
+
+        if (plumbedState.status === "enabled") {
+            log.info(
+                'This room is marked for plumbing (m.room.plumbing.status = "enabled"). ' +
+                'Not treating room as admin room.'
+            );
+            return Promise.resolve();
+        }
+    }
+    catch (err) {
+        log.error(`Error retrieving power levels (${err.data.error})`);
+    }
+
     // clobber any previous admin room ID
     yield this.ircBridge.getStore().storeAdminRoom(mxRoom, inviter.userId);
 });

--- a/lib/bridge/MatrixHandler.js
+++ b/lib/bridge/MatrixHandler.js
@@ -42,7 +42,7 @@ MatrixHandler.prototype._handleAdminRoomInvite = Promise.coroutine(function*(req
     yield this.ircBridge.getAppServiceBridge().getIntent().join(event.room_id);
 
     // Do not create an admin room if the room is marked as 'plumbed'
-    let matrixClient = this._ircBridge.getAppServiceBridge().getClientFactory().getClientAs();
+    let matrixClient = this.ircBridge.getAppServiceBridge().getClientFactory().getClientAs();
 
     try {
         let plumbedState = yield matrixClient.getStateEvent(event.room_id, 'm.room.plumbing');

--- a/lib/bridge/MatrixHandler.js
+++ b/lib/bridge/MatrixHandler.js
@@ -48,7 +48,7 @@ MatrixHandler.prototype._handleAdminRoomInvite = Promise.coroutine(function*(req
         let plumbedState = yield matrixClient.getStateEvent(event.room_id, 'm.room.plumbing');
 
         if (plumbedState.status === "enabled") {
-            log.info(
+            req.log.info(
                 'This room is marked for plumbing (m.room.plumbing.status = "enabled"). ' +
                 'Not treating room as admin room.'
             );
@@ -56,7 +56,7 @@ MatrixHandler.prototype._handleAdminRoomInvite = Promise.coroutine(function*(req
         }
     }
     catch (err) {
-        log.error(`Error retrieving power levels (${err.data.error})`);
+        req.log.info(`Not a plumbed room: Error retrieving m.room.plumbing (${err.data.error})`);
     }
 
     // clobber any previous admin room ID


### PR DESCRIPTION
The bridge will not create an admin room if there is plumbing state in the room of the form:

```JS
m.room.plumbing: {
    content: {
        status: "enabled"
    },
    ...
}
```