### PR TITLE
Do not cache stale clients. Always keep the bot client pool up-to-date

### DIFF
--- a/lib/bridge/IrcBridge.js
+++ b/lib/bridge/IrcBridge.js
@@ -641,7 +641,7 @@ IrcBridge.prototype._loginToServer = Promise.coroutine(function*(server) {
         log.logErr(err);
         return this._loginToServer(server);
     }
-    this._clientPool.addBot(server, bridgedClient);
+    this._clientPool.setBot(server, bridgedClient);
     var num = 1;
     chansToJoin.forEach((c) => {
         // join a channel every 500ms. We stagger them like this to

--- a/lib/irc/ClientPool.js
+++ b/lib/irc/ClientPool.js
@@ -30,14 +30,7 @@ function ClientPool(ircBridge) {
     }
 }
 
-ClientPool.prototype.addBot = function(server, client) {
-    if (this._botClients[server.domain]) {
-        log.error(
-            "Bot for %s already exists (old=%s new=%s) - disconnecting it.",
-            server.domain, this._botClients[server.domain]._id, client._id
-        );
-        this._botClients[server.domain].disconnect();
-    }
+ClientPool.prototype.setBot = function(server, client) {
     this._botClients[server.domain] = client;
 };
 
@@ -56,6 +49,9 @@ ClientPool.prototype.createIrcClient = function(ircClientConfig, matrixUser, isB
             nicks: Object.create(null),
             userIds: Object.create(null)
         };
+    }
+    if (isBot) {
+        this._botClients[server.domain] = bridgedClient;
     }
 
     // add event listeners
@@ -191,6 +187,10 @@ ClientPool.prototype._removeBridgedClient = function(bridgedClient) {
     var server = bridgedClient.server;
     this._virtualClients[server.domain].userIds[bridgedClient.userId] = undefined;
     this._virtualClients[server.domain].nicks[bridgedClient.nick] = undefined;
+
+    if (bridgedClient.isBot) {
+        this._botClients[server.domain] = undefined;
+    }
 };
 
 ClientPool.prototype._onClientConnected = function(bridgedClient) {

--- a/lib/provisioning/Provisioner.js
+++ b/lib/provisioning/Provisioner.js
@@ -606,7 +606,7 @@ Provisioner.prototype.queryLink = Promise.coroutine(function*(options) {
         throw new Error(`Server is configured to exclude channel ${ircChannel}`);
     }
 
-    let botClient = yield yield this._ircBridge.getBotClient(server);
+    let botClient = yield this._ircBridge.getBotClient(server);
 
     let opsInfo = null;
 

--- a/lib/provisioning/Provisioner.js
+++ b/lib/provisioning/Provisioner.js
@@ -196,15 +196,6 @@ Provisioner.prototype.isProvisionRequest = function(req) {
             req.url === "/_matrix/provision/querylink"
 };
 
-// Returns a bridgedClient representing a bot for the given server
-Provisioner.prototype._getBotClientForServer = Promise.coroutine(
-    function*(server) {
-        if (!this._botClients[server.domain]) {
-            this._botClients[server.domain] = yield this._ircBridge.getBotClient(server);
-        }
-        return this._botClients[server.domain];
-});
-
 Provisioner.prototype._updateBridgingState = Promise.coroutine(
     function*(roomId, userId, status, skey) {
         let intent = this._ircBridge.getAppServiceBridge().getIntent();
@@ -292,7 +283,7 @@ Provisioner.prototype._authoriseProvisioning = Promise.coroutine(
         // (IRC) Check that op's nick is actually op
         log.info(`Check that op's nick is actually op`);
 
-        let botClient = yield this._getBotClientForServer(server);
+        let botClient = yield this._ircBridge.getBotClient(server);
 
         let info = yield botClient.getOperators(ircChannel, {key : key});
 
@@ -417,7 +408,7 @@ Provisioner.prototype._authoriseProvisioning = Promise.coroutine(
 
 Provisioner.prototype._sendToUser = Promise.coroutine(
     function*(receiverNick, server, message) {
-        let botClient = yield this._getBotClientForServer(server);
+        let botClient = yield this._ircBridge.getBotClient(server);
         return this._ircBridge.sendIrcAction(
             new IrcRoom(server, receiverNick),
             botClient,
@@ -615,7 +606,7 @@ Provisioner.prototype.queryLink = Promise.coroutine(function*(options) {
         throw new Error(`Server is configured to exclude channel ${ircChannel}`);
     }
 
-    let botClient = yield this._getBotClientForServer(server);
+    let botClient = yield yield this._ircBridge.getBotClient(server);
 
     let opsInfo = null;
 
@@ -727,7 +718,7 @@ Provisioner.prototype._doLink = Promise.coroutine(
         // Cause the bot to join the new plumbed channel if it is enabled
         // TODO: key not persisted on restart
         if (server.isBotEnabled()) {
-            let botClient = yield this._getBotClientForServer(server);
+            let botClient = yield this._ircBridge.getBotClient(server);
             yield botClient.joinChannel(ircChannel, key);
         }
 
@@ -855,7 +846,7 @@ Provisioner.prototype._leaveIfUnprovisioned = Promise.coroutine(
         // channel
         let mxRooms = yield this._ircBridge.getStore().getMatrixRoomsForChannel(server, ircChannel);
         if (mxRooms.length === 0) {
-            let botClient = yield this._getBotClientForServer(server);
+            let botClient = yield this._ircBridge.getBotClient(server);
             log.info(`Leaving channel ${ircChannel} as there are no more provisioned mappings`);
             yield botClient.leaveChannel(ircChannel);
         }


### PR DESCRIPTION
Fix https://github.com/matrix-org/matrix-appservice-irc/issues/189

Turns out the `ClientPool` would not update the cache when the bot disconnected
then reconnected, resulting in a stale `BridgedClient` being returned when
calling `clientPool.getBot(server)`. This is now fixed.

In addition, do not have another layer of caching at the `Provisioner`, and
instead rely on `ClientPool` to not be broken. We need to remove this cache
else it too will get stale clients on disconnects.