### PR TITLE
Admin room name change and added topic

### DIFF
--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -13,13 +13,17 @@ ircService:
   servers:
     # The address of the server to connect to.
     irc.example.com:
-      # A human-readable short name. Defaults to the first word of the description
-      # (the characters before the first instance of whitespace or the end of the
-      # description). This is used to label IRC status rooms where matrix users
-      # control their connections. E.g. 'ExampleNet IRC Bridge status'.
+      # A human-readable short name. This is used to label IRC status rooms
+      # where matrix users control their connections.
+      # E.g. 'ExampleNet IRC Bridge status'.
+      # It is also used in the Third Party Lookup API as the instance `desc`
+      # property, where each server is an instance.
       name: "ExampleNet"
+      #
+      # [DEPRECATED] Use `name`, above, instead.
       # A human-readable description string
-      description: "Example.com IRC network"
+      # description: "Example.com IRC network"
+
       # The port to connect to. Optional.
       port: 6697
       # Whether to use SSL or not. Default: false.

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -13,8 +13,13 @@ ircService:
   servers:
     # The address of the server to connect to.
     irc.example.com:
+      # A human-readable short name. Defaults to the first word of the description
+      # (the characters before the first instance of whitespace or the end of the
+      # description). This is used to label IRC status rooms where matrix users
+      # control their connections. E.g. 'ExampleNet IRC Bridge status'.
+      name: "ExampleNet"
       # A human-readable description string
-      description: "The example.com IRC network"
+      description: "Example.com IRC network"
       # The port to connect to. Optional.
       port: 6697
       # Whether to use SSL or not. Default: false.

--- a/lib/bridge/IrcBridge.js
+++ b/lib/bridge/IrcBridge.js
@@ -453,7 +453,7 @@ IrcBridge.prototype.getThirdPartyProtocol = function(protocol) {
         "instances": servers.map((server) => {
             return {
                 bot_user_id: this.getAppServiceUserId(),
-                desc: server.config.description || server.domain,
+                desc: server.config.name || server.domain,
                 icon: server.config.icon,
                 fields: {
                     domain: server.domain,

--- a/lib/bridge/IrcHandler.js
+++ b/lib/bridge/IrcHandler.js
@@ -444,8 +444,8 @@ IrcHandler.prototype.onMetadata = Promise.coroutine(function*(req, client, msg) 
             createAsClient: false,
             options: {
                 name: `${client.server.domain} Admin`,
-                topic:  "This room shows any errors or status messages from " +
-                        "${client.server.domain}, as well as letting you control " +
+                topic:  `This room shows any errors or status messages from ` +
+                        `${client.server.domain}, as well as letting you control ` +
                         "the connection. ",
                 preset: "trusted_private_chat",
                 visibility: "private",

--- a/lib/bridge/IrcHandler.js
+++ b/lib/bridge/IrcHandler.js
@@ -443,7 +443,10 @@ IrcHandler.prototype.onMetadata = Promise.coroutine(function*(req, client, msg) 
         let response = yield this.ircBridge.getAppServiceBridge().getIntent().createRoom({
             createAsClient: false,
             options: {
-                name: "IRC Admin Room",
+                name: `${client.server.domain} Admin`,
+                topic:  "This room shows any errors or status messages from " +
+                        "${client.server.domain}, as well as letting you control " +
+                        "the connection. ",
                 preset: "trusted_private_chat",
                 visibility: "private",
                 invite: [client.userId]

--- a/lib/bridge/IrcHandler.js
+++ b/lib/bridge/IrcHandler.js
@@ -443,7 +443,7 @@ IrcHandler.prototype.onMetadata = Promise.coroutine(function*(req, client, msg) 
         let response = yield this.ircBridge.getAppServiceBridge().getIntent().createRoom({
             createAsClient: false,
             options: {
-                name: `${client.server.domain} Admin`,
+                name: `${client.server.getReadableName()} IRC Bridge status`,
                 topic:  `This room shows any errors or status messages from ` +
                         `${client.server.domain}, as well as letting you control ` +
                         "the connection. ",

--- a/lib/config/schema.yml
+++ b/lib/config/schema.yml
@@ -101,6 +101,8 @@ properties:
                             type: "string"
                         sendConnectionMessages:
                             type: "boolean"
+                        name:
+                            type: "string"
                         description:
                             type: "string"
                         icon:

--- a/lib/irc/IrcServer.js
+++ b/lib/irc/IrcServer.js
@@ -19,9 +19,8 @@ function IrcServer(domain, serverConfig) {
 
 /**
  * Get a string that represents the human-readable name for a server.
- * @returns config.name if available, otherwise it will attempt to
- * return the first word of the description. If the description has
- * not been set, the domain of the server will be used.
+ * @return {string} this.config.name if truthy, otherwise it will return
+ * an empty string.
  */
 IrcServer.prototype.getReadableName = function() {
     let name = this.config.name;
@@ -29,11 +28,7 @@ IrcServer.prototype.getReadableName = function() {
         return name;
     }
 
-    if (!this.config.description) {
-        return this.domain;
-    }
-
-    return this.config.description.split(/\s/)[0];
+    return '';
 }
 
 IrcServer.prototype.getHardCodedRoomIds = function() {

--- a/lib/irc/IrcServer.js
+++ b/lib/irc/IrcServer.js
@@ -17,6 +17,25 @@ function IrcServer(domain, serverConfig) {
     this.config = serverConfig;
 }
 
+/**
+ * Get a string that represents the human-readable name for a server.
+ * @returns config.name if available, otherwise it will attempt to
+ * return the first word of the description. If the description has
+ * not been set, the domain of the server will be used.
+ */
+IrcServer.prototype.getReadableName = function() {
+    let name = this.config.name;
+    if (name) {
+        return name;
+    }
+
+    if (!this.config.description) {
+        return this.domain;
+    }
+
+    return this.config.description.split(/\s/)[0];
+}
+
 IrcServer.prototype.getHardCodedRoomIds = function() {
     var roomIds = new Set();
     var channels = Object.keys(this.config.mappings);


### PR DESCRIPTION
Example:
 - Room name: 'irc.freenode.net Admin'
 - Room topic: 'This room shows any errors or status messages from irc.freenode.net, as well as letting you control the connection.'

Fixes #198 