### PR TITLE
Randomly jitter quit debouncing between min, max

### DIFF
--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -58,11 +58,17 @@ ircService:
         # The maximum number of quits per second acceptable above which a netsplit is
         # considered ongoing. Default: 5.
         quitsPerSecond: 5
-        # The time to wait before bridging a QUIT to Matrix that occured during a netsplit.
+        # The time window in which to wait before bridging a QUIT to Matrix that occured during
+        # a netsplit. Debouncing is jittered randomly between startMs and endMs so that the HS
+        # is not sent many requests to leave rooms all at once if a netsplit occurs and many
+        # people to not rejoin.
         # If the user with the same IRC nick as the one who sent the quit rejoins a channel
-        # before delayMs, consider them back online and do not bridge the quit.
+        # they are considered back online and the quit is not bridged, so long as the rejoin
+        # occurs before the randomly-jittered timeout is not reached.
         # Default: 3600000, = 1h
-        delayMs: 3600000 # 1h
+        startMs: 3600000 # 1h
+        # Default: 7200000, = 2h
+        endMs: 7200000 # 2h
 
       botConfig:
         # Enable the presence of the bot in IRC channels. The bot serves as the entity

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -59,16 +59,16 @@ ircService:
         # considered ongoing. Default: 5.
         quitsPerSecond: 5
         # The time window in which to wait before bridging a QUIT to Matrix that occured during
-        # a netsplit. Debouncing is jittered randomly between startMs and endMs so that the HS
+        # a netsplit. Debouncing is jittered randomly between delayMinMs and delayMaxMs so that the HS
         # is not sent many requests to leave rooms all at once if a netsplit occurs and many
         # people to not rejoin.
         # If the user with the same IRC nick as the one who sent the quit rejoins a channel
         # they are considered back online and the quit is not bridged, so long as the rejoin
         # occurs before the randomly-jittered timeout is not reached.
         # Default: 3600000, = 1h
-        startMs: 3600000 # 1h
+        delayMinMs: 3600000 # 1h
         # Default: 7200000, = 2h
-        endMs: 7200000 # 2h
+        delayMaxMs: 7200000 # 2h
 
       botConfig:
         # Enable the presence of the bot in IRC channels. The bot serves as the entity

--- a/lib/bridge/QuitDebouncer.js
+++ b/lib/bridge/QuitDebouncer.js
@@ -104,10 +104,13 @@ QuitDebouncer.prototype.debounceQuit = Promise.coroutine(function*(req, server, 
         return true;
     }
 
-    let debounceMs = server.getQuitDebounceDelayMs();
+    let debounceStartMs = server.getQuitDebounceStartMs();
+    let debounceEndMs = server.getQuitDebounceEndMs();
 
-    // We do want to immediately bridge a leave if undefined or set to 0
-    if (!debounceMs) {
+    let debounceMs = debounceStartMs + Math.random() * (debounceEndMs - debounceStartMs);
+
+    // We do want to immediately bridge a leave if <= 0
+    if (debounceMs <= 0) {
         return true;
     }
 

--- a/lib/bridge/QuitDebouncer.js
+++ b/lib/bridge/QuitDebouncer.js
@@ -104,10 +104,10 @@ QuitDebouncer.prototype.debounceQuit = Promise.coroutine(function*(req, server, 
         return true;
     }
 
-    let debounceStartMs = server.getQuitDebounceStartMs();
-    let debounceEndMs = server.getQuitDebounceEndMs();
+    let debounceDelayMinMs = server.getQuitDebounceDelayMinMs();
+    let debounceDelayMaxMs = server.getQuitDebounceDelayMaxMs();
 
-    let debounceMs = debounceStartMs + Math.random() * (debounceEndMs - debounceStartMs);
+    let debounceMs = debounceDelayMinMs + Math.random() * (debounceDelayMaxMs - debounceDelayMinMs);
 
     // We do want to immediately bridge a leave if <= 0
     if (debounceMs <= 0) {

--- a/lib/config/schema.yml
+++ b/lib/config/schema.yml
@@ -116,11 +116,11 @@ properties:
                                     type: "boolean"
                                 quitsPerSecond:
                                     type: "number"
-                                startMs:
+                                delayMinMs:
                                     type: "integer"
                                     minimum: 0
                                     exclusiveMinimum: true
-                                endMs:
+                                delayMaxMs:
                                     type: "integer"
                                     minimum: 0
                                     exclusiveMinimum: true

--- a/lib/config/schema.yml
+++ b/lib/config/schema.yml
@@ -116,8 +116,14 @@ properties:
                                     type: "boolean"
                                 quitsPerSecond:
                                     type: "number"
-                                delayMs:
-                                    type: "number"
+                                startMs:
+                                    type: "integer"
+                                    minimum: 0
+                                    exclusiveMinimum: true
+                                endMs:
+                                    type: "integer"
+                                    minimum: 0
+                                    exclusiveMinimum: true
                         botConfig:
                             type: "object"
                             properties:

--- a/lib/irc/IrcServer.js
+++ b/lib/irc/IrcServer.js
@@ -46,18 +46,18 @@ IrcServer.prototype.shouldDebounceQuits = function() {
  * the quit to a leave, the leave will not be sent.
  * @return {number}
  */
-IrcServer.prototype.getQuitDebounceStartMs = function() {
-    return this.config.quitDebounce.startMs;
+IrcServer.prototype.getQuitDebounceDelayMinMs = function() {
+    return this.config.quitDebounce.delayMinMs;
 }
 
 /**
  * Get the maximum number of ms to debounce before bridging a QUIT to Matrix
  * during a detected net-split. If a leave is bridged, it will occur at a
- * random time between startMs (see above) endMs.
+ * random time between delayMinMs (see above) delayMaxMs.
  * @return {number}
  */
-IrcServer.prototype.getQuitDebounceEndMs = function() {
-    return this.config.quitDebounce.endMs;
+IrcServer.prototype.getQuitDebounceDelayMaxMs = function() {
+    return this.config.quitDebounce.delayMaxMs;
 }
 
 /**
@@ -412,8 +412,8 @@ IrcServer.DEFAULT_CONFIG = {
     quitDebounce: {
         enabled: false,
         quitsPerSecond: 5,
-        startMs: 3600000, // 1h
-        endMs: 7200000, // 2h
+        delayMinMs: 3600000, // 1h
+        delayMaxMs: 7200000, // 2h
     },
     botConfig: {
         nick: "appservicebot",

--- a/lib/irc/IrcServer.js
+++ b/lib/irc/IrcServer.js
@@ -41,13 +41,23 @@ IrcServer.prototype.shouldDebounceQuits = function() {
 }
 
 /**
- * Get the number of ms to debounce before bridging a QUIT to Matrix
+ * Get the minimum number of ms to debounce before bridging a QUIT to Matrix
  * during a detected net-split. If the user rejoins a channel before bridging
  * the quit to a leave, the leave will not be sent.
  * @return {number}
  */
-IrcServer.prototype.getQuitDebounceDelayMs = function() {
-    return this.config.quitDebounce.delayMs;
+IrcServer.prototype.getQuitDebounceStartMs = function() {
+    return this.config.quitDebounce.startMs;
+}
+
+/**
+ * Get the maximum number of ms to debounce before bridging a QUIT to Matrix
+ * during a detected net-split. If a leave is bridged, it will occur at a
+ * random time between startMs (see above) endMs.
+ * @return {number}
+ */
+IrcServer.prototype.getQuitDebounceEndMs = function() {
+    return this.config.quitDebounce.endMs;
 }
 
 /**
@@ -402,7 +412,8 @@ IrcServer.DEFAULT_CONFIG = {
     quitDebounce: {
         enabled: false,
         quitsPerSecond: 5,
-        delayMs: 3600000, // 1h
+        startMs: 3600000, // 1h
+        endMs: 7200000, // 2h
     },
     botConfig: {
         nick: "appservicebot",


### PR DESCRIPTION
Add config to allow specification of jittering window.
When a QUIT occurs, jitter the timeout between a min and max time before bridging the leave.

Aims to fix #274 