### PR TITLE
Use the home server domain in all templates

### DIFF
--- a/lib/bridge/IrcBridge.js
+++ b/lib/bridge/IrcBridge.js
@@ -170,7 +170,7 @@ IrcBridge.prototype.run = Promise.coroutine(function*(port) {
         let completeConfig = extend(
             true, {}, IrcServer.DEFAULT_CONFIG, this.config.ircService.servers[domain]
         );
-        let server = new IrcServer(domain, completeConfig);
+        let server = new IrcServer(domain, completeConfig, this.config.homeserver.domain);
         // store the config mappings in the DB to keep everything in one place.
         yield this._dataStore.setServerFromConfig(server, completeConfig);
         this.ircServers.push(server);
@@ -524,7 +524,7 @@ IrcBridge.prototype.getThirdPartyLocation = function(protocol, fields) {
         return Promise.resolve([]);
     }
 
-    var alias = server.getAliasFromChannel(channel, this.config.homeserver.domain);
+    var alias = server.getAliasFromChannel(channel);
 
     return Promise.resolve([
         {
@@ -555,7 +555,7 @@ IrcBridge.prototype.getThirdPartyUser = function(protocol, fields) {
         return Promise.resolve([]);
     }
 
-    var userId = server.getUserIdFromNick(nick, this.config.homeserver.domain);
+    var userId = server.getUserIdFromNick(nick);
 
     return Promise.resolve([
         {

--- a/lib/bridge/MatrixHandler.js
+++ b/lib/bridge/MatrixHandler.js
@@ -952,7 +952,7 @@ MatrixHandler.prototype._onMessage = Promise.coroutine(function*(req, event) {
         // convert the sender's user ID to a nick and back to a virtual user for this server
         // then send from that user ID (yuck!).
         let n = otherServer.getNick(event.user_id);
-        let virtUserId = otherServer.getUserIdFromNick(n, this.ircBridge.config.homeserver.domain);
+        let virtUserId = otherServer.getUserIdFromNick(n);
         promises.push(
             this.ircBridge.sendMatrixAction(
                 new MatrixRoom(roomId), new MatrixUser(virtUserId), mxAction, req

--- a/lib/irc/IrcServer.js
+++ b/lib/irc/IrcServer.js
@@ -12,9 +12,11 @@ var log = logging.get("IrcServer");
  * @param {string} domain : The IRC network address
  * @param {Object} serverConfig : The config options for this network.
  */
-function IrcServer(domain, serverConfig) {
+function IrcServer(domain, serverConfig, homeserverDomain) {
     this.domain = domain;
     this.config = serverConfig;
+
+    this._homeserverDomain = homeserverDomain;
 }
 
 /**
@@ -249,7 +251,7 @@ IrcServer.prototype.claimsUserId = function(userId) {
         {
             "$NICK": "(.*)"
         },
-        ":.*"
+        ":" + escapeRegExp(this._homeserverDomain)
     );
     return new RegExp(regex).test(userId);
 };
@@ -264,7 +266,7 @@ IrcServer.prototype.getNickFromUserId = function(userId) {
         {
             "$NICK": "(.*?)"
         },
-        ":.*"
+        ":" + escapeRegExp(this._homeserverDomain)
     );
     var match = new RegExp(regex).exec(userId);
     if (!match) {
@@ -273,10 +275,10 @@ IrcServer.prototype.getNickFromUserId = function(userId) {
     return match[1];
 };
 
-IrcServer.prototype.getUserIdFromNick = function(nick, homeserverDomain) {
+IrcServer.prototype.getUserIdFromNick = function(nick) {
     var template = this.config.matrixClients.userTemplate;
     return template.replace(/\$NICK/g, nick).replace(/\$SERVER/g, this.domain) +
-        ":" + homeserverDomain;
+        ":" + this._homeserverDomain;
 };
 
 IrcServer.prototype.getDisplayNameFromNick = function(nick) {
@@ -296,7 +298,7 @@ IrcServer.prototype.claimsAlias = function(alias) {
         {
             "$CHANNEL": "#(.*)"
         },
-        ":.*"
+        ":" + escapeRegExp(this._homeserverDomain)
     );
     return new RegExp(regex).test(alias);
 };
@@ -311,7 +313,7 @@ IrcServer.prototype.getChannelFromAlias = function(alias) {
         {
             "$CHANNEL": "([^:]*)"
         },
-        ":.*"
+        ":" + escapeRegExp(this._homeserverDomain)
     );
     var match = new RegExp(regex).exec(alias);
     if (!match) {
@@ -321,9 +323,9 @@ IrcServer.prototype.getChannelFromAlias = function(alias) {
     return match[1];
 };
 
-IrcServer.prototype.getAliasFromChannel = function(channel, homeserverDomain) {
+IrcServer.prototype.getAliasFromChannel = function(channel) {
     var template = this.config.dynamicChannels.aliasTemplate;
-    return template.replace(/\$CHANNEL/, channel) + ":" + homeserverDomain;
+    return template.replace(/\$CHANNEL/, channel) + ":" + this._homeserverDomain;
 };
 
 IrcServer.prototype.getNick = function(userId, displayName) {
@@ -336,7 +338,7 @@ IrcServer.prototype.getNick = function(userId, displayName) {
     return nick;
 };
 
-IrcServer.prototype.getAliasRegex = function(homeserverDomain) {
+IrcServer.prototype.getAliasRegex = function() {
     return templateToRegex(
         this.config.dynamicChannels.aliasTemplate,
         {
@@ -346,11 +348,11 @@ IrcServer.prototype.getAliasRegex = function(homeserverDomain) {
             "$CHANNEL": ".*"  // the nick is unknown, so replace with a wildcard
         },
         // Only match the domain of the HS
-        ":" + escapeRegExp(homeserverDomain)
+        ":" + escapeRegExp(this._homeserverDomain)
     );
 };
 
-IrcServer.prototype.getUserRegex = function(homeserverDomain) {
+IrcServer.prototype.getUserRegex = function() {
     return templateToRegex(
         this.config.matrixClients.userTemplate,
         {
@@ -360,7 +362,7 @@ IrcServer.prototype.getUserRegex = function(homeserverDomain) {
             "$NICK": ".*"  // the nick is unknown, so replace with a wildcard
         },
         // Only match the domain of the HS
-        ":" + escapeRegExp(homeserverDomain)
+        ":" + escapeRegExp(this._homeserverDomain)
     );
 };
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -18,7 +18,7 @@ process.on("unhandledRejection", function(reason, promise) {
     log.error(reason ? reason.stack : "No reason given");
 });
 
-var _toServer = function(domain, serverConfig) {
+var _toServer = function(domain, serverConfig, homeserverDomain) {
     // set server config defaults
     if (serverConfig.dynamicChannels.visibility) {
         throw new Error(
@@ -27,7 +27,9 @@ var _toServer = function(domain, serverConfig) {
             and dynamicChannels.createAlias instead.`
         );
     }
-    return new IrcServer(domain, extend(true, IrcServer.DEFAULT_CONFIG, serverConfig));
+    return new IrcServer(
+        domain, extend(true, IrcServer.DEFAULT_CONFIG, serverConfig), homeserverDomain
+    );
 };
 
 module.exports.defaultConfig = function() {
@@ -93,15 +95,15 @@ module.exports.generateRegistration = Promise.coroutine(function*(reg, config) {
 
     let serverDomains = Object.keys(config.ircService.servers);
     serverDomains.sort().forEach(function(domain) {
-        let server = _toServer(domain, config.ircService.servers[domain]);
+        let server = _toServer(domain, config.ircService.servers[domain], config.homeserver.domain);
         server.getHardCodedRoomIds().sort().forEach(function(roomId) {
             reg.addRegexPattern("rooms", roomId, false);
         });
         // add an alias pattern for servers who want aliases exposed.
         if (server.createsDynamicAliases()) {
-            reg.addRegexPattern("aliases", server.getAliasRegex(config.homeserver.domain), true);
+            reg.addRegexPattern("aliases", server.getAliasRegex(), true);
         }
-        reg.addRegexPattern("users", server.getUserRegex(config.homeserver.domain), true);
+        reg.addRegexPattern("users", server.getUserRegex(), true);
     });
 
     return reg;


### PR DESCRIPTION
When two HSs with respective IRC bridges running, make sure that their templates for claiming things claim only on their respective HSs and not globally.

Aims to fix #190