### PR TITLE
WIP of +s conflict checking

### DIFF
--- a/lib/DataStore.js
+++ b/lib/DataStore.js
@@ -120,6 +120,37 @@ DataStore.prototype.getRoom = function(roomId, ircDomain, ircChannel, origin) {
 };
 
 /**
+ * Get all Matrix <--> IRC room mappings from the database.
+ * @return {Promise} A promise which resolves to a map:
+ *      $roomId => ['server #channel1', 'server #channel2',...]
+ */
+DataStore.prototype.getAllMappings = Promise.coroutine(function*() {
+    let entries = yield this._roomStore.select(
+        {
+            matrix_id : {$exists: true},
+            remote_id: {$exists: true},
+        }
+    );
+
+    let uniqueFilter = (value, index, self) => {
+        // Returns true if this is the first occurance of value
+        return self.indexOf(value) === index;
+    };
+
+    let roomIds = entries.map((e) => e.matrix_id).filter(uniqueFilter);
+
+    let mappings = {};
+
+    roomIds.forEach((roomId) => {
+        mappings[roomId] = entries.filter(
+            (e) => e.matrix_id === roomId
+        ).map((e) => e.remote.domain + ' ' + e.remote.channel);
+    });
+
+    return mappings;
+});
+
+/**
  * Get provisioned IRC <--> Matrix room mappings from the database where
  * the matrix room ID is roomId.
  * @param {string} roomId : The Matrix room ID.

--- a/lib/bridge/IrcBridge.js
+++ b/lib/bridge/IrcBridge.js
@@ -102,6 +102,21 @@ function IrcBridge(config, registration) {
     );
 
     this._provisioner = null;
+
+    // Cache the mode of each channel, the visibility of each room and the
+    // known mappings between them. When any of these change, any inconsistencies
+    // should be resolved by keeping the matrix side as private as necessary
+    this._visibilityMap = {
+        mappings: {
+            //room_id: ['server #channel1', 'server channel2',...]
+        },
+        channelModes: {
+            // '$server $channel': true | false
+        },
+        roomVisibilities: {
+            // room_id: "private" | "public"
+        }
+    }
 }
 
 IrcBridge.prototype.getAppServiceUserId = function() {
@@ -753,6 +768,128 @@ IrcBridge.prototype.getBotClient = function(server) {
         return this._clientPool.getBot(server);
     });
 }
+
+
+var _solveTimeout = null;
+
+IrcBridge.prototype._updateVisibilityMap = function(isMode, key, value) {
+    let hasChanged = false;
+    if (isMode) {
+        if (typeof value !== 'boolean') {
+            throw new Error('+s state must be indicated with a boolean');
+        }
+        if (this._visibilityMap.channelModes[key] !== value) {
+            this._visibilityMap.channelModes[key] = value;
+            hasChanged = true;
+        }
+    }
+    else {
+        if (typeof value !== 'string' || (value !== "private" && value !== "public")) {
+            throw new Error('Room visibility must = "private" | "public"');
+        }
+
+        if (this._visibilityMap.roomVisibilities[key] !== value) {
+            this._visibilityMap.roomVisibilities[key] = value;
+            hasChanged = true;
+        }
+    }
+
+    if (hasChanged) {
+        clearTimeout(_solveTimeout);
+
+        _solveTimeout = setTimeout(() => {
+            this._solveVisibility()
+        }, 10000);
+        return Promise.resolve();
+    }
+
+    return Promise.resolve();
+}
+
+IrcBridge.prototype._solveVisibility = Promise.coroutine(function*() {
+    // For each room, do a big OR on all of the channels that are linked in any way
+
+    this._visibilityMap.mappings = yield this.getStore().getAllMappings();
+
+    let roomIds = Object.keys(this._visibilityMap.roomVisibilities);
+
+    let checkedChannels = [];
+
+    let shouldBePrivate = (roomId) => {
+        // If any channel connected to this room is +s, stop early and call it private
+
+        // List first connected
+        let channels = this._visibilityMap.mappings[roomId];
+        //      = ['localhost #channel1', 'localhost #channel2', ... ]
+
+        // Filter out already checked channels
+        channels = channels.filter((c) => checkedChannels.indexOf(c) === -1);
+
+        // No channels mapped to this roomId
+        if (!channels) {
+            return false;
+        }
+
+        let anyAreSecret = channels.any((channel) => {
+            let channelIsSecret = this._visibilityMap.channelModes[channel];
+
+            // If a channel mode is unknown, assume it is secret
+            if (typeof channelIsSecret === 'undefined') {
+                channelIsSecret = true;
+            }
+
+            return channelIsSecret;
+        });
+        if (anyAreSecret) {
+            return true;
+        }
+
+        checkedChannels = checkedChannels.concat(channels);
+
+        // Otherwise, recurse with the rooms connected to each channel
+
+        // So get all the roomIds that this channel is mapped to
+        let connectedRooms = channels.map((channel) => {
+            return Object.keys(this._visibilityMap.mappings).filter((roomId2) => {
+                return this._visibilityMap.mappings[roomId2].indexOf(channel) !== -1;
+            });
+        });
+
+        return connectedRooms.any(shouldBePrivate);
+    }
+
+    let roomCorrectVisibilities = roomIds.map(
+        shouldBePrivate
+    ).map((b) => b ? 'private' : 'public');
+
+    let roomsShouldBePrivate = roomIds.filter((roomId, index) => {
+        let isCurrentlyPrivate = this._visibilityMap.roomVisibilities[roomId] === 'private';
+        let roomShouldBePrivate = roomCorrectVisibilities[index] === 'private';
+
+        return !isCurrentlyPrivate && roomShouldBePrivate;
+    });
+
+    let roomsShouldBePublic = roomIds.filter((roomId, index) => {
+        let isCurrentlyPrivate = this._visibilityMap.roomVisibilities[roomId] === 'private';
+        let roomShouldBePublic = roomCorrectVisibilities[index] === 'public';
+
+        return isCurrentlyPrivate && roomShouldBePublic;
+    });
+
+    // Update rooms to correct visibilities
+    let cli = this.getAppServiceBridge().getClientFactory().getClientAs();
+
+    let promises = roomsShouldBePrivate.map((roomId) => {
+        return cli.setRoomDirectoryVisibility(roomId, "private");
+    });
+
+    promises = promises.concat(roomsShouldBePublic.map((roomId) => {
+        return cli.setRoomDirectoryVisibility(roomId, "public");
+    }));
+
+    return Promise.all(promises);
+});
+
 
 IrcBridge.DEFAULT_LOCALPART = "appservice-irc";
 

--- a/lib/bridge/IrcBridge.js
+++ b/lib/bridge/IrcBridge.js
@@ -813,9 +813,8 @@ IrcBridge.prototype._solveVisibility = Promise.coroutine(function*() {
 
     let roomIds = Object.keys(this._visibilityMap.roomVisibilities);
 
-    let checkedChannels = [];
-
-    let shouldBePrivate = (roomId) => {
+    // level is the current depth of recursion
+    let shouldBePrivate = (roomId, checkedChannels) => {
         // If any channel connected to this room is +s, stop early and call it private
 
         // List first connected
@@ -844,22 +843,23 @@ IrcBridge.prototype._solveVisibility = Promise.coroutine(function*() {
             return true;
         }
 
-        checkedChannels = checkedChannels.concat(channels);
-
         // Otherwise, recurse with the rooms connected to each channel
 
-        // So get all the roomIds that this channel is mapped to
-        let connectedRooms = channels.map((channel) => {
+        // So get all the roomIds that this channel is mapped to and return whether any
+        //  are mapped to channels that are secret
+        return channels.map((channel) => {
             return Object.keys(this._visibilityMap.mappings).filter((roomId2) => {
                 return this._visibilityMap.mappings[roomId2].indexOf(channel) !== -1;
             });
+        }).any((roomId2) => {
+            return shouldBePrivate(roomId2, checkedChannels.concat(channels));
         });
-
-        return connectedRooms.any(shouldBePrivate);
     }
 
     let roomCorrectVisibilities = roomIds.map(
-        shouldBePrivate
+        (roomId) => {
+            return shouldBePrivate(roomId, []);
+        }
     ).map((b) => b ? 'private' : 'public');
 
     let roomsShouldBePrivate = roomIds.filter((roomId, index) => {

--- a/lib/bridge/IrcHandler.js
+++ b/lib/bridge/IrcHandler.js
@@ -415,12 +415,15 @@ IrcHandler.prototype._updateVisibilityMap = function(isMode, key, value) {
     }
 
     if (hasChanged) {
-        this._solveVisibility();
+        return this._solveVisibility();
     }
+
+    return Promise.resolve();
 }
 
 IrcHandler.prototype._solveVisibility = function() {
     // solve inconsistencies
+    return Promise.resolve();
 }
 
 IrcHandler.prototype.onMode = Promise.coroutine(function*(req, server, channel, by,
@@ -455,27 +458,13 @@ IrcHandler.prototype.onMode = Promise.coroutine(function*(req, server, channel, 
         return;
     }
 
+    if (mode === "s") {
+        // Update the visibility for all rooms connected to this channel
+        return this._updateVisibilityMap(true, channel, enabled);
+    }
+
     var promises = matrixRooms.map((room) => {
         switch (mode) {
-            case "s":
-                let cli = this.ircBridge.getAppServiceBridge().getClientFactory().getClientAs();
-
-                // Cache what has been sent in memory
-
-                let visibility = enabled ? 'private' : 'public';
-                let roomId = room.getId();
-
-                let cachedVisibility = this._visibilityCache[roomId];
-
-                if (visibility === cachedVisibility) {
-                    req.log.info(`Not updating room directory visibility for ` +
-                                 `${roomId} - cache hit. Visibility remains ` +
-                                 `${cachedVisibility}`);
-                    return Promise.resolve();
-                }
-
-                this._visibilityCache[roomId] = visibility;
-                return cli.setRoomDirectoryVisibility(roomId, visibility);
             case "k":
             case "i":
                 req.log.info((enabled ? "Locking room %s" :

--- a/lib/bridge/IrcHandler.js
+++ b/lib/bridge/IrcHandler.js
@@ -436,45 +436,49 @@ IrcHandler.prototype._solveVisibility = Promise.coroutine(function*() {
 
     let roomIds = Object.keys(this._visibilityMap.roomVisibilities);
 
-    let roomCorrectVisibilities = roomIds.map(
-        shouldBePrivate = (roomId) => {
-            // If any channel connected to this room is +s, stop early and call it private
+    let shouldBePrivate = (roomId) => {
+        // If any channel connected to this room is +s, stop early and call it private
 
-            // List first connected
-            let channels = this._visibilityMap.mappings[roomId];
-            //      = ['localhost #channel1', 'localhost #channel2', ... ]
+        // List first connected
+        let channels = this._visibilityMap.mappings[roomId];
+        //      = ['localhost #channel1', 'localhost #channel2', ... ]
 
-            // No channels mapped to this roomId
-            if (!channels) {
-                return false;
-            }
-
-            let anyAreSecret = channels.any((channel) => {
-                let channelIsSecret = this._visibilityMap.channelModes[channel];
-
-                // If a channel mode is unknown, assume it is secret
-                if (typeof channelIsSecret === 'undefined') {
-                    channelIsSecret = true;
-                }
-
-                return channelIsSecret;
-            });
-            if (anyAreSecret) {
-                return true;
-            }
-
-            // Otherwise, recurse with the rooms connected to each channel
-
-            // So get all the roomIds that this channel is mapped to
-            let connectedRooms = channels.map((channel) => {
-                return Object.keys(this._visibilityMap.mappings).filter((roomId2) => {
-                    return this._visibilityMap.mappings[roomId2].indexOf(channel) !== -1;
-                });
-            });
-
-            return connectedRooms.any(shouldBePrivate);
+        // No channels mapped to this roomId
+        if (!channels) {
+            return false;
         }
+
+        let anyAreSecret = channels.any((channel) => {
+            let channelIsSecret = this._visibilityMap.channelModes[channel];
+
+            // If a channel mode is unknown, assume it is secret
+            if (typeof channelIsSecret === 'undefined') {
+                channelIsSecret = true;
+            }
+
+            return channelIsSecret;
+        });
+        if (anyAreSecret) {
+            return true;
+        }
+
+        // Otherwise, recurse with the rooms connected to each channel
+
+        // So get all the roomIds that this channel is mapped to
+        let connectedRooms = channels.map((channel) => {
+            return Object.keys(this._visibilityMap.mappings).filter((roomId2) => {
+                return this._visibilityMap.mappings[roomId2].indexOf(channel) !== -1;
+            });
+        });
+
+        return connectedRooms.any(shouldBePrivate);
+    }
+
+    let roomCorrectVisibilities = roomIds.map(
+        shouldBePrivate
     ).map((b) => b ? 'private' : 'public');
+
+    console.log(roomIds, roomCorrectVisibilities);
 
     let roomsShouldBePrivate = roomIds.filter((roomId, index) => {
         let isCurrentlyPrivate = this._visibilityMap.roomVisibilities[roomId] === 'private';
@@ -485,9 +489,9 @@ IrcHandler.prototype._solveVisibility = Promise.coroutine(function*() {
 
     let roomsShouldBePublic = roomIds.filter((roomId, index) => {
         let isCurrentlyPrivate = this._visibilityMap.roomVisibilities[roomId] === 'private';
-        let shouldBePublic = roomCorrectVisibilities[index] === 'public';
+        let roomShouldBePublic = roomCorrectVisibilities[index] === 'public';
 
-        return isCurrentlyPrivate && shouldBePublic;
+        return isCurrentlyPrivate && roomShouldBePublic;
     });
 
     // Update rooms to correct visibilities

--- a/lib/bridge/IrcHandler.js
+++ b/lib/bridge/IrcHandler.js
@@ -22,7 +22,7 @@ function IrcHandler(ircBridge) {
     // should be resolved by keeping the matrix side as private as necessary
     this._visibilityMap = {
         mappings: {
-            //channel: room_id
+            //room_id: ['#channel1', 'channel2',...]
         },
         channelModes: {
             //channel: true | false
@@ -422,7 +422,51 @@ IrcHandler.prototype._updateVisibilityMap = function(isMode, key, value) {
 }
 
 IrcHandler.prototype._solveVisibility = function() {
-    // solve inconsistencies
+
+    // For each room, do a big OR on all of the channels that are linked in any way
+
+    let roomIds = Object.keys(this._visibilityMap.roomVisibilities);
+
+    let roomCorrectVisibilities = roomIds.map(
+        recurse = (roomId) => {
+            // If any channel connected to this room is +s, stop early and call it private
+
+            // List first connected
+            let channels = this._visibilityMap.mappings[roomId];
+            let anyAreSecret = channels.any((channel) => {
+                return this._visibilityMap.channelModes[channel];
+            });
+            if (anyAreSecret) {
+                return true;
+            }
+
+            // Otherwise, recurse with the rooms connected to each channel
+
+            // So get all the roomIds that this channel is mapped to
+            let connectedRooms = channels.map((channel) => {
+                return Object.keys(this._visibilityMap.mappings).filter((roomId2) => {
+                    return this._visibilityMap.mappings[roomId2].indexOf(channel) !== -1;
+                });
+            });
+
+            return connectedRooms.any(recurse);
+        }
+    ).map((b) => b ? 'private' : 'public');
+
+    let roomsShouldBePrivate = roomIds.filter((roomId, index) => {
+        let isCurrentlyPrivate = this._visibilityMap.roomVisibilities[roomId] === 'private';
+        let shouldBePrivate = roomCorrectVisibilities[index];
+
+        return !isCurrentlyPrivate && shouldBePrivate;
+    });
+
+    // Update rooms to correct visibilities
+    let cli = this.ircBridge.getAppServiceBridge().getClientFactory().getClienAS();
+
+    roomsShouldBePrivate.forEach(() => {
+        cli.setRoomDirectoryVisibility(roomId, visibility);
+    });
+
     return Promise.resolve();
 }
 

--- a/lib/bridge/IrcHandler.js
+++ b/lib/bridge/IrcHandler.js
@@ -445,7 +445,7 @@ IrcHandler.prototype._solveVisibility = Promise.coroutine(function*() {
         let channels = this._visibilityMap.mappings[roomId];
         //      = ['localhost #channel1', 'localhost #channel2', ... ]
 
-        // Filter out checked channels
+        // Filter out already checked channels
         channels = channels.filter((c) => checkedChannels.indexOf(c) === -1);
 
         // No channels mapped to this roomId
@@ -484,8 +484,6 @@ IrcHandler.prototype._solveVisibility = Promise.coroutine(function*() {
     let roomCorrectVisibilities = roomIds.map(
         shouldBePrivate
     ).map((b) => b ? 'private' : 'public');
-
-    console.log(roomIds, roomCorrectVisibilities);
 
     let roomsShouldBePrivate = roomIds.filter((roomId, index) => {
         let isCurrentlyPrivate = this._visibilityMap.roomVisibilities[roomId] === 'private';

--- a/lib/bridge/IrcHandler.js
+++ b/lib/bridge/IrcHandler.js
@@ -430,7 +430,8 @@ IrcHandler.prototype.onMode = Promise.coroutine(function*(req, server, channel, 
 
                 if (visibility === cachedVisibility) {
                     req.log.info(`Not updating room directory visibility for ` +
-                                 `${roomId} - cache hit.`);
+                                 `${roomId} - cache hit. Visibility remains ` +
+                                 `${cachedVisibility}`);
                     return Promise.resolve();
                 }
 

--- a/lib/bridge/IrcHandler.js
+++ b/lib/bridge/IrcHandler.js
@@ -25,7 +25,7 @@ function IrcHandler(ircBridge) {
             //channel: room_id
         },
         channelModes: {
-            //channel: "+abcdef"
+            //channel: true | false
         },
         roomVisibilities: {
             // room_id: "private" | "public"
@@ -391,6 +391,37 @@ IrcHandler.prototype.onPart = Promise.coroutine(function*(req, server, leavingUs
     stats.membership(true, "part");
     yield Promise.all(promises);
 });
+
+IrcHandler.prototype._updateVisibilityMap = function(isMode, key, value) {
+    let hasChanged = false;
+    if (isMode) {
+        if (typeof value !== 'boolean') {
+            throw new Error('+s state must be indicated with a boolean');
+        }
+        if (this._visibilityMap.channelModes[key] !== value) {
+            this._visibilityMap.channelModes[key] = value;
+            hasChanged = true;
+        }
+    }
+    else {
+        if (typeof value !== 'string' || (value !== "private" && value !== "public")) {
+            throw new Error('Room visibility must = "private" | "public"');
+        }
+
+        if (this._visibilityMap.roomVisibilities[key] !== value) {
+            this._visibilityMap.roomVisibilities[key] = value;
+            hasChanged = true;
+        }
+    }
+
+    if (hasChanged) {
+        this._solveVisibility();
+    }
+}
+
+IrcHandler.prototype._solveVisibility = function() {
+    // solve inconsistencies
+}
 
 IrcHandler.prototype.onMode = Promise.coroutine(function*(req, server, channel, by,
                                                 mode, enabled, arg) {

--- a/lib/bridge/IrcHandler.js
+++ b/lib/bridge/IrcHandler.js
@@ -17,12 +17,20 @@ function IrcHandler(ircBridge) {
         // room_id: { user_id: $USER_ID, membership: "join|invite|leave|etc" }
     };
 
-    // Cache that stores the previously sent room directory state
-    // This is needed so that not too many requests hit the HS when
-    // the bridge starts up and receives a lot of RPL_CHANMODEIS (mode_is)
-    this._visibilityCache = {
-        // room_id: "private" | "public"
-    };
+    // Cache the mode of each channel, the visibility of each room and the
+    // known mappings between them. When any of these change, any inconsistencies
+    // should be resolved by keeping the matrix side as private as necessary
+    this._visibilityMap = {
+        mappings: {
+            //channel: room_id
+        },
+        channelModes: {
+            //channel: "+abcdef"
+        },
+        roomVisibilities: {
+            // room_id: "private" | "public"
+        }
+    }
 }
 
 IrcHandler.prototype.onMatrixMemberEvent = function(event) {

--- a/lib/bridge/IrcHandler.js
+++ b/lib/bridge/IrcHandler.js
@@ -16,6 +16,13 @@ function IrcHandler(ircBridge) {
     this._roomIdToPrivateMember = {
         // room_id: { user_id: $USER_ID, membership: "join|invite|leave|etc" }
     };
+
+    // Cache that stores the previously sent room directory state
+    // This is needed so that not too many requests hit the HS when
+    // the bridge starts up and receives a lot of RPL_CHANMODEIS (mode_is)
+    this._visibilityCache = {
+        // room_id: "private" | "public"
+    };
 }
 
 IrcHandler.prototype.onMatrixMemberEvent = function(event) {
@@ -413,7 +420,22 @@ IrcHandler.prototype.onMode = Promise.coroutine(function*(req, server, channel, 
         switch (mode) {
             case "s":
                 let cli = this.ircBridge.getAppServiceBridge().getClientFactory().getClientAs();
-                return cli.setRoomDirectoryVisibility(room.getId(), enabled ? 'private' : 'public');
+
+                // Cache what has been sent in memory
+
+                let visibility = enabled ? 'private' : 'public';
+                let roomId = room.getId();
+
+                let cachedVisibility = this._visibilityCache[roomId];
+
+                if (visibility === cachedVisibility) {
+                    req.log.info(`Not updating room directory visibility for ` +
+                                 `${roomId} - cache hit.`);
+                    return Promise.resolve();
+                }
+
+                this._visibilityCache[roomId] = visibility;
+                return cli.setRoomDirectoryVisibility(roomId, visibility);
             case "k":
             case "i":
                 req.log.info((enabled ? "Locking room %s" :

--- a/lib/bridge/IrcHandler.js
+++ b/lib/bridge/IrcHandler.js
@@ -22,10 +22,10 @@ function IrcHandler(ircBridge) {
     // should be resolved by keeping the matrix side as private as necessary
     this._visibilityMap = {
         mappings: {
-            //room_id: ['#channel1', 'channel2',...]
+            //room_id: ['server #channel1', 'server channel2',...]
         },
         channelModes: {
-            //channel: true | false
+            // '$server $channel': true | false
         },
         roomVisibilities: {
             // room_id: "private" | "public"
@@ -392,6 +392,9 @@ IrcHandler.prototype.onPart = Promise.coroutine(function*(req, server, leavingUs
     yield Promise.all(promises);
 });
 
+
+var _solveTimeout = null;
+
 IrcHandler.prototype._updateVisibilityMap = function(isMode, key, value) {
     let hasChanged = false;
     if (isMode) {
@@ -415,26 +418,46 @@ IrcHandler.prototype._updateVisibilityMap = function(isMode, key, value) {
     }
 
     if (hasChanged) {
-        return this._solveVisibility();
+        clearTimeout(_solveTimeout);
+
+        _solveTimeout = setTimeout(() => {
+            this._solveVisibility()
+        }, 10000);
+        return Promise.resolve();
     }
 
     return Promise.resolve();
 }
 
-IrcHandler.prototype._solveVisibility = function() {
-
+IrcHandler.prototype._solveVisibility = Promise.coroutine(function*() {
     // For each room, do a big OR on all of the channels that are linked in any way
+
+    this._visibilityMap.mappings = yield this.ircBridge.getStore().getAllMappings();
 
     let roomIds = Object.keys(this._visibilityMap.roomVisibilities);
 
     let roomCorrectVisibilities = roomIds.map(
-        recurse = (roomId) => {
+        shouldBePrivate = (roomId) => {
             // If any channel connected to this room is +s, stop early and call it private
 
             // List first connected
             let channels = this._visibilityMap.mappings[roomId];
+            //      = ['localhost #channel1', 'localhost #channel2', ... ]
+
+            // No channels mapped to this roomId
+            if (!channels) {
+                return false;
+            }
+
             let anyAreSecret = channels.any((channel) => {
-                return this._visibilityMap.channelModes[channel];
+                let channelIsSecret = this._visibilityMap.channelModes[channel];
+
+                // If a channel mode is unknown, assume it is secret
+                if (typeof channelIsSecret === 'undefined') {
+                    channelIsSecret = true;
+                }
+
+                return channelIsSecret;
             });
             if (anyAreSecret) {
                 return true;
@@ -449,26 +472,37 @@ IrcHandler.prototype._solveVisibility = function() {
                 });
             });
 
-            return connectedRooms.any(recurse);
+            return connectedRooms.any(shouldBePrivate);
         }
     ).map((b) => b ? 'private' : 'public');
 
     let roomsShouldBePrivate = roomIds.filter((roomId, index) => {
         let isCurrentlyPrivate = this._visibilityMap.roomVisibilities[roomId] === 'private';
-        let shouldBePrivate = roomCorrectVisibilities[index];
+        let roomShouldBePrivate = roomCorrectVisibilities[index] === 'private';
 
-        return !isCurrentlyPrivate && shouldBePrivate;
+        return !isCurrentlyPrivate && roomShouldBePrivate;
+    });
+
+    let roomsShouldBePublic = roomIds.filter((roomId, index) => {
+        let isCurrentlyPrivate = this._visibilityMap.roomVisibilities[roomId] === 'private';
+        let shouldBePublic = roomCorrectVisibilities[index] === 'public';
+
+        return isCurrentlyPrivate && shouldBePublic;
     });
 
     // Update rooms to correct visibilities
-    let cli = this.ircBridge.getAppServiceBridge().getClientFactory().getClienAS();
+    let cli = this.ircBridge.getAppServiceBridge().getClientFactory().getClientAs();
 
-    roomsShouldBePrivate.forEach(() => {
-        cli.setRoomDirectoryVisibility(roomId, visibility);
+    let promises = roomsShouldBePrivate.map((roomId) => {
+        return cli.setRoomDirectoryVisibility(roomId, "private");
     });
 
-    return Promise.resolve();
-}
+    promises = promises.concat(roomsShouldBePublic.map((roomId) => {
+        return cli.setRoomDirectoryVisibility(roomId, "public");
+    }));
+
+    return Promise.all(promises);
+});
 
 IrcHandler.prototype.onMode = Promise.coroutine(function*(req, server, channel, by,
                                                 mode, enabled, arg) {
@@ -504,7 +538,7 @@ IrcHandler.prototype.onMode = Promise.coroutine(function*(req, server, channel, 
 
     if (mode === "s") {
         // Update the visibility for all rooms connected to this channel
-        return this._updateVisibilityMap(true, channel, enabled);
+        return this._updateVisibilityMap(true, server.domain + ' ' + channel, enabled);
     }
 
     var promises = matrixRooms.map((room) => {

--- a/lib/bridge/IrcHandler.js
+++ b/lib/bridge/IrcHandler.js
@@ -16,21 +16,6 @@ function IrcHandler(ircBridge) {
     this._roomIdToPrivateMember = {
         // room_id: { user_id: $USER_ID, membership: "join|invite|leave|etc" }
     };
-
-    // Cache the mode of each channel, the visibility of each room and the
-    // known mappings between them. When any of these change, any inconsistencies
-    // should be resolved by keeping the matrix side as private as necessary
-    this._visibilityMap = {
-        mappings: {
-            //room_id: ['server #channel1', 'server channel2',...]
-        },
-        channelModes: {
-            // '$server $channel': true | false
-        },
-        roomVisibilities: {
-            // room_id: "private" | "public"
-        }
-    }
 }
 
 IrcHandler.prototype.onMatrixMemberEvent = function(event) {
@@ -392,127 +377,6 @@ IrcHandler.prototype.onPart = Promise.coroutine(function*(req, server, leavingUs
     yield Promise.all(promises);
 });
 
-
-var _solveTimeout = null;
-
-IrcHandler.prototype._updateVisibilityMap = function(isMode, key, value) {
-    let hasChanged = false;
-    if (isMode) {
-        if (typeof value !== 'boolean') {
-            throw new Error('+s state must be indicated with a boolean');
-        }
-        if (this._visibilityMap.channelModes[key] !== value) {
-            this._visibilityMap.channelModes[key] = value;
-            hasChanged = true;
-        }
-    }
-    else {
-        if (typeof value !== 'string' || (value !== "private" && value !== "public")) {
-            throw new Error('Room visibility must = "private" | "public"');
-        }
-
-        if (this._visibilityMap.roomVisibilities[key] !== value) {
-            this._visibilityMap.roomVisibilities[key] = value;
-            hasChanged = true;
-        }
-    }
-
-    if (hasChanged) {
-        clearTimeout(_solveTimeout);
-
-        _solveTimeout = setTimeout(() => {
-            this._solveVisibility()
-        }, 10000);
-        return Promise.resolve();
-    }
-
-    return Promise.resolve();
-}
-
-IrcHandler.prototype._solveVisibility = Promise.coroutine(function*() {
-    // For each room, do a big OR on all of the channels that are linked in any way
-
-    this._visibilityMap.mappings = yield this.ircBridge.getStore().getAllMappings();
-
-    let roomIds = Object.keys(this._visibilityMap.roomVisibilities);
-
-    let checkedChannels = [];
-
-    let shouldBePrivate = (roomId) => {
-        // If any channel connected to this room is +s, stop early and call it private
-
-        // List first connected
-        let channels = this._visibilityMap.mappings[roomId];
-        //      = ['localhost #channel1', 'localhost #channel2', ... ]
-
-        // Filter out already checked channels
-        channels = channels.filter((c) => checkedChannels.indexOf(c) === -1);
-
-        // No channels mapped to this roomId
-        if (!channels) {
-            return false;
-        }
-
-        let anyAreSecret = channels.any((channel) => {
-            let channelIsSecret = this._visibilityMap.channelModes[channel];
-
-            // If a channel mode is unknown, assume it is secret
-            if (typeof channelIsSecret === 'undefined') {
-                channelIsSecret = true;
-            }
-
-            return channelIsSecret;
-        });
-        if (anyAreSecret) {
-            return true;
-        }
-
-        checkedChannels = checkedChannels.concat(channels);
-
-        // Otherwise, recurse with the rooms connected to each channel
-
-        // So get all the roomIds that this channel is mapped to
-        let connectedRooms = channels.map((channel) => {
-            return Object.keys(this._visibilityMap.mappings).filter((roomId2) => {
-                return this._visibilityMap.mappings[roomId2].indexOf(channel) !== -1;
-            });
-        });
-
-        return connectedRooms.any(shouldBePrivate);
-    }
-
-    let roomCorrectVisibilities = roomIds.map(
-        shouldBePrivate
-    ).map((b) => b ? 'private' : 'public');
-
-    let roomsShouldBePrivate = roomIds.filter((roomId, index) => {
-        let isCurrentlyPrivate = this._visibilityMap.roomVisibilities[roomId] === 'private';
-        let roomShouldBePrivate = roomCorrectVisibilities[index] === 'private';
-
-        return !isCurrentlyPrivate && roomShouldBePrivate;
-    });
-
-    let roomsShouldBePublic = roomIds.filter((roomId, index) => {
-        let isCurrentlyPrivate = this._visibilityMap.roomVisibilities[roomId] === 'private';
-        let roomShouldBePublic = roomCorrectVisibilities[index] === 'public';
-
-        return isCurrentlyPrivate && roomShouldBePublic;
-    });
-
-    // Update rooms to correct visibilities
-    let cli = this.ircBridge.getAppServiceBridge().getClientFactory().getClientAs();
-
-    let promises = roomsShouldBePrivate.map((roomId) => {
-        return cli.setRoomDirectoryVisibility(roomId, "private");
-    });
-
-    promises = promises.concat(roomsShouldBePublic.map((roomId) => {
-        return cli.setRoomDirectoryVisibility(roomId, "public");
-    }));
-
-    return Promise.all(promises);
-});
-
 IrcHandler.prototype.onMode = Promise.coroutine(function*(req, server, channel, by,
                                                 mode, enabled, arg) {
     let privateModes = ["k", "i", "s"];
@@ -547,7 +411,7 @@ IrcHandler.prototype.onMode = Promise.coroutine(function*(req, server, channel, 
 
     if (mode === "s") {
         // Update the visibility for all rooms connected to this channel
-        return this._updateVisibilityMap(true, server.domain + ' ' + channel, enabled);
+        return this.ircBridge.updateVisibilityMap(true, server.domain + ' ' + channel, enabled);
     }
 
     var promises = matrixRooms.map((room) => {

--- a/lib/bridge/IrcHandler.js
+++ b/lib/bridge/IrcHandler.js
@@ -436,12 +436,17 @@ IrcHandler.prototype._solveVisibility = Promise.coroutine(function*() {
 
     let roomIds = Object.keys(this._visibilityMap.roomVisibilities);
 
+    let checkedChannels = [];
+
     let shouldBePrivate = (roomId) => {
         // If any channel connected to this room is +s, stop early and call it private
 
         // List first connected
         let channels = this._visibilityMap.mappings[roomId];
         //      = ['localhost #channel1', 'localhost #channel2', ... ]
+
+        // Filter out checked channels
+        channels = channels.filter((c) => checkedChannels.indexOf(c) === -1);
 
         // No channels mapped to this roomId
         if (!channels) {
@@ -461,6 +466,8 @@ IrcHandler.prototype._solveVisibility = Promise.coroutine(function*() {
         if (anyAreSecret) {
             return true;
         }
+
+        checkedChannels = checkedChannels.concat(channels);
 
         // Otherwise, recurse with the rooms connected to each channel
 


### PR DESCRIPTION
It is currently possible still for +s channels to leak as public matrix rooms. So this fix goes to the extreme of full graph traversal of all mappings between channels and rooms and corrects discrepancies.

When any change to the cache of '+s' for channels or private/public for rooms occurs, the conflicts are resolved by keeping the matrix side as private as possible (by set[ing]RoomDirectoryVisibility()). This resolution only occurs when 10 seconds has elapsed where no changes have occurred. On top of this, it may also be useful to have a minimum interval where it is always updated (provided there have been changes).

TODO:

- [ ] Listen for room visibility from matrix somehow