### PR TITLE
Allow setting a custom CA

### DIFF
--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -30,6 +30,12 @@ ircService:
       ssl: true
       # Whether or not IRC server is using a self-signed cert or not providing CA Chain
       sslselfsign: false
+      # A specific CA to trust instead of the default CAs. Optional.
+      #ca: |
+      #  -----BEGIN CERTIFICATE-----
+      #  ...
+      #  -----END CERTIFICATE-----
+
       #
       # The connection password to send for all clients as a PASS command. Optional.
       # password: 'pa$$w0rd'

--- a/lib/irc/ConnectionInstance.js
+++ b/lib/irc/ConnectionInstance.js
@@ -249,11 +249,15 @@ ConnectionInstance.create = function(server, opts, onCreatedCallback) {
         floodProtection: true,
         floodProtectionDelay: FLOOD_PROTECTION_DELAY_MS,
         port: server.getPort(),
-        secure: server.useSsl(),
         selfSigned: server.useSslSelfSigned(),
         retryCount: 0,
         family: server.getIpv6Prefix() ? 6 : 4,
     };
+
+    if (server.useSsl()) {
+        connectionOpts.secure = { ca: server.getCA() };
+    }
+
     // TODO : coroutine this
     var d = promiseutil.defer();
     var returnClient = function(cli) {

--- a/lib/irc/IrcServer.js
+++ b/lib/irc/IrcServer.js
@@ -74,6 +74,10 @@ IrcServer.prototype.isInWhitelist = function(userId) {
     return this.config.dynamicChannels.whitelist.indexOf(userId) !== -1;
 };
 
+IrcServer.prototype.getCA = function() {
+    return this.config.ca;
+};
+
 IrcServer.prototype.useSsl = function() {
     return Boolean(this.config.ssl);
 };


### PR DESCRIPTION
In some configurations it's useful to trust a single CA only. This allows setting the 'ca' parameter from the configuration file.