### PR TITLE
Add !quit command to admin rooms

### DIFF
--- a/lib/bridge/MatrixHandler.js
+++ b/lib/bridge/MatrixHandler.js
@@ -452,7 +452,9 @@ MatrixHandler.prototype._onAdminMessage = Promise.coroutine(function*(req, event
         return;
     }
     else if (cmd === "!quit") {
-        clientList.forEach((bridgedClient) => {
+        clientList.filter(
+            (bridgedClient) => bridgedClient.server.domain === ircServer.domain
+        ).forEach((bridgedClient) => {
             bridgedClient.kill();
         });
     }

--- a/lib/bridge/MatrixHandler.js
+++ b/lib/bridge/MatrixHandler.js
@@ -451,6 +451,11 @@ MatrixHandler.prototype._onAdminMessage = Promise.coroutine(function*(req, event
         yield this.ircBridge.sendMatrixAction(adminRoom, botUser, notice, req);
         return;
     }
+    else if (cmd === "!quit") {
+        clientList.forEach((bridgedClient) => {
+            bridgedClient.kill();
+        });
+    }
     else if (cmd === "!cmd" && args[0]) {
         req.log.info(`No valid (old form) admin command, will try new format`);
 

--- a/lib/irc/BridgedClient.js
+++ b/lib/irc/BridgedClient.js
@@ -119,6 +119,10 @@ BridgedClient.prototype.connect = Promise.coroutine(function*() {
             "Connecting to IRC server %s as %s (user=%s)",
             server.domain, this.nick, nameInfo.username
         );
+        this._eventBroker.sendMetadata(this,
+            `Connecting to the IRC network '${this.server.domain}' as ${this.nick}...`
+        );
+
         let connInst = yield ConnectionInstance.create(server, {
             nick: this.nick,
             username: nameInfo.username,
@@ -571,7 +575,7 @@ BridgedClient.prototype._onConnectionCreated = function(connInst, nameInfo) {
         self.emit("client-disconnected", self);
         self._eventBroker.sendMetadata(self,
             "Your connection to the IRC network '" + self.server.domain +
-            "' has been lost. Reconnecting."
+            "' has been lost. "
         );
     };
 


### PR DESCRIPTION
Send `!quit server.name` to kill all bridgedClients that the sending use has associated with the specified server. This required some updates to the connection notices; the one that indicates a disconnect now doesn't read '...Reconnecting' and this has been replaced by a separate notice that says 'Connecting...' when a client is doing so. This does mean that if the server isn't starting up and the clients reconnect for any reason, 3 notices are now seen instead of 2, but I feel like that's a fair trade-off for being better informed.