### PR TITLE
Remove `disabled` property on `BridgedClient`

### DIFF
--- a/lib/bridge/IrcBridge.js
+++ b/lib/bridge/IrcBridge.js
@@ -14,6 +14,7 @@ var ClientPool = require("../irc/ClientPool");
 var IrcEventBroker = require("../irc/IrcEventBroker");
 var BridgedClient = require("../irc/BridgedClient");
 var IrcUser = require("../models/IrcUser");
+var IrcRoom = require("../models/IrcRoom");
 var IrcClientConfig = require("../models/IrcClientConfig");
 var BridgeRequest = require("../models/BridgeRequest");
 var stats = require("../config/stats");
@@ -574,6 +575,10 @@ IrcBridge.prototype.matrixToIrcUser = function(user) {
 };
 
 IrcBridge.prototype.trackChannel = function(server, channel, key) {
+    if (!server.isBotEnabled()) {
+        log.info("trackChannel: Bot is disabled.");
+        return Promise.resolve(new IrcRoom(server, channel));
+    }
     return this.getBotClient(server).then(function(client) {
         return client.joinChannel(channel, key);
     }).catch(log.logErr);
@@ -592,16 +597,18 @@ IrcBridge.prototype._loginToServer = Promise.coroutine(function*(server) {
         var botIrcConfig = server.createBotIrcClientConfig(uname);
         bridgedClient = this._clientPool.createIrcClient(botIrcConfig, null, true);
         log.debug(
-            "Created new bot client for %s (disabled=%s): %s",
-            server.domain, bridgedClient.disabled, bridgedClient._id
+            "Created new bot client for %s : %s (bot enabled=%s)",
+            server.domain, bridgedClient._id, server.isBotEnabled()
         );
     }
     var chansToJoin = [];
-    if (server.shouldJoinChannelsIfNoUsers()) {
-        chansToJoin = yield this.getStore().getTrackedChannelsForServer(server.domain);
-    }
-    else {
-        chansToJoin = yield this.memberListSyncers[server.domain].getChannelsToJoin();
+    if (server.isBotEnabled()) {
+        if (server.shouldJoinChannelsIfNoUsers()) {
+            chansToJoin = yield this.getStore().getTrackedChannelsForServer(server.domain);
+        }
+        else {
+            chansToJoin = yield this.memberListSyncers[server.domain].getChannelsToJoin();
+        }
     }
     log.info("Bot connecting to %s (%s channels) => %s",
         server.domain, chansToJoin.length, JSON.stringify(chansToJoin)
@@ -641,6 +648,10 @@ IrcBridge.prototype.checkNickExists = function(server, nick) {
 };
 
 IrcBridge.prototype.joinBot = function(ircRoom) {
+    if (!ircRoom.server.isBotEnabled()) {
+        log.info("joinBot: Bot is disabled.");
+        return Promise.resolve();
+    }
     return this.getBotClient(ircRoom.server).then((client) => {
         return client.joinChannel(ircRoom.channel);
     }).catch((e) => {

--- a/lib/bridge/IrcHandler.js
+++ b/lib/bridge/IrcHandler.js
@@ -303,7 +303,7 @@ IrcHandler.prototype.onKick = Promise.coroutine(function*(req, server,
         let bridgedIrcClient = this.ircBridge.getClientPool().getBridgedClientByNick(
             server, kickee.nick
         );
-        if (!bridgedIrcClient) {
+        if (!bridgedIrcClient || bridgedIrcClient.isBot) {
             return; // unexpected given isVirtual == true, but meh, bail.
         }
         let promises = matrixRooms.map((room) => {

--- a/lib/irc/BridgedClient.js
+++ b/lib/irc/BridgedClient.js
@@ -40,7 +40,6 @@ function BridgedClient(server, ircClientConfig, matrixUser, isBot, eventBroker, 
     this.userId = matrixUser ? this.matrixUser.getId() : null;
 
     this.isBot = Boolean(isBot);
-    this.disabled = this.isBot && !server.isBotEnabled();
     this.lastActionTs = Date.now();
     this.inst = null;
     this.instCreationFailed = false;
@@ -232,12 +231,10 @@ BridgedClient.prototype.changeNick = function(newNick) {
 };
 
 BridgedClient.prototype.joinChannel = function(channel, key) {
-    if (this.disabled) { return Promise.resolve(new IrcRoom(this.server, channel)); }
     return this._joinChannel(channel, key);
 };
 
 BridgedClient.prototype.leaveChannel = function(channel, reason) {
-    if (this.disabled) { return Promise.resolve("disabled"); }
     return this._leaveChannel(channel, reason);
 };
 
@@ -266,7 +263,6 @@ BridgedClient.prototype._leaveChannel = function(channel, reason) {
 
 BridgedClient.prototype.kick = function(nick, channel, reason) {
     reason = reason || "User kicked";
-    if (this.disabled) { return Promise.resolve("disabled"); }
     if (!this.inst || this.inst.dead) {
         return Promise.resolve(); // we were never connected to the network.
     }
@@ -286,7 +282,6 @@ BridgedClient.prototype.kick = function(nick, channel, reason) {
 };
 
 BridgedClient.prototype.sendAction = function(room, action) {
-    if (this.disabled) { return Promise.resolve("disabled"); }
     this._keepAlive();
     switch (action.type) {
         case "message":
@@ -308,12 +303,6 @@ BridgedClient.prototype.sendAction = function(room, action) {
  * @param {string} nick : The nick to call /whois on
  */
 BridgedClient.prototype.whois = function(nick) {
-    if (this.disabled) {
-        return Promise.resolve({
-            server: this.server,
-            nick: nick
-        });
-    }
     var self = this;
     return new Promise(function(resolve, reject) {
         self.unsafeClient.whois(nick, function(whois) {
@@ -401,14 +390,6 @@ BridgedClient.prototype.getOperators = function(channel, opts) {
  * @param {string} channel : The channel to call /names on
  */
 BridgedClient.prototype.getNicks = function(channel) {
-    if (this.disabled) {
-        return Promise.resolve({
-            server: this.server,
-            channel: channel,
-            nicks: [],
-            names: {}
-        });
-    }
     var self = this;
     return new Promise(function(resolve, reject) {
         self.unsafeClient.names(channel, function(channelName, names) {

--- a/lib/irc/BridgedClient.js
+++ b/lib/irc/BridgedClient.js
@@ -32,7 +32,6 @@ function BridgedClient(server, ircClientConfig, matrixUser, isBot, eventBroker, 
     this._ipv6Generator = ipv6Generator;
     this._clientConfig = ircClientConfig;
     this.matrixUser = matrixUser;
-
     this.server = server;
     this.nick = this._getValidNick(ircClientConfig.getDesiredNick(), false);
     this.password = (


### PR DESCRIPTION
It makes little semantic sense to cripple most methods of an instance like this.
The checks for "should I call this function or not" should be the responsibility
of the caller. This bodge was added in a long time ago to make it faster to
deploy a no-bot bridge. This has now been done properly, where the bridge
performs `server.isBotEnabled()` checks at key points (joining channels) rather
than blindly disabling huge wodges of functionality of a `BridgedClient`. This
is important because `Provisioning` *requires* a working bot client and not a
crippled one.