### PR TITLE
Make config schema path to be relative to installation directory

### DIFF
--- a/app.js
+++ b/app.js
@@ -2,6 +2,7 @@
 var Cli = require("matrix-appservice-bridge").Cli;
 var log = require("./lib/logging").get("CLI");
 var main = require("./lib/main");
+var path = require("path");
 
 const REG_PATH = "appservice-registration-irc.yaml";
 
@@ -11,7 +12,7 @@ new Cli({
     enableLocalpart: true,
     bridgeConfig: {
         affectsRegistration: true,
-        schema: "./lib/config/schema.yml",
+        schema: path.join(__dirname, "lib/config/schema.yml"),
         defaults: main.defaultConfig()
     },
     generateRegistration: function(reg, callback) {


### PR DESCRIPTION
This changed fixes wrong assumption that working directory of IRC bridge is always a directory where it's installed.

Schema path has been changed to be relative to installation directory, not working directory.