### PR TITLE
Display join errors in admin room

### DIFF
--- a/lib/bridge/IrcHandler.js
+++ b/lib/bridge/IrcHandler.js
@@ -598,11 +598,12 @@ IrcHandler.prototype.onModeIs = Promise.coroutine(function*(req, server, channel
  * @param {Request} req The metadata request
  * @param {BridgedClient} client The client who is acting on behalf of the Matrix user.
  * @param {string} msg The message to share with the Matrix user.
+ * @param {boolean} force True if ignoring startup suppresion.
  * @return {Promise} which is resolved/rejected when the request finishes.
  */
-IrcHandler.prototype.onMetadata = Promise.coroutine(function*(req, client, msg) {
+IrcHandler.prototype.onMetadata = Promise.coroutine(function*(req, client, msg, force) {
     req.log.info("%s : Sending metadata '%s'", client, msg);
-    if (!this.ircBridge.isStartedUp()) {
+    if (!this.ircBridge.isStartedUp() && !force) {
         req.log.info("Suppressing metadata: not started up.");
         return;
     }

--- a/lib/irc/BridgedClient.js
+++ b/lib/irc/BridgedClient.js
@@ -648,6 +648,9 @@ BridgedClient.prototype._joinChannel = function(channel, key, attemptCount) {
             client.removeListener("error", failFn);
             defer.reject(new Error(err.command));
             this.emit("join-error", this, channel, err.command);
+            this._eventBroker.sendMetadata(
+                this, `Could not join ${channel} on '${this.server.domain}': ${err.command}`, true
+            );
         }
     };
     client.once("error", failFn);

--- a/lib/irc/IrcEventBroker.js
+++ b/lib/irc/IrcEventBroker.js
@@ -229,8 +229,8 @@ IrcEventBroker.prototype._hookIfClaimed = function(client, connInst, eventName, 
     });
 };
 
-IrcEventBroker.prototype.sendMetadata = function(client, msg) {
-    if (client.isBot || !client.server.shouldSendConnectionNotices()) {
+IrcEventBroker.prototype.sendMetadata = function(client, msg, force) {
+    if ((client.isBot || !client.server.shouldSendConnectionNotices()) && !force) {
         return;
     }
     var req = new BridgeRequest(
@@ -240,7 +240,7 @@ IrcEventBroker.prototype.sendMetadata = function(client, msg) {
             }
         })
     );
-    complete(req, this._ircHandler.onMetadata(req, client, msg));
+    complete(req, this._ircHandler.onMetadata(req, client, msg, force));
 };
 
 IrcEventBroker.prototype.addHooks = function(client, connInst) {


### PR DESCRIPTION
This works by ignoring startup suppression for errors that occur when joining a channel. When the bridge is restarted, users will be notified of all the channels that they must send a key to, using '!join ...'

Aims to fix #129 