### PR TITLE
Try to kick bridged mx users on !quit

### DIFF
--- a/lib/bridge/MatrixHandler.js
+++ b/lib/bridge/MatrixHandler.js
@@ -485,7 +485,10 @@ MatrixHandler.prototype._onAdminMessage = Promise.coroutine(function*(req, event
         let bridgedClient = clients[0];
 
         if (bridgedClient.chanList.length === 0) {
-            req.log.info(`Bridged client for ${event.user_id} is not in any channels on ${ircServer.domain}`);
+            req.log.info(
+                `Bridged client for ${event.user_id} is not in any channels ` +
+                `on ${ircServer.domain}`
+            );
             let notice = new MatrixAction("notice", "You are not in any channels.");
             yield this.ircBridge.sendMatrixAction(adminRoom, botUser, notice, req);
         }

--- a/lib/bridge/MatrixHandler.js
+++ b/lib/bridge/MatrixHandler.js
@@ -468,11 +468,51 @@ MatrixHandler.prototype._onAdminMessage = Promise.coroutine(function*(req, event
         return;
     }
     else if (cmd === "!quit") {
-        clientList.filter(
+        // Filter to get the clients for the [specified] server
+        let clients = clientList.filter(
             (bridgedClient) => bridgedClient.server.domain === ircServer.domain
-        ).forEach((bridgedClient) => {
+        );
+        if (clients.length === 0) {
+            req.log.info(`No bridgedClients for ${event.user_id}`);
+            let notice = new MatrixAction("notice", "You are not connected to any networks.");
+            yield this.ircBridge.sendMatrixAction(adminRoom, botUser, notice, req);
+        }
+        let getRoomsForChannel = (channel) => {
+            return this.ircBridge.getStore().getMatrixRoomsForChannel(ircServer, channel);
+        };
+        for (var i = 0; i < clients.length; i++) {
+            let bridgedClient = clients[i];
+            // Get all rooms that the bridgedClient is in
+            let rooms = yield Promise.all(bridgedClient.chanList.map(getRoomsForChannel));
+
+            // rooms is an array of arrays
+            rooms = rooms.reduce((a, b) => {return a.concat(b)});
+
+            let uniqueRoomIds = [];
+            rooms.forEach((matrixRoom) => {
+                if (uniqueRoomIds.indexOf(matrixRoom.roomId) === -1) {
+                    uniqueRoomIds.push(matrixRoom.roomId);
+                }
+            });
+
+            let promises = uniqueRoomIds.map((roomId) => {
+                return this.ircBridge.getAppServiceBridge().getIntent().kick(
+                    roomId, bridgedClient.userId, "issued !quit command"
+                )
+            });
+
+            try {
+                yield Promise.all(promises);
+            }
+            catch (err) {
+                req.log.warn(
+                    `Could not kick ${bridgedClient.userId} from bridged rooms: ${err.message}`
+                );
+            }
+
+            req.log.info(`Killing bridgedClient (nick = ${bridgedClient.nick}) for ${bridgedClient.userId}`);
             bridgedClient.kill();
-        });
+        }
     }
     else if (cmd === "!storepass") {
         let domain = ircServer.domain;

--- a/lib/bridge/MatrixHandler.js
+++ b/lib/bridge/MatrixHandler.js
@@ -483,12 +483,14 @@ MatrixHandler.prototype._onAdminMessage = Promise.coroutine(function*(req, event
 
         let bridgedClient = clients[0];
 
-        let getRoomsForChannel = (channel) => {
-            return this.ircBridge.getStore().getMatrixRoomsForChannel(ircServer, channel);
-        };
-
         // Get all rooms that the bridgedClient is in
-        let rooms = yield Promise.all(bridgedClient.chanList.map(getRoomsForChannel));
+        let rooms = yield Promise.all(
+            bridgedClient.chanList.map(
+                (channel) => {
+                    return this.ircBridge.getStore().getMatrixRoomsForChannel(ircServer, channel);
+                }
+            )
+        );
 
         // rooms is an array of arrays
         rooms = rooms.reduce((a, b) => {return a.concat(b)});

--- a/lib/bridge/MatrixHandler.js
+++ b/lib/bridge/MatrixHandler.js
@@ -525,6 +525,7 @@ MatrixHandler.prototype._onAdminMessage = Promise.coroutine(function*(req, event
         req.log.info(
             `Killing bridgedClient (nick = ${bridgedClient.nick}) for ${bridgedClient.userId}`
         );
+        // The success message will effectively be 'Your connection to ... has been lost.`
         bridgedClient.kill();
     }
     else if (cmd === "!storepass") {

--- a/lib/bridge/MatrixHandler.js
+++ b/lib/bridge/MatrixHandler.js
@@ -476,12 +476,19 @@ MatrixHandler.prototype._onAdminMessage = Promise.coroutine(function*(req, event
             req.log.info(`No bridgedClients for ${event.user_id}`);
             let notice = new MatrixAction("notice", "You are not connected to any networks.");
             yield this.ircBridge.sendMatrixAction(adminRoom, botUser, notice, req);
+            return;
         }
         else if (clients.length > 1) {
             throw new Error(`Multiple bridgedClients on ${ircServer.domain} for ${event.user_id}`);
         }
 
         let bridgedClient = clients[0];
+
+        if (bridgedClient.chanList.length === 0) {
+            req.log.info(`Bridged client for ${event.user_id} is not in any channels on ${ircServer.domain}`);
+            let notice = new MatrixAction("notice", "You are not in any channels.");
+            yield this.ircBridge.sendMatrixAction(adminRoom, botUser, notice, req);
+        }
 
         // Get all rooms that the bridgedClient is in
         let rooms = yield Promise.all(
@@ -495,20 +502,24 @@ MatrixHandler.prototype._onAdminMessage = Promise.coroutine(function*(req, event
         // rooms is an array of arrays
         rooms = rooms.reduce((a, b) => {return a.concat(b)});
 
-        let uniqueRoomIds = new Set(rooms.map((matrixRoom) => matrixRoom.roomId));
-        let promises = uniqueRoomIds.map((roomId) => {
-            return this.ircBridge.getAppServiceBridge().getIntent().kick(
+        let uniqueRoomIds = Array.from(
+            new Set(rooms.map((matrixRoom) => matrixRoom.roomId))
+        );
+        for (var i = 0; i < uniqueRoomIds.length; i++) {
+            let roomId = uniqueRoomIds[i];
+            let promise = this.ircBridge.getAppServiceBridge().getIntent().kick(
                 roomId, bridgedClient.userId, "issued !quit command"
-            )
-        });
-
-        try {
-            yield Promise.all(promises);
-        }
-        catch (err) {
-            req.log.warn(
-                `Could not kick ${bridgedClient.userId} from bridged rooms: ${err.message}`
             );
+            try {
+                yield promise;
+            }
+            catch (err) {
+                req.log.error(err);
+                req.log.warn(
+                    `Could not kick ${bridgedClient.userId} ` +
+                    `from bridged room ${roomId}: ${err.message}`
+                );
+            }
         }
 
         req.log.info(

--- a/lib/bridge/MatrixHandler.js
+++ b/lib/bridge/MatrixHandler.js
@@ -510,11 +510,10 @@ MatrixHandler.prototype._onAdminMessage = Promise.coroutine(function*(req, event
         );
         for (var i = 0; i < uniqueRoomIds.length; i++) {
             let roomId = uniqueRoomIds[i];
-            let promise = this.ircBridge.getAppServiceBridge().getIntent().kick(
-                roomId, bridgedClient.userId, "issued !quit command"
-            );
             try {
-                yield promise;
+                yield this.ircBridge.getAppServiceBridge().getIntent().kick(
+                    roomId, bridgedClient.userId, "issued !quit command"
+                );
             }
             catch (err) {
                 req.log.error(err);

--- a/lib/bridge/MatrixHandler.js
+++ b/lib/bridge/MatrixHandler.js
@@ -510,7 +510,9 @@ MatrixHandler.prototype._onAdminMessage = Promise.coroutine(function*(req, event
                 );
             }
 
-            req.log.info(`Killing bridgedClient (nick = ${bridgedClient.nick}) for ${bridgedClient.userId}`);
+            req.log.info(
+                `Killing bridgedClient (nick = ${bridgedClient.nick}) for ${bridgedClient.userId}`
+            );
             bridgedClient.kill();
         }
     }

--- a/lib/bridge/MatrixHandler.js
+++ b/lib/bridge/MatrixHandler.js
@@ -495,13 +495,7 @@ MatrixHandler.prototype._onAdminMessage = Promise.coroutine(function*(req, event
         // rooms is an array of arrays
         rooms = rooms.reduce((a, b) => {return a.concat(b)});
 
-        let uniqueRoomIds = [];
-        rooms.forEach((matrixRoom) => {
-            if (uniqueRoomIds.indexOf(matrixRoom.roomId) === -1) {
-                uniqueRoomIds.push(matrixRoom.roomId);
-            }
-        });
-
+        let uniqueRoomIds = new Set(rooms.map((matrixRoom) => matrixRoom.roomId));
         let promises = uniqueRoomIds.map((roomId) => {
             return this.ircBridge.getAppServiceBridge().getIntent().kick(
                 roomId, bridgedClient.userId, "issued !quit command"

--- a/lib/bridge/MatrixHandler.js
+++ b/lib/bridge/MatrixHandler.js
@@ -468,11 +468,11 @@ MatrixHandler.prototype._onAdminMessage = Promise.coroutine(function*(req, event
         return;
     }
     else if (cmd === "!quit") {
-        // clientList.filter(
-        //     (bridgedClient) => bridgedClient.server.domain === ircServer.domain
-        // ).forEach((bridgedClient) => {
-        //     bridgedClient.kill();
-        // });
+        clientList.filter(
+            (bridgedClient) => bridgedClient.server.domain === ircServer.domain
+        ).forEach((bridgedClient) => {
+            bridgedClient.kill();
+        });
     }
     else if (cmd === "!storepass") {
         let domain = ircServer.domain;

--- a/lib/bridge/MatrixHandler.js
+++ b/lib/bridge/MatrixHandler.js
@@ -477,44 +477,48 @@ MatrixHandler.prototype._onAdminMessage = Promise.coroutine(function*(req, event
             let notice = new MatrixAction("notice", "You are not connected to any networks.");
             yield this.ircBridge.sendMatrixAction(adminRoom, botUser, notice, req);
         }
+        else if (clients.length > 1) {
+            throw new Error(`Multiple bridgedClients on ${ircServer.domain} for ${event.user_id}`);
+        }
+
+        let bridgedClient = clients[0];
+
         let getRoomsForChannel = (channel) => {
             return this.ircBridge.getStore().getMatrixRoomsForChannel(ircServer, channel);
         };
-        for (var i = 0; i < clients.length; i++) {
-            let bridgedClient = clients[i];
-            // Get all rooms that the bridgedClient is in
-            let rooms = yield Promise.all(bridgedClient.chanList.map(getRoomsForChannel));
 
-            // rooms is an array of arrays
-            rooms = rooms.reduce((a, b) => {return a.concat(b)});
+        // Get all rooms that the bridgedClient is in
+        let rooms = yield Promise.all(bridgedClient.chanList.map(getRoomsForChannel));
 
-            let uniqueRoomIds = [];
-            rooms.forEach((matrixRoom) => {
-                if (uniqueRoomIds.indexOf(matrixRoom.roomId) === -1) {
-                    uniqueRoomIds.push(matrixRoom.roomId);
-                }
-            });
+        // rooms is an array of arrays
+        rooms = rooms.reduce((a, b) => {return a.concat(b)});
 
-            let promises = uniqueRoomIds.map((roomId) => {
-                return this.ircBridge.getAppServiceBridge().getIntent().kick(
-                    roomId, bridgedClient.userId, "issued !quit command"
-                )
-            });
-
-            try {
-                yield Promise.all(promises);
+        let uniqueRoomIds = [];
+        rooms.forEach((matrixRoom) => {
+            if (uniqueRoomIds.indexOf(matrixRoom.roomId) === -1) {
+                uniqueRoomIds.push(matrixRoom.roomId);
             }
-            catch (err) {
-                req.log.warn(
-                    `Could not kick ${bridgedClient.userId} from bridged rooms: ${err.message}`
-                );
-            }
+        });
 
-            req.log.info(
-                `Killing bridgedClient (nick = ${bridgedClient.nick}) for ${bridgedClient.userId}`
-            );
-            bridgedClient.kill();
+        let promises = uniqueRoomIds.map((roomId) => {
+            return this.ircBridge.getAppServiceBridge().getIntent().kick(
+                roomId, bridgedClient.userId, "issued !quit command"
+            )
+        });
+
+        try {
+            yield Promise.all(promises);
         }
+        catch (err) {
+            req.log.warn(
+                `Could not kick ${bridgedClient.userId} from bridged rooms: ${err.message}`
+            );
+        }
+
+        req.log.info(
+            `Killing bridgedClient (nick = ${bridgedClient.nick}) for ${bridgedClient.userId}`
+        );
+        bridgedClient.kill();
     }
     else if (cmd === "!storepass") {
         let domain = ircServer.domain;


### PR DESCRIPTION
Fixes https://github.com/matrix-org/matrix-appservice-irc/issues/285

When a !quit command is issued, make the bridge mx bot kick all instances of the bridged mx user from all bridged rooms. This currently excludes PM rooms and admin rooms and any rooms in which the user has an equal or greater power than the bot.

If users cannot be kicked from a room, log it but continue to disconnect the user from IRC.