### PR TITLE
Improved admin room details

### DIFF
--- a/lib/bridge/IrcHandler.js
+++ b/lib/bridge/IrcHandler.js
@@ -441,7 +441,7 @@ IrcHandler.prototype.onMetadata = Promise.coroutine(function*(req, client, msg) 
         let response = yield this.ircBridge.getAppServiceBridge().getIntent().createRoom({
             createAsClient: false,
             options: {
-                name: "IRC Application Service",
+                name: "IRC Admin Room",
                 preset: "trusted_private_chat",
                 visibility: "private",
                 invite: [client.userId]

--- a/lib/bridge/MatrixHandler.js
+++ b/lib/bridge/MatrixHandler.js
@@ -205,6 +205,12 @@ MatrixHandler.prototype._onAdminMessage = Promise.coroutine(function*(req, event
         }
     }
 
+    let fmt = '\n\tirc.example.com\n'+
+                '\t(JOIN [arg0 [arg1 [...]]])\n'+
+                '\tirc.example2.com\n' +
+                '\t(KICK [arg0 [arg1 [...]]])\n'+
+                '\t(COMMAND [arg0 [arg1 [...]]])';
+
     if (cmd === "!nick") {
         // Format is: "!nick irc.example.com NewNick"
         if (!ircServer.allowsNickChanges()) {
@@ -400,19 +406,18 @@ MatrixHandler.prototype._onAdminMessage = Promise.coroutine(function*(req, event
     }
     else if (cmd === "!help") {
         let notice = new MatrixAction("notice",
-            `Valid commands:
-            !join irc.example.com #channel [key]
-            !nick irc.example.com DesiredNick
-            !whois nick`
+            `This is an IRC admin room for sending commands directly to IRC. Commands ` +
+            `can be sent all as one message, but these will not reply with any information:` +
+            fmt +
+            `\nOr if feedback is desired, the following commands can be used:\n` +
+            `\t!join irc.example.com #channel [key]\n` +
+            `\t!nick irc.example.com DesiredNick\n` +
+            `\t!whois nick\n`
         );
         yield this.ircBridge.sendMatrixAction(adminRoom, botUser, notice, req);
         return;
     }
     else {
-        let fmt = '\nirc.server\n'+
-                    '(COMMAND [arg0 [arg1 [...]]])\n'+
-                    '(COMMAND [arg0 [arg1 [...]]])\n'+
-                    'irc.server2';
         req.log.info(`No valid (old form) admin command, will try new format`);
 
         // Assumes commands have the form

--- a/lib/irc/BridgedClient.js
+++ b/lib/irc/BridgedClient.js
@@ -134,10 +134,10 @@ BridgedClient.prototype.connect = Promise.coroutine(function*() {
         this._keepAlive();
 
         this._eventBroker.sendMetadata(this,
-            `You've been connected to the IRC network '${this.server.domain}' as ` +
-            `${this.nick}. This room can be used to send commands directly through ` +
-            `your personal connection to the connected IRC networks. Type !help for ` +
-            `more information.`
+            `You've joined a Matrix room which is bridged to the IRC network ` +
+            `'${this.server.domain}', where you are now connected as ${this.nick}. ` +
+            `This room shows any errors or status messags from IRC, as well as ` +
+            `letting you control the connection. Type !help for more information.`
         );
 
 

--- a/lib/irc/BridgedClient.js
+++ b/lib/irc/BridgedClient.js
@@ -135,7 +135,9 @@ BridgedClient.prototype.connect = Promise.coroutine(function*() {
 
         this._eventBroker.sendMetadata(this,
             `You've been connected to the IRC network '${this.server.domain}' as ` +
-            `${this.nick}.`
+            `${this.nick}. This room can be used to send commands directly through ` +
+            `your personal connection to the connected IRC networks. Type !help for ` +
+            `more information.`
         );
 
 


### PR DESCRIPTION
Mostly to stop confusion regarding it's use/behaviour.

Upon joining a network, the bot will invite the user to a room called 'IRC Admin Room', if the admin room does not already exist. The message sent upon connecting to a network now looks like:

> You've been connected to the IRC network 'localhost' as Lukeb[m]. This room can be used to send commands directly through your personal connection to connected IRC networks. Type !help for more information.

Sending '!help' will now give:
```
This is an IRC admin room for sending commands directly to IRC.
Commands can be sent all as one message, but these will not reply with any information:
	irc.server
	(JOIN [arg0 [arg1 [...]]])
	irc.server2
	(KICK [arg0 [arg1 [...]]])
	(COMMAND [arg0 [arg1 [...]]])
Or if feedback is desired, the following commands can be used:
	!join irc.example.com #channel [key]
	!nick irc.example.com DesiredNick
	!whois nick
```