### PR TITLE
Prevent races I->M with creating new PM rooms

### DIFF
--- a/lib/bridge/IrcHandler.js
+++ b/lib/bridge/IrcHandler.js
@@ -31,6 +31,15 @@ function IrcHandler(ircBridge) {
     this.topicQueues = {
         //$channel : Queue
     }
+
+    // A map of promises that resolve to the PM room that has been created for the
+    // two users in the key. The $fromUserId is the user ID of the virtual IRC user
+    // and the $toUserId, the user ID of the recipient of the message. This is used
+    // to prevent races when many messages are sent as PMs at once and therefore
+    // prevent many pm rooms from being created.
+    this.pmRoomPromises = {
+        //'$fromUserId $toUserId' : Promise
+    };
 }
 
 IrcHandler.prototype.onMatrixMemberEvent = function(event) {
@@ -94,6 +103,40 @@ IrcHandler.prototype._ensureMatrixUserJoined = Promise.coroutine(function*(roomI
 });
 
 /**
+ * Create a new matrix PM room for an IRC user  with nick `fromUserNick` and another
+ * matrix user with user ID `toUserId`.
+ * @param {string} toUserId : The user ID of the recipient.
+ * @param {string} fromUserId : The user ID of the sender.
+ * @param {string} fromUserNick : The nick of the sender.
+ * @param {IrcServer} server : The sending IRC server.
+ * @return {Promise} which is resolved when the PM room has been created.
+ */
+IrcHandler.prototype._createPmRoom = Promise.coroutine(
+    function*(toUserId, fromUserId, fromUserNick, server) {
+        let response = yield this.ircBridge.getAppServiceBridge().getIntent(
+            fromUserId
+        ).createRoom({
+            createAsClient: true,
+            options: {
+                name: (fromUserNick + " (PM on " + server.domain + ")"),
+                visibility: "private",
+                invite: [toUserId],
+                creation_content: {
+                    "m.federate": server.shouldFederatePMs()
+                }
+            }
+        });
+        let pmRoom = new MatrixRoom(response.room_id);
+        let ircRoom = new IrcRoom(server, fromUserNick);
+        yield this.ircBridge.getStore().setPmRoom(
+            ircRoom, pmRoom, toUserId, fromUserId
+        );
+
+        return pmRoom;
+    }
+);
+
+/**
  * Called when the AS receives an IRC message event.
  * @param {IrcServer} server : The sending IRC server.
  * @param {IrcUser} fromUser : The sender.
@@ -154,26 +197,18 @@ IrcHandler.prototype.onPrivateMessage = Promise.coroutine(function*(req, server,
     );
 
     if (!pmRoom) {
-        // make a pm room then send the message
-        req.log.info("Creating a PM room with %s", bridgedIrcClient.userId);
-        let response = yield this.ircBridge.getAppServiceBridge().getIntent(
-            virtualMatrixUser.getId()
-        ).createRoom({
-            createAsClient: true,
-            options: {
-                name: (fromUser.nick + " (PM on " + server.domain + ")"),
-                visibility: "private",
-                invite: [bridgedIrcClient.userId],
-                creation_content: {
-                    "m.federate": server.shouldFederatePMs()
-                }
-            }
-        });
-        pmRoom = new MatrixRoom(response.room_id);
-        let ircRoom = new IrcRoom(server, fromUser.nick);
-        yield this.ircBridge.getStore().setPmRoom(
-            ircRoom, pmRoom, bridgedIrcClient.userId, virtualMatrixUser.getId()
-        );
+        let pmRoomPromiseId = bridgedIrcClient.userId + ' ' + virtualMatrixUser.getId();
+
+        // If a promise to create this PM room does not already exist, create one
+        if (!this.pmRoomPromises[pmRoomPromiseId]) {
+            req.log.info("Creating a PM room with %s", bridgedIrcClient.userId);
+            this.pmRoomPromises[pmRoomPromiseId] = this._createPmRoom(
+                bridgedIrcClient.userId, virtualMatrixUser.getId(), fromUser.nick, server
+            );
+        }
+
+        // Yield on the PM room being created
+        pmRoom = yield this.pmRoomPromises[pmRoomPromiseId];
     }
     else {
         // make sure that the matrix user is still in the room

--- a/lib/bridge/IrcHandler.js
+++ b/lib/bridge/IrcHandler.js
@@ -128,6 +128,8 @@ IrcHandler.prototype._createPmRoom = Promise.coroutine(
         });
         let pmRoom = new MatrixRoom(response.room_id);
         let ircRoom = new IrcRoom(server, fromUserNick);
+
+
         yield this.ircBridge.getStore().setPmRoom(
             ircRoom, pmRoom, toUserId, fromUserId
         );
@@ -198,17 +200,19 @@ IrcHandler.prototype.onPrivateMessage = Promise.coroutine(function*(req, server,
 
     if (!pmRoom) {
         let pmRoomPromiseId = bridgedIrcClient.userId + ' ' + virtualMatrixUser.getId();
+        let p = this.pmRoomPromises[pmRoomPromiseId];
 
         // If a promise to create this PM room does not already exist, create one
-        if (!this.pmRoomPromises[pmRoomPromiseId]) {
+        if (!p || p.isRejected()) {
             req.log.info("Creating a PM room with %s", bridgedIrcClient.userId);
             this.pmRoomPromises[pmRoomPromiseId] = this._createPmRoom(
                 bridgedIrcClient.userId, virtualMatrixUser.getId(), fromUser.nick, server
             );
+            p = this.pmRoomPromises[pmRoomPromiseId];
         }
 
         // Yield on the PM room being created
-        pmRoom = yield this.pmRoomPromises[pmRoomPromiseId];
+        pmRoom = yield p;
     }
     else {
         // make sure that the matrix user is still in the room

--- a/lib/bridge/IrcHandler.js
+++ b/lib/bridge/IrcHandler.js
@@ -129,7 +129,6 @@ IrcHandler.prototype._createPmRoom = Promise.coroutine(
         let pmRoom = new MatrixRoom(response.room_id);
         let ircRoom = new IrcRoom(server, fromUserNick);
 
-
         yield this.ircBridge.getStore().setPmRoom(
             ircRoom, pmRoom, toUserId, fromUserId
         );

--- a/spec/integ/pm.spec.js
+++ b/spec/integ/pm.spec.js
@@ -314,18 +314,16 @@ describe("IRC-to-Matrix PMing", function() {
                 });
             });
         });
+        let MESSAGE_COUNT = 10;
+        let receivedMessageCount = 0;
 
         // mock send message impl
         let sentMessagePromise = new Promise(function(resolve, reject) {
-            sdk.sendEvent.andCallFake(function(roomId, type, content) {
-                expect(roomId).toEqual(tCreatedRoomId);
-                expect(type).toEqual("m.room.message");
-                expect(content).toEqual({
-                    body: tText,
-                    msgtype: "m.text"
-                });
-                resolve();
-                return Promise.resolve({});
+            sdk.sendEvent.andCallFake(() => {
+                receivedMessageCount++;
+                if (receivedMessageCount === MESSAGE_COUNT) {
+                    resolve();
+                }
             });
         });
 
@@ -335,7 +333,7 @@ describe("IRC-to-Matrix PMing", function() {
         );
 
         // Send several messages, almost at once, to simulate a race
-        for (var i = 0; i < 10; i++) {
+        for (var i = 0; i < MESSAGE_COUNT; i++) {
             client.emit("message", tRealIrcUserNick, tRealMatrixUserNick, tText);
         }
 


### PR DESCRIPTION
When creating a new PM room, immediately create a promise and store it in an object that maps each stored pair of user IDs (one virtual IRC user and one matrix user) to a promise that resolves when the pm room has been created.