### PR TITLE
Ignore IRC onPM if bot and not message

### DIFF
--- a/lib/bridge/IrcHandler.js
+++ b/lib/bridge/IrcHandler.js
@@ -114,16 +114,21 @@ IrcHandler.prototype.onPrivateMessage = Promise.coroutine(function*(req, server,
         req.log.error("Cannot route PM to %s - no client", toUser);
         return;
     }
-    if (bridgedIrcClient.isBot && action.type === "message") {
+    req.log.info("onPrivateMessage: %s from=%s to=%s action=%s",
+        server.domain, fromUser, toUser,
+        JSON.stringify(action).substring(0, 80)
+    );
+
+    if (bridgedIrcClient.isBot) {
+        if (!action.type === "message") {
+            req.log.info("Ignoring non-message PM");
+            return;
+        }
         req.log.debug("Rerouting PM directed to the bot from %s to provisioning", fromUser);
         this.ircBridge.getProvisioner().handlePm(server, fromUser, action.text);
         return;
     }
 
-    req.log.info("onPrivateMessage: %s from=%s to=%s action=%s",
-        server.domain, fromUser, toUser,
-        JSON.stringify(action).substring(0, 80)
-    );
 
     if (!server.allowsPms()) {
         req.log.error("Server %s disallows PMs.", server.domain);


### PR DESCRIPTION
The IRC handler will ignore PMs directed to a bridgedClient that is as bot unless the IRC action type is "message". This includes notices from NickServ, for example.