### PR TITLE
Cache the visibilty of a room last sent to mx

### DIFF
--- a/lib/bridge/IrcHandler.js
+++ b/lib/bridge/IrcHandler.js
@@ -430,7 +430,8 @@ IrcHandler.prototype.onMode = Promise.coroutine(function*(req, server, channel, 
 
                 if (visibility === cachedVisibility) {
                     req.log.info(`Not updating room directory visibility for ` +
-                                 `${roomId} - cache hit.`);
+                                 `${roomId} - cache hit. Visibility remains ` +
+                                 `${cachedVisibility}`);
                     return Promise.resolve();
                 }
 

--- a/lib/bridge/IrcHandler.js
+++ b/lib/bridge/IrcHandler.js
@@ -16,6 +16,13 @@ function IrcHandler(ircBridge) {
     this._roomIdToPrivateMember = {
         // room_id: { user_id: $USER_ID, membership: "join|invite|leave|etc" }
     };
+
+    // Cache that stores the previously sent room directory state
+    // This is needed so that not too many requests hit the HS when
+    // the bridge starts up and receives a lot of RPL_CHANMODEIS (mode_is)
+    this._visibilityCache = {
+        // room_id: "private" | "public"
+    };
 }
 
 IrcHandler.prototype.onMatrixMemberEvent = function(event) {
@@ -413,7 +420,22 @@ IrcHandler.prototype.onMode = Promise.coroutine(function*(req, server, channel, 
         switch (mode) {
             case "s":
                 let cli = this.ircBridge.getAppServiceBridge().getClientFactory().getClientAs();
-                return cli.setRoomDirectoryVisibility(room.getId(), enabled ? 'private' : 'public');
+
+                // Cache what has been sent in memory
+
+                let visibility = enabled ? 'private' : 'public';
+                let roomId = room.getId();
+
+                let cachedVisibility = this._visibilityCache[roomId];
+
+                if (visibility === cachedVisibility) {
+                    req.log.info(`Not updating room directory visibility for ` +
+                                 `${roomId} - cache hit.`);
+                    return Promise.resolve();
+                }
+
+                this._visibilityCache[roomId] = visibility;
+                return cli.setRoomDirectoryVisibility(roomId, visibility);
             case "k":
             case "i":
                 req.log.info((enabled ? "Locking room %s" :


### PR DESCRIPTION
This is so that the HS is not hammered on startup when a lot of RPL_CHANMODEIS _could_ be received as clients join channels.

The problem with this is, what happens when two channels are mapped to one room and just one of the rooms is +s or +i/k? See issue #223