### PR TITLE
Fix the bridge tightlooping when Matrix users leave a bridged channel

### DIFF
--- a/lib/bridge/MatrixHandler.js
+++ b/lib/bridge/MatrixHandler.js
@@ -876,6 +876,9 @@ MatrixHandler.prototype._onLeave = Promise.coroutine(function*(req, event, user,
         if (!client) {
             return; // no client left the room, so no need to recheck part room.
         }
+        if (!ircRoom.server.isBotEnabled()) {
+            return; // don't do expensive queries needlessly
+        }
         if (!ircRoom.server.shouldJoinChannelsIfNoUsers()) {
             if (ircRoom.server.domain) {
                 // this = IrcBridge


### PR DESCRIPTION
This is a deeply unsatisfying fix. `checkBotPartRoom` would be called even if
the bot was disabled, so all the tightlooping work was needlessly being done.

It's unsatisfying because this sidesteps the real issue here. The cause of the
tightloop is still unknown, but this fixes the problem for Freenode.