### PR TITLE
Do not block the connection queue for 1h

### DIFF
--- a/lib/irc/ConnectionInstance.js
+++ b/lib/irc/ConnectionInstance.js
@@ -275,12 +275,24 @@ ConnectionInstance.create = function(server, opts, onCreatedCallback) {
     var BASE_RETRY_TIME_MS = 1000;
     function retryForever() {
         let retryFailed = function(err) {
+            if (err && err.message) {
+                log.error(`retryFailed after ${connAttempts} attempts (${err.message})`);
+            }
             connAttempts += 1;
+
             if (err.message === "throttled") {
                 retryTimeMs += THROTTLE_WAIT_MS;
             }
             if (err.message === "banned") {
-                retryTimeMs += BANNED_TIME_MS;
+                setTimeout(() => {
+                    retryFailed(
+                        new Error(
+                            `${opts.nick} is banned from ${server.domain}, ` +
+                            `retrying in ${BANNED_TIME_MS}ms`
+                        )
+                    );
+                }, BANNED_TIME_MS);
+                return;
             }
 
             if (server.getReconnectIntervalMs() > 0) {

--- a/lib/irc/ConnectionInstance.js
+++ b/lib/irc/ConnectionInstance.js
@@ -284,12 +284,14 @@ ConnectionInstance.create = function(server, opts, onCreatedCallback) {
                 retryTimeMs += THROTTLE_WAIT_MS;
             }
             if (err.message === "banned") {
+                log.error(
+                    `${opts.nick} is banned from ${server.domain}, ` +
+                    `retrying in ${BANNED_TIME_MS}ms`
+                );
+
                 setTimeout(() => {
                     retryFailed(
-                        new Error(
-                            `${opts.nick} is banned from ${server.domain}, ` +
-                            `retrying in ${BANNED_TIME_MS}ms`
-                        )
+                        new Error(`${opts.nick} was banned from ${server.domain}, retrying now`)
                     );
                 }, BANNED_TIME_MS);
                 return;


### PR DESCRIPTION
Prevent banned users from head-of-line blocking the queue for one hour. Scheduling delays effect the entire queue, as intended, but a single banned user should not prevent others from connecting.