### PR TITLE
Set `rate_limited = false` reg flag on generation

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -84,6 +84,10 @@ module.exports.generateRegistration = Promise.coroutine(function*(reg, config) {
     reg.setHomeserverToken(AppServiceRegistration.generateToken());
     reg.setAppServiceToken(asToken || AppServiceRegistration.generateToken());
 
+    // Disable rate limiting to allow large numbers of requests when many IRC users
+    // connect, for example on startup.
+    reg.setRateLimited(false);
+
     let serverDomains = Object.keys(config.ircService.servers);
     serverDomains.sort().forEach(function(domain) {
         let server = _toServer(domain, config.ircService.servers[domain]);


### PR DESCRIPTION
This is to prevent rate limiting from the HS, for example when starting up with lots of users to connect and lots of messages being sent I->M by NickServ/ChanServ.

This depends on https://github.com/matrix-org/matrix-appservice-node/pull/6