### PR TITLE
Part IRC clients which should no longer be in a channel due to unlinking

### DIFF
--- a/lib/provisioning/Provisioner.js
+++ b/lib/provisioning/Provisioner.js
@@ -239,8 +239,7 @@ Provisioner.prototype._userHasProvisioningPower = Promise.coroutine(
 
         // In 10 minutes
         setTimeout(() => {
-            // Leave matrix room if unprovisioned
-            this._leaveRoomIfUnprovisioned(roomId);
+            this._leaveMatrixRoomIfUnprovisioned(roomId);
         }, 10 * 60 * 1000);
 
         let actualPower = 0;
@@ -738,11 +737,18 @@ Provisioner.prototype.unlink = Promise.coroutine(function*(options) {
 });
 
 // Force the bot to leave both sides of a provisioned mapping if there are no more mappings that
-//  map either the channel or room
+//  map either the channel or room. Force IRC clients to part the channel.
 Provisioner.prototype._leaveIfUnprovisioned = Promise.coroutine(
     function*(roomId, server, ircChannel) {
+        try {
+            yield this._partUnlinkedIrcClients(roomId, server, ircChannel)
+        }
+        catch (err) {
+            log.error(err); // keep going, we still need to part the bot; this is just cleanup
+        }
+
         // Cause the bot to part the channel if there are no other rooms being mapped to this
-        // channel (and if it is enabled (see leaveChannel))
+        // channel
         let mxRooms = yield this._ircBridge.getStore().getMatrixRoomsForChannel(server, ircChannel);
         if (mxRooms.length === 0) {
             let botClient = yield this._getBotClientForServer(server);
@@ -750,14 +756,82 @@ Provisioner.prototype._leaveIfUnprovisioned = Promise.coroutine(
             yield botClient.leaveChannel(ircChannel);
         }
 
-        // Leave matrix room if unprovisioned
-        yield this._leaveRoomIfUnprovisioned(roomId);
+        yield this._leaveMatrixRoomIfUnprovisioned(roomId);
+    }
+);
+
+// Parts IRC clients who should no longer be in the channel as a result of the given mapping being
+// unlinked.
+Provisioner.prototype._partUnlinkedIrcClients = Promise.coroutine(
+    function*(roomId, server, ircChannel) {
+        // Get the full set of room IDs linked to this #channel
+        let matrixRooms = yield this._ircBridge.getStore().getMatrixRoomsForChannel(
+            server, ircChannel
+        );
+        // make sure the unlinked room exists as we may have just removed it
+        let exists = false;
+        for (let i = 0; i < matrixRooms.length; i++) {
+            if (matrixRooms[i].getId() === roomId) {
+                exists = true;
+                break;
+            }
+        }
+        if (!exists) {
+            matrixRooms.push(new MatrixRoom(roomId));
+        }
+
+
+        // For each room, get the list of real matrix users and tally up how many times each one
+        // appears as joined
+        let joinedUserCounts = Object.create(null); // user_id => Number
+        let unlinkedUserIds = [];
+        let asBot = this._ircBridge.getAppServiceBridge().getBot();
+        for (let i = 0; i < matrixRooms.length; i++) {
+            let stateEvents = [];
+            try {
+                stateEvents = yield asBot.getClient().roomState(matrixRooms[i].getId());
+            }
+            catch (err) {
+                log.error("Failed to hit /state for room " + matrixRooms[i].getId());
+                log.error(err);
+            }
+            let roomInfo = asBot._getRoomInfo(roomId, stateEvents);
+            for (let j = 0; j < roomInfo.realJoinedUsers.length; j++) {
+                let userId = roomInfo.realJoinedUsers[j];
+                if (!joinedUserCounts[userId]) {
+                    joinedUserCounts[userId] = 0;
+                }
+                joinedUserCounts[userId] += 1;
+
+                if (matrixRooms[i].getId() === roomId) { // the unlinked room
+                    unlinkedUserIds.push(userId);
+                }
+            }
+        }
+
+        // Decrement counters for users who are in the unlinked mapping
+        // as they are now "leaving". Part clients which have a tally of 0.
+        unlinkedUserIds.forEach((userId) => {
+            joinedUserCounts[userId] -= 1;
+        });
+        let partUserIds = Object.keys(joinedUserCounts).filter((userId) => {
+            return joinedUserCounts[userId] === 0;
+        });
+        partUserIds.forEach((userId) => {
+            log.info(`Parting user ${userId} from ${ircChannel} as mapping unlinked.`);
+            let cli = this._ircBridge.getIrcUserFromCache(server, userId);
+            if (!cli) {
+                return; // client is disconnected
+            }
+            cli.leaveChannel(ircChannel, "Unlinked");
+        });
+        log.info(`Unlinked user_id tallies for ${ircChannel}: ${JSON.stringify(joinedUserCounts)}`);
     }
 );
 
 // Cause the bot to leave the matrix room if there are no other channels being mapped to
 // this room
-Provisioner.prototype._leaveRoomIfUnprovisioned = Promise.coroutine(
+Provisioner.prototype._leaveMatrixRoomIfUnprovisioned = Promise.coroutine(
     function*(roomId) {
         let ircChannels = yield this._ircBridge.getStore().getIrcChannelsForRoomId(roomId);
         if (ircChannels.length === 0) {


### PR DESCRIPTION
This is somewhat non-trivial because we need to work out the correct subset
of clients to disconnect (as a given Matrix user may be in multiple Matrix
rooms which are linked to the same channel). Manually tested.