### PR TITLE
Stop the freenode bridge from spinning for minutes by fixing #242

### DIFF
--- a/lib/bridge/MemberListSyncer.js
+++ b/lib/bridge/MemberListSyncer.js
@@ -95,34 +95,30 @@ MemberListSyncer.prototype.checkBotPartRoom = Promise.coroutine(function*(ircRoo
 
     if (matrixRooms.length === 0) {
         // no mapped rooms, leave the channel.
-        this.ircBridge.partBot(ircRoom);
+        yield this.ircBridge.partBot(ircRoom);
+        return;
     }
-    else if (matrixRooms.length === 1) {
-        // common case, just hit /state rather than slow /initialSync
-        let roomId = matrixRooms[0].getId();
+
+    // At least 1 mapped room - query for the membership list in each room. If there are
+    // any real users still left in the room, then do not part the bot from the channel.
+    // Query via /$room_id/state rather than /initialSync as the latter can cause
+    // the bridge to spin for minutes if the response is large.
+
+    let shouldPart = true;
+    for (let i = 0; i < matrixRooms.length; i++) {
+        let roomId = matrixRooms[i].getId();
+        req.log.debug("checkBotPartRoom: Querying room state in room %s", roomId);
         let res = yield this.appServiceBot.getClient().roomState(roomId);
         let data = getRoomMemberData(ircRoom.server, roomId, res, this.appServiceUserId);
-        req.log.debug("%s Matrix users are in room %s", data.reals.length, roomId);
-        if (data.reals.length === 0) {
-            this.ircBridge.partBot(ircRoom);
+        req.log.debug("checkBotPartRoom: %s Matrix users are in room %s", data.reals.length, roomId);
+        if (data.reals.length > 0) {
+            shouldPart = false;
+            break;
         }
     }
-    else {
-        // hit initial sync to get list
-        let syncableRooms = yield this._getSyncableRooms(ircRoom.server, true);
-        matrixRooms.forEach(function(matrixRoom) {
-            // if the room isn't in the syncable rooms list, then we part.
-            var shouldPart = true;
-            for (var i = 0; i < syncableRooms.length; i++) {
-                if (syncableRooms[i].id === matrixRoom.getId()) {
-                    shouldPart = false;
-                    break;
-                }
-            }
-            if (shouldPart) {
-                this.ircBridge.partBot(ircRoom);
-            }
-        });
+
+    if (shouldPart) {
+        yield this.ircBridge.partBot(ircRoom);
     }
 });
 

--- a/lib/bridge/MemberListSyncer.js
+++ b/lib/bridge/MemberListSyncer.js
@@ -110,7 +110,9 @@ MemberListSyncer.prototype.checkBotPartRoom = Promise.coroutine(function*(ircRoo
         req.log.debug("checkBotPartRoom: Querying room state in room %s", roomId);
         let res = yield this.appServiceBot.getClient().roomState(roomId);
         let data = getRoomMemberData(ircRoom.server, roomId, res, this.appServiceUserId);
-        req.log.debug("checkBotPartRoom: %s Matrix users are in room %s", data.reals.length, roomId);
+        req.log.debug(
+            "checkBotPartRoom: %s Matrix users are in room %s", data.reals.length, roomId
+        );
         if (data.reals.length > 0) {
             shouldPart = false;
             break;

--- a/spec/util/irc-client-mock.js
+++ b/spec/util/irc-client-mock.js
@@ -54,7 +54,7 @@ function Client(addr, nick, opts) {
 
     var spies = [
         "connect", "whois", "join", "send", "action", "ctcp", "say",
-        "disconnect", "notice", "part", "names"
+        "disconnect", "notice", "part", "names", "mode"
     ];
     spies.forEach(function(fnName) {
         self[fnName] = jasmine.createSpy("Client." + fnName);


### PR DESCRIPTION
The spin was caused by the bridge processing the `/initialSync` JSON response.
This is a huge wodge of JSON which took **minutes** to process into a JSON
object. This completely wedged the bridge for that length of time
(no logging, no ping/pongs, no messages being sent/recv).

This fixes it by never calling `/initialSync`, and instead always using
`/$room_id/state` even if there are >1 mapped Matrix rooms for a given IRC channel.