### PR TITLE
Fix #267 : Invalid username prevents connection

### DIFF
--- a/lib/irc/IdentGenerator.js
+++ b/lib/irc/IdentGenerator.js
@@ -201,7 +201,7 @@ function sanitiseUsername(username, replacementChar) {
     username = username.replace(/[^A-Za-z0-9\]\[\^\\\{\}\-`]/g, replacementChar);
     // Whilst the RFC doesn't say you can't have special characters eg ("-") as the
     // first character of a USERNAME, empirically Freenode rejects connections
-    // stating"Invalid username". Having  "-" is valid, so long as it isn't the first.
+    // stating "Invalid username". Having  "-" is valid, so long as it isn't the first.
     // Prefix usernames with "M" if they start with a special character.
     if (/^[^A-Za-z]/.test(username)) {
         return "M" + username;

--- a/lib/irc/IdentGenerator.js
+++ b/lib/irc/IdentGenerator.js
@@ -198,7 +198,15 @@ function sanitiseUsername(username, replacementChar) {
     // strip illegal chars according to RFC 1459 Sect 2.3.1
     // (technically it's any <nonwhite> ascii for <user> but meh)
     // also strip '_' since we use that as the delimiter
-    return username.replace(/[^A-Za-z0-9\]\[\^\\\{\}\-`]/g, replacementChar);
+    username = username.replace(/[^A-Za-z0-9\]\[\^\\\{\}\-`]/g, replacementChar);
+    // Whilst the RFC doesn't say you can't have special characters eg ("-") as the
+    // first character of a USERNAME, empirically Freenode rejects connections
+    // stating"Invalid username". Having  "-" is valid, so long as it isn't the first.
+    // Prefix usernames with "M" if they start with a special character.
+    if (/^[^A-Za-z]/.test(username)) {
+        return "M" + username;
+    }
+    return username;
 }
 
 function sanitiseRealname(realname) {

--- a/spec/unit/IdentGenerator.spec.js
+++ b/spec/unit/IdentGenerator.spec.js
@@ -51,7 +51,7 @@ describe("Username generation", function() {
         IdentGenerator.MAX_USER_NAME_LENGTH = 8;
     });
 
-    it("should attempt a truncated user ID on a long user ID", function(done) {
+    it("should attempt to truncate the user ID on a long user ID", function(done) {
         var userId = "@myreallylonguseridhere:localhost";
         var uname = "myreally";
         identGenerator.getIrcNames(ircClientConfig, mkMatrixUser(userId)).done(function(info) {
@@ -110,4 +110,12 @@ describe("Username generation", function() {
         });
     });
 
+    it("should prefix 'M' onto usernames which don't begin with A-z", function(done) {
+        var userId = "@-myname:localhost";
+        var uname = "M-myname";
+        identGenerator.getIrcNames(ircClientConfig, mkMatrixUser(userId)).done(function(info) {
+            expect(info.username).toEqual(uname);
+            done();
+        });
+    });
 });


### PR DESCRIPTION
You cannot start a username with special characters on Freenode, even though
both IRC RFCs seem a-okay with it. :/