### PR TITLE
Add membershipLists.floodDelayMs to config.yaml

### DIFF
--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -122,6 +122,11 @@ ircService:
         # effect. Default: false.
         enabled: false
 
+        # Syncing membership lists at startup can result in hundreds of members to
+        # process all at once. This timer drip feeds membership entries at the
+        # specified rate. Default: 10000. (10s)
+        floodDelayMs: 10000
+
         global:
           ircToMatrix:
             # Get a snapshot of all real IRC users on a channel (via NAMES) and

--- a/lib/bridge/MemberListSyncer.js
+++ b/lib/bridge/MemberListSyncer.js
@@ -8,9 +8,6 @@ var Promise = require("bluebird");
 var promiseutil = require("../promiseutil");
 var log = require("../logging").get("MemberListSyncer");
 
-const JOIN_WAIT_TIME_MS = 10 * 1000;
-
-
 function MemberListSyncer(ircBridge, appServiceBot, server, appServiceUserId, injectJoinFn) {
     this.ircBridge = ircBridge;
     this.appServiceBot = appServiceBot;
@@ -236,8 +233,9 @@ function joinMatrixUsersToChannels(rooms, server, injectJoinFn) {
             "Injecting join event for %s in %s (%s left) is_frontier=%s",
             entry.userId, entry.roomId, entries.length, entry.frontier
         );
-        injectJoinFn(entry.roomId, entry.userId, entry.frontier).timeout(JOIN_WAIT_TIME_MS).finally(
-        function() {
+        injectJoinFn(entry.roomId, entry.userId, entry.frontier).timeout(server.getMemberListFloodDelayMs()).then(() => {
+            joinNextUser();
+        }, (err) => { // discard error, this will be due to timeouts which we don't want to log
             joinNextUser();
         });
     }

--- a/lib/bridge/MemberListSyncer.js
+++ b/lib/bridge/MemberListSyncer.js
@@ -233,7 +233,9 @@ function joinMatrixUsersToChannels(rooms, server, injectJoinFn) {
             "Injecting join event for %s in %s (%s left) is_frontier=%s",
             entry.userId, entry.roomId, entries.length, entry.frontier
         );
-        injectJoinFn(entry.roomId, entry.userId, entry.frontier).timeout(server.getMemberListFloodDelayMs()).then(() => {
+        injectJoinFn(entry.roomId, entry.userId, entry.frontier).timeout(
+            server.getMemberListFloodDelayMs()
+        ).then(() => {
             joinNextUser();
         }, (err) => { // discard error, this will be due to timeouts which we don't want to log
             joinNextUser();

--- a/lib/config/schema.yml
+++ b/lib/config/schema.yml
@@ -132,6 +132,8 @@ properties:
                             properties:
                                 enabled:
                                     type: "boolean"
+                                floodDelayMs:
+                                    type: "integer"
                                 global:
                                     type: "object"
                                     properties:

--- a/lib/irc/IrcServer.js
+++ b/lib/irc/IrcServer.js
@@ -44,6 +44,10 @@ IrcServer.prototype.shouldFederatePMs = function() {
     return this.config.privateMessages.federate;
 };
 
+IrcServer.prototype.getMemberListFloodDelayMs = function() {
+    return this.config.membershipLists.floodDelayMs;
+};
+
 IrcServer.prototype.shouldFederate = function() {
     return this.config.dynamicChannels.federate;
 };
@@ -384,6 +388,7 @@ IrcServer.DEFAULT_CONFIG = {
     },
     membershipLists: {
         enabled: false,
+        floodDelayMs: 10000, // 10s
         global: {
             ircToMatrix: {
                 initial: false,


### PR DESCRIPTION
This replaces `JOIN_WAIT_TIME_MS` which was hard-coded to 10s. This means we
can sync membership lists from M->I much more rapidly if we are allowed to
(e.g. by being on IPv6).

Also tweak how we invoked `joinNextUser()`. It appears that using `finally()`
is NOT enough to make bluebird not whine about uncaught exceptions, resulting
in `TimeoutErrors` in the logs. We now explicitly `then()` the Promise and just
do the same no matter what happens (which is semantically the same as `finally`).
This removes all those `TimeoutErrors` in the logs \o/