### PR TITLE
Fix log scheduled queue length

### DIFF
--- a/lib/irc/Scheduler.js
+++ b/lib/irc/Scheduler.js
@@ -49,6 +49,10 @@ var Scheduler = {
             (addedDelayMs > 0 ? ` with ${Math.round(addedDelayMs)}ms added delay`:'')
         );
 
+        log.info(
+            `Queue for ${server.domain} length = ${q._queue.length}`
+        );
+
         return promise;
     }),
 


### PR DESCRIPTION
Fix for #188

Log line looks like:

```
2016-09-28 09:58:48 INFO:scheduler Queue for localhost length = 1
```