### PR TITLE
Specifiy family = 6 when prefix is set

### DIFF
--- a/lib/irc/ConnectionInstance.js
+++ b/lib/irc/ConnectionInstance.js
@@ -245,7 +245,7 @@ ConnectionInstance.create = function(server, opts, onCreatedCallback) {
         secure: server.useSsl(),
         selfSigned: server.useSslSelfSigned(),
         retryCount: 0,
-        family: server.getIpv6Prefix() === undefined ? 4 : 6,
+        family: server.getIpv6Prefix() ? 6 : 4,
     };
     // TODO : coroutine this
     var d = promiseutil.defer();

--- a/lib/irc/ConnectionInstance.js
+++ b/lib/irc/ConnectionInstance.js
@@ -244,7 +244,8 @@ ConnectionInstance.create = function(server, opts, onCreatedCallback) {
         port: server.getPort(),
         secure: server.useSsl(),
         selfSigned: server.useSslSelfSigned(),
-        retryCount: 0
+        retryCount: 0,
+        family: server.getIpv6Prefix() === undefined ? 4 : 6,
     };
     // TODO : coroutine this
     var d = promiseutil.defer();


### PR DESCRIPTION
Otherwise, it is assumed that the IRC server ONLY does IPv6

**NOTE: This depends on some uncommitted node-irc code: https://github.com/matrix-org/node-irc/pull/11**