### PR TITLE
If the bot is enabled, join the bot to the channel post-provision

### DIFF
--- a/lib/provisioning/Provisioner.js
+++ b/lib/provisioning/Provisioner.js
@@ -650,12 +650,15 @@ Provisioner.prototype._doLink = Promise.coroutine(
             throw new Error(`Room mapping already exists (${mappingLogId},` +
                             `origin = ${entry.data.origin})`);
         }
-        yield this._ircBridge.getStore().storeRoom(ircRoom, mxRoom, 'provision');
 
-        // Cause the bot to join the new plumbed channel (if it is enabled (see joinChannel))
+        // Cause the bot to join the new plumbed channel if it is enabled
         // TODO: key not persisted on restart
-        let botClient = yield this._getBotClientForServer(server);
-        yield botClient.joinChannel(ircChannel, key);
+        if (server.isBotEnabled()) {
+            let botClient = yield this._getBotClientForServer(server);
+            yield botClient.joinChannel(ircChannel, key);
+        }
+
+        yield this._ircBridge.getStore().storeRoom(ircRoom, mxRoom, 'provision');
 
         try {
             // Cause the provisioner to join the IRC channel


### PR DESCRIPTION
Move the join to BEFORE we store the mapping in the database: if the bot is
enabled and cannot join the channel, then arguably the link is *not* successful
and we shouldn't update the database to say that the link is made.