### PR TITLE
Request channel mode on ANY join

### DIFF
--- a/lib/irc/BridgedClient.js
+++ b/lib/irc/BridgedClient.js
@@ -677,6 +677,11 @@ BridgedClient.prototype._joinChannel = function(channel, key, attemptCount) {
         client.removeListener("error", failFn);
         var room = new IrcRoom(this.server, channel);
         defer.resolve(room);
+
+        if (this.unsafeClient) {
+            this.log.debug("Requesting channel mode");
+            this.unsafeClient.mode(channel);
+        }
     });
 
     return defer.promise;

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "bluebird": "^3.1.1",
     "crc": "^3.2.1",
     "extend": "^2.0.0",
-    "irc": "matrix-org/node-irc#310b07fbdb97f738d79746148474a58e85733d80",
+    "irc": "matrix-org/node-irc#cd27d6a7e804c286233f009e51d4deb778da3a69",
     "jayschema": "^0.3.1",
     "js-yaml": "^3.2.7",
     "matrix-appservice-bridge": "^1.3",

--- a/spec/util/irc-client-mock.js
+++ b/spec/util/irc-client-mock.js
@@ -54,7 +54,7 @@ function Client(addr, nick, opts) {
 
     var spies = [
         "connect", "whois", "join", "send", "action", "ctcp", "say",
-        "disconnect", "notice", "part", "names"
+        "disconnect", "notice", "part", "names", "mode"
     ];
     spies.forEach(function(fnName) {
         self[fnName] = jasmine.createSpy("Client." + fnName);


### PR DESCRIPTION
This is so that +s is synced whenever the bridge has access to the channel mode. This is probably overkill and should only be done when the frontier user has joined the channel (because the bot might be disabled).