### PR TITLE
Allow topic setting /w mappings origin undefined

### DIFF
--- a/lib/DataStore.js
+++ b/lib/DataStore.js
@@ -258,7 +258,7 @@ DataStore.prototype.getMappingsForChannelByOrigin = function(server, channel, or
     let remoteId = IrcRoom.createId(server, channel);
     return this._roomStore.getEntriesByLinkData({}).then((entries) => {
         return entries.filter((e) => {
-            if (!(e.remote && e.remote.getId() === remoteId)) {
+            if (!e.remote || e.remote.getId() !== remoteId) {
                 return false;
             }
             if (allowUnset) {

--- a/lib/DataStore.js
+++ b/lib/DataStore.js
@@ -258,10 +258,15 @@ DataStore.prototype.getMappingsForChannelByOrigin = function(server, channel, or
     let remoteId = IrcRoom.createId(server, channel);
     return this._roomStore.getEntriesByLinkData({}).then((entries) => {
         return entries.filter((e) => {
-            return e.remote && e.remote.getId() === remoteId && (
-                (typeof e.data.origin === 'undefined' && allowUnset) ||
-                origin.indexOf(e.data.origin) !== -1
-            );
+            if (!(e.remote && e.remote.getId() === remoteId)) {
+                return false;
+            }
+            if (allowUnset) {
+                if (typeof e.data === 'undefined' || typeof e.data.origin === 'undefined') {
+                    return true;
+                }
+            }
+            return origin.indexOf(e.data.origin) !== -1;
         });
     });
 };

--- a/lib/DataStore.js
+++ b/lib/DataStore.js
@@ -262,11 +262,11 @@ DataStore.prototype.getMappingsForChannelByOrigin = function(server, channel, or
                 return false;
             }
             if (allowUnset) {
-                if (typeof e.data === 'undefined' || typeof e.data.origin === 'undefined') {
+                if (!e.data || !e.data.origin) {
                     return true;
                 }
             }
-            return origin.indexOf(e.data.origin) !== -1;
+            return e.data && origin.indexOf(e.data.origin) !== -1;
         });
     });
 };

--- a/lib/DataStore.js
+++ b/lib/DataStore.js
@@ -245,7 +245,7 @@ DataStore.prototype.getMatrixRoomsForChannel = function(server, channel) {
     );
 };
 
-DataStore.prototype.getMappingsForChannelByOrigin = function(server, channel, origin) {
+DataStore.prototype.getMappingsForChannelByOrigin = function(server, channel, origin, allowUndefined) {
     log.debug(
         "getMatrixRoomsForChannelByOrigin " + channel + ", origin: " + JSON.stringify(origin)
     );
@@ -256,12 +256,12 @@ DataStore.prototype.getMappingsForChannelByOrigin = function(server, channel, or
         throw new Error("origin must be string or array of strings");
     }
     let remoteId = IrcRoom.createId(server, channel);
-
-    return this._roomStore.getEntriesByLinkData({
-        origin: {$in : origin}
-    }).then((entries) => {
+    return this._roomStore.getEntriesByLinkData({}).then((entries) => {
         return entries.filter((e) => {
-            return e.remote.getId() === remoteId
+            return e.remote && e.remote.getId() === remoteId && (
+                (typeof e.data.origin === 'undefined' && allowUndefined) ||
+                origin.indexOf(e.data.origin) !== -1
+            );
         });
     });
 };

--- a/lib/DataStore.js
+++ b/lib/DataStore.js
@@ -245,7 +245,7 @@ DataStore.prototype.getMatrixRoomsForChannel = function(server, channel) {
     );
 };
 
-DataStore.prototype.getMappingsForChannelByOrigin = function(server, channel, origin, allowUndefined) {
+DataStore.prototype.getMappingsForChannelByOrigin = function(server, channel, origin, allowUnset) {
     log.debug(
         "getMatrixRoomsForChannelByOrigin " + channel + ", origin: " + JSON.stringify(origin)
     );
@@ -259,7 +259,7 @@ DataStore.prototype.getMappingsForChannelByOrigin = function(server, channel, or
     return this._roomStore.getEntriesByLinkData({}).then((entries) => {
         return entries.filter((e) => {
             return e.remote && e.remote.getId() === remoteId && (
-                (typeof e.data.origin === 'undefined' && allowUndefined) ||
+                (typeof e.data.origin === 'undefined' && allowUnset) ||
                 origin.indexOf(e.data.origin) !== -1
             );
         });

--- a/lib/bridge/IrcHandler.js
+++ b/lib/bridge/IrcHandler.js
@@ -250,7 +250,7 @@ IrcHandler.prototype.onTopic = Promise.coroutine(function*(req, server, fromUser
     // Only bridge topics for rooms created by the bridge, via !join or an alias
     let origins = ["join", "alias"];
     let entries = yield this.ircBridge.getStore().getMappingsForChannelByOrigin(
-        server, channel, origins
+        server, channel, origins, true
     );
     if (entries.length === 0) {
         req.log.info(


### PR DESCRIPTION
Before 'origin' was introduced, entries were created without an origin. When setting a topic, allow them to be set on rooms with unknown origin as well as origin = 'join' | 'alias'.