### PR TITLE
Prevent race occuring whilst spamming 'yes'->MBot

### DIFF
--- a/lib/provisioning/Provisioner.js
+++ b/lib/provisioning/Provisioner.js
@@ -527,10 +527,19 @@ Provisioner.prototype._removeRequest = function (server, opNick) {
     }
 }
 
+// Returns a pending request if it's promise isPending(), otherwise null
 Provisioner.prototype._getRequest = function (server, opNick) {
-    if (this._pendingRequests[server.domain]) {
-        return this._pendingRequests[server.domain][opNick];
+    let reqs = this._pendingRequests[server.domain];
+    if (reqs) {
+        if (!reqs[opNick]) {
+            return null;
+        }
+
+        if (reqs[opNick].defer.promise.isPending()) {
+            return reqs[opNick];
+        }
     }
+    return null;
 }
 
 Provisioner.prototype._setRequest = function (server, opNick, request) {


### PR DESCRIPTION
When replying to a bot in response to a provisioning request, spamming 'yes' can cause 'bridge request authorised' to be sent back multiple times, indicating that the same mapping is being created over and over again, or at least that the Provisioner is trying to do that.

The fix is to only return pending requests that have pending promises, i.e. those that have not been resolved/cancelled/rejected.