### PR TITLE
Improve admin room messages 

### DIFF
--- a/lib/bridge/IrcHandler.js
+++ b/lib/bridge/IrcHandler.js
@@ -455,7 +455,7 @@ IrcHandler.prototype.onMetadata = Promise.coroutine(function*(req, client, msg) 
                          `'${client.server.domain}', where you ` +
                          `are now connected as ${client.nick}. ` +
                          `This room shows any errors or status messages from IRC, as well as ` +
-                         `letting you control the connection. Type !help for more information)`
+                         `letting you control the connection. Type !help for more information`
 
         let notice = new MatrixAction("notice", newRoomMsg);
         yield this.ircBridge.sendMatrixAction(adminRoom, botUser, notice, req);

--- a/lib/bridge/IrcHandler.js
+++ b/lib/bridge/IrcHandler.js
@@ -435,6 +435,8 @@ IrcHandler.prototype.onMetadata = Promise.coroutine(function*(req, client, msg) 
         req.log.info("Suppressing metadata: not started up.");
         return;
     }
+    let botUser = new MatrixUser(this.ircBridge.getAppServiceUserId());
+
     let adminRoom = yield this.ircBridge.getStore().getAdminRoomByUserId(client.userId);
     if (!adminRoom) {
         req.log.info("Creating an admin room with %s", client.userId);
@@ -449,8 +451,16 @@ IrcHandler.prototype.onMetadata = Promise.coroutine(function*(req, client, msg) 
         });
         adminRoom = new MatrixRoom(response.room_id);
         yield this.ircBridge.getStore().storeAdminRoom(adminRoom, client.userId);
+        let newRoomMsg = `You've joined a Matrix room which is bridged to the IRC network ` +
+                         `'${client.server.domain}', where you ` +
+                         `are now connected as ${client.nick}. ` +
+                         `This room shows any errors or status messags from IRC, as well as ` +
+                         `letting you control the connection. Type !help for more information);`
+
+        let notice = new MatrixAction("notice", newRoomMsg);
+        yield this.ircBridge.sendMatrixAction(adminRoom, botUser, notice, req);
     }
-    let botUser = new MatrixUser(this.ircBridge.getAppServiceUserId());
+
     let notice = new MatrixAction("notice", msg);
     yield this.ircBridge.sendMatrixAction(adminRoom, botUser, notice, req);
 });

--- a/lib/bridge/IrcHandler.js
+++ b/lib/bridge/IrcHandler.js
@@ -454,8 +454,8 @@ IrcHandler.prototype.onMetadata = Promise.coroutine(function*(req, client, msg) 
         let newRoomMsg = `You've joined a Matrix room which is bridged to the IRC network ` +
                          `'${client.server.domain}', where you ` +
                          `are now connected as ${client.nick}. ` +
-                         `This room shows any errors or status messags from IRC, as well as ` +
-                         `letting you control the connection. Type !help for more information);`
+                         `This room shows any errors or status messages from IRC, as well as ` +
+                         `letting you control the connection. Type !help for more information)`
 
         let notice = new MatrixAction("notice", newRoomMsg);
         yield this.ircBridge.sendMatrixAction(adminRoom, botUser, notice, req);

--- a/lib/irc/BridgedClient.js
+++ b/lib/irc/BridgedClient.js
@@ -134,12 +134,9 @@ BridgedClient.prototype.connect = Promise.coroutine(function*() {
         this._keepAlive();
 
         this._eventBroker.sendMetadata(this,
-            `You've joined a Matrix room which is bridged to the IRC network ` +
-            `'${this.server.domain}', where you are now connected as ${this.nick}. ` +
-            `This room shows any errors or status messags from IRC, as well as ` +
-            `letting you control the connection. Type !help for more information.`
+            `You've been connected to the IRC network '${this.server.domain}' as ` +
+            `${this.nick}. `
         );
-
 
         connInst.client.addListener("nick", (old, newNick) => {
             if (old === this.nick) {


### PR DESCRIPTION
Following on from #171

When a client is connected to the IRC network, they now only see a minimal message in the IRC admin room, "You've been connected to _ as _". 

When the admin room is first created (only if one doesn't already exist) a message is sent to the admin room saying, ```"You've joined a Matrix room which is bridged to the IRC network '...', where you are now connected as '...'. This room shows any errors or status messages from IRC, as well as letting you control the connection. Type !help for more information)".```