### PR TITLE
Only allow joined mods in a matrix room to unlink channels

### DIFF
--- a/lib/provisioning/Provisioner.js
+++ b/lib/provisioning/Provisioner.js
@@ -77,7 +77,8 @@ function Provisioner(ircBridge, enabled, requestTimeoutSeconds) {
         "required": [
             "matrix_room_id",
             "remote_room_channel",
-            "remote_room_server"
+            "remote_room_server",
+            "user_id"
         ]
     });
     this._roomIdValidator = new ConfigValidator({
@@ -717,6 +718,36 @@ Provisioner.prototype.unlink = Promise.coroutine(function*(options) {
     if (!server) {
         throw new Error("Server requested for linking not found");
     }
+
+    // Make sure the requester is a mod in the room
+    let botCli = this._ircBridge.getAppServiceBridge().getBot().getClient();
+    let stateEvents = yield botCli.roomState(roomId);
+    // user_id must be JOINED and must have permission to modify power levels
+    let isJoined = false;
+    let hasPower = false;
+    stateEvents.forEach((e) => {
+        if (e.type === "m.room.member" && e.state_key === options.user_id) {
+            isJoined = e.content.membership === "join";
+        }
+        else if (e.type == "m.room.power_levels" && e.state_key === "") {
+            let powerRequired = e.content.state_default;
+            if (e.content.events && e.content.events["m.room.power_levels"]) {
+                powerRequired = e.content.events["m.room.power_levels"];
+            }
+            let power = e.content.users_default;
+            if (e.content.users && e.content.users[options.user_id]) {
+                power = e.content.users[options.user_id];
+            }
+            hasPower = power >= powerRequired;
+        }
+    });
+    if (!isJoined) {
+        throw new Error(`${options.user_id} is not in the room`);
+    }
+    if (!hasPower) {
+        throw new Error(`${options.user_id} is not a moderator in the room.`);
+    }
+
 
     // Delete the room link
     let entry = yield this._ircBridge.getStore()

--- a/spec/integ/provisioning.spec.js
+++ b/spec/integ/provisioning.spec.js
@@ -232,6 +232,29 @@ describe("Provisioning API", function() {
                     }
                 }
 
+                let sdk = env.clientMock._client(config._botUserId);
+                sdk.roomState.andCallFake((roomId) => {
+                    return Promise.resolve([{
+                        type: "m.room.member",
+                        state_key: parameters.user_id,
+                        user_id: parameters.user_id,
+                        content: {
+                            membership: "join"
+                        }
+                    }, {
+                        type: "m.room.power_levels",
+                        state_key: "",
+                        user_id: "@someone:here",
+                        content:{
+                            users_default: 0,
+                            users: {
+                                [parameters.user_id]: 100
+                            },
+                            state_default: 100
+                        }
+                    }]);
+                });
+
                 yield env.mockAppService._unlink(
                    parameters, status, json
                 );
@@ -249,7 +272,6 @@ describe("Provisioning API", function() {
 
         return test.coroutine(function*() {
             yield mockLinkCR.apply(mockLinkCR, args);
-            return Promise.resolve();
         });
     }
 
@@ -661,6 +683,26 @@ describe("Provisioning API", function() {
                     type: "m.room.message"
                 });
 
+                var sdk = env.clientMock._client(config._botUserId);
+                sdk.roomState.andCallFake((roomId) => {
+                    return Promise.resolve([{
+                        type: "m.room.member",
+                        state_key: parameters.user_id,
+                        user_id: parameters.user_id,
+                        content: {
+                            membership: "join"
+                        }
+                    }, {
+                        type: "m.room.power_levels",
+                        state_key: "",
+                        user_id: "@someone:here",
+                        content:{
+                            users_default: 100,
+                            state_default: 100
+                        }
+                    }]);
+                });
+
                 //Remove the link
                 yield env.mockAppService._unlink(parameters, status, json);
 
@@ -940,6 +982,27 @@ describe("Provisioning API", function() {
                 yield env.mockAppService._link(parameters[0], status, json);
                 yield env.mockAppService._link(parameters[1], status, json);
                 yield Promise.all(isLinked.map((d)=>{return d.promise;}));
+
+
+                var sdk = env.clientMock._client(config._botUserId);
+                sdk.roomState.andCallFake((rid) => {
+                    return Promise.resolve([{
+                        type: "m.room.member",
+                        state_key: mxUser.id,
+                        user_id: mxUser.id,
+                        content: {
+                            membership: "join"
+                        }
+                    }, {
+                        type: "m.room.power_levels",
+                        state_key: "",
+                        user_id: "@someone:here",
+                        content:{
+                            users_default: 100,
+                            state_default: 100
+                        }
+                    }]);
+                });
 
                 yield env.mockAppService._unlink(parameters[0], status, json);
                 yield env.mockAppService._listLinks({roomId : roomId}, status, listingsjson);


### PR DESCRIPTION
This now means that on `/unlink`:
 - The bridge will hit `/roomState`
 - And make sure that `user_id` is in the room.
 - And make sure that `user_id` has enough power to modify `m.room.power_levels`