### PR TITLE
Leave matrix users if their associated IRC nick is no longer in a bridged channel

### DIFF
--- a/lib/bridge/MemberListSyncer.js
+++ b/lib/bridge/MemberListSyncer.js
@@ -15,6 +15,22 @@ function MemberListSyncer(ircBridge, appServiceBot, server, appServiceUserId, in
     this.appServiceUserId = appServiceUserId;
     this.injectJoinFn = injectJoinFn;
     this._syncableRoomsPromise = null;
+    this._memberLists = {
+        matrix: {
+            //$roomId : [
+            //    {
+            //        id: roomId,
+            //        state: stateEvents,
+            //        realJoinedUsers: [],
+            //        remoteJoinedUsers: []
+            //    },
+            //    ...
+            //  ]
+        },
+        irc: {
+            //$channel : nick[]
+        }
+    }
 }
 
 MemberListSyncer.prototype.sync = Promise.coroutine(function*() {
@@ -31,6 +47,8 @@ MemberListSyncer.prototype.sync = Promise.coroutine(function*() {
     let start = Date.now();
     let rooms = yield this._getSyncableRooms(server);
     log.info("Found %s syncable rooms (%sms)", rooms.length, Date.now() - start);
+    log.info("Marking Matrix rooms for cleanup when updateIrcMemberList called...");
+    yield this.leaveIrcUsersFromRooms(rooms, server);
     start = Date.now();
     log.info("Joining Matrix users to IRC channels...");
     yield joinMatrixUsersToChannels(rooms, server, this.injectJoinFn);
@@ -38,10 +56,6 @@ MemberListSyncer.prototype.sync = Promise.coroutine(function*() {
     // NB: We do not need to explicitly join IRC users to Matrix rooms
     // because we get all of the NAMEs/JOINs as events when we connect to
     // the IRC server. This effectively "injects" the list for us.
-    start = Date.now();
-    log.info("Leaving IRC users from Matrix rooms (cleanup)...");
-    yield leaveIrcUsersFromRooms(rooms, server);
-    log.info("Left IRC users from Matrix rooms. (%sms)", Date.now() - start);
 });
 
 MemberListSyncer.prototype.getChannelsToJoin = Promise.coroutine(function*() {
@@ -129,6 +143,16 @@ MemberListSyncer.prototype.checkBotPartRoom = Promise.coroutine(function*(ircRoo
 // so we don't do it unless they need absolutely fresh data. On startup, this can be called
 // multiple times, so we cache the first request's promise and return that instead of making
 // double hits.
+//
+// returns [
+//   {
+//       id: roomId,
+//       state: stateEvents,
+//       realJoinedUsers: [],
+//       remoteJoinedUsers: []
+//   },
+//   ...
+// ]
 MemberListSyncer.prototype._getSyncableRooms = function(server, ignoreCache) {
     if (!ignoreCache && this._syncableRoomsPromise) {
         log.debug("Returning existing _getSyncableRooms Promise");
@@ -247,9 +271,62 @@ function joinMatrixUsersToChannels(rooms, server, injectJoinFn) {
     return d.promise;
 }
 
-function leaveIrcUsersFromRooms(rooms, server) {
+MemberListSyncer.prototype.leaveIrcUsersFromRooms = function(rooms, server) {
+    log.info("leaveIrcUsersFromRooms");
+
+    // Store the matrix room info in memory for later retrieval when NAMES is received
+    // and updateIrcMemberList is called. At that point, we have enough information to
+    // leave users from the channel that the NAMES is for.
+    rooms.forEach((roomInfo) => {
+        this._memberLists.matrix[roomInfo.id] = roomInfo;
+    });
+
     return Promise.resolve();
 }
+
+// Update the MemberListSyncer with the IRC NAMES_RPL that has been received for channel.
+// This will leave any matrix users that do not have their associated IRC nick in the list
+// of names for this channel.
+MemberListSyncer.prototype.updateIrcMemberList = Promise.coroutine(function*(channel, names) {
+    log.info(`updateIrcMemberList: Updating IRC member list for ${channel}`);
+    this._memberLists.irc[channel] = Object.keys(names);
+
+    // Convert the IRC channels nicks to userIds
+    let ircUserIds = this._memberLists.irc[channel].map(
+        (nick) => this.server.getUserIdFromNick(nick)
+    );
+
+    // For all bridged rooms, leave users from matrix that are not in the channel
+    let roomsForChannel = yield this.ircBridge.getStore().getMatrixRoomsForChannel(
+        this.server, channel
+    );
+
+    if (roomsForChannel.length === 0) {
+        log.info(`updateIrcMemberList: No bridged rooms for channel ${channel}`);
+        return;
+    }
+
+    // If a userId is in remoteJoinedUsers, but not ircUserIds, intend on leaving roomId
+    yield Promise.all(roomsForChannel.map((matrixRoom) => {
+        return matrixRoom.getId();
+    }).map((roomId) => {
+        let userIdsToLeave = this._memberLists.matrix[roomId].remoteJoinedUsers.filter(
+            (userId) => {
+                return ircUserIds.indexOf(userId) === -1;
+            }
+        );
+        log.info(
+            `updateIrcMemberList: Leaving ${userIdsToLeave.length} users from ${roomId} ` +
+            `because they are not in ${channel}.`
+        );
+
+        return userIdsToLeave.map(
+            (userId) => {
+                return this.ircBridge.getAppServiceBridge().getIntent(userId).leave(roomId);
+            }
+        );
+    }));
+});
 
 function getRoomMemberData(server, roomId, stateEvents, appServiceUserId) {
     stateEvents = stateEvents || [];

--- a/lib/bridge/MemberListSyncer.js
+++ b/lib/bridge/MemberListSyncer.js
@@ -285,13 +285,16 @@ MemberListSyncer.prototype.leaveIrcUsersFromRooms = function(rooms, server) {
 // This will leave any matrix users that do not have their associated IRC nick in the list
 // of names for this channel.
 MemberListSyncer.prototype.updateIrcMemberList = Promise.coroutine(function*(channel, names) {
-    log.info(`updateIrcMemberList: Updating IRC member list for ${channel}`);
     if (this._memberLists.irc[channel] !== undefined ||
-        !this.server.shouldSyncMembershipToMatrix("initial", channel)) {
-            return;
+            !this.server.shouldSyncMembershipToMatrix("initial", channel)) {
+        return;
     }
-
     this._memberLists.irc[channel] = Object.keys(names);
+
+    log.info(
+        `updateIrcMemberList: Updating IRC member list for ${channel} with ` +
+        `${this._memberLists.irc[channel].length} IRC nicks`
+    );
 
     // Convert the IRC channels nicks to userIds
     let ircUserIds = this._memberLists.irc[channel].map(

--- a/lib/bridge/MemberListSyncer.js
+++ b/lib/bridge/MemberListSyncer.js
@@ -326,7 +326,7 @@ MemberListSyncer.prototype.updateIrcMemberList = Promise.coroutine(function*(cha
                 return this.ircBridge.getAppServiceBridge().getIntent(userId).leave(roomId);
             }
         );
-    });
+    }).reduce((a, b) => a.concat(b));
     yield Promise.all(promises);
 });
 

--- a/lib/bridge/MemberListSyncer.js
+++ b/lib/bridge/MemberListSyncer.js
@@ -303,13 +303,15 @@ MemberListSyncer.prototype.updateIrcMemberList = Promise.coroutine(function*(cha
         return;
     }
 
-    // If a userId is in remoteJoinedUsers, but not ircUserIds, intend on leaving roomId
-    yield Promise.all(roomsForChannel.map((matrixRoom) => {
+    let bridgedRoomIds = roomsForChannel.map((matrixRoom) => {
         return matrixRoom.getId();
     }).filter((roomId) => { // Filter rooms to remove those without member list data stored
         return this._memberLists.matrix[roomId] &&
             this._memberLists.matrix[roomId].remoteJoinedUsers;
-    }).map((roomId) => {
+    });
+
+    // If a userId is in remoteJoinedUsers, but not ircUserIds, intend on leaving roomId
+    let promises = bridgedRoomIds.map((roomId) => {
         let userIdsToLeave = this._memberLists.matrix[roomId].remoteJoinedUsers.filter(
             (userId) => {
                 return ircUserIds.indexOf(userId) === -1;
@@ -319,13 +321,13 @@ MemberListSyncer.prototype.updateIrcMemberList = Promise.coroutine(function*(cha
             `updateIrcMemberList: Leaving ${userIdsToLeave.length} users from ${roomId} ` +
             `because they are not in ${channel}.`
         );
-
         return userIdsToLeave.map(
             (userId) => {
                 return this.ircBridge.getAppServiceBridge().getIntent(userId).leave(roomId);
             }
         );
-    }));
+    });
+    yield Promise.all(promises);
 });
 
 function getRoomMemberData(server, roomId, stateEvents, appServiceUserId) {

--- a/lib/bridge/MemberListSyncer.js
+++ b/lib/bridge/MemberListSyncer.js
@@ -47,7 +47,7 @@ MemberListSyncer.prototype.sync = Promise.coroutine(function*() {
     let start = Date.now();
     let rooms = yield this._getSyncableRooms(server);
     log.info("Found %s syncable rooms (%sms)", rooms.length, Date.now() - start);
-    yield this.leaveIrcUsersFromRooms(rooms, server);
+    this.leaveIrcUsersFromRooms(rooms, server);
     start = Date.now();
     log.info("Joining Matrix users to IRC channels...");
     yield joinMatrixUsersToChannels(rooms, server, this.injectJoinFn);
@@ -279,8 +279,6 @@ MemberListSyncer.prototype.leaveIrcUsersFromRooms = function(rooms, server) {
     rooms.forEach((roomInfo) => {
         this._memberLists.matrix[roomInfo.id] = roomInfo;
     });
-
-    return Promise.resolve();
 }
 
 // Update the MemberListSyncer with the IRC NAMES_RPL that has been received for channel.

--- a/lib/bridge/MemberListSyncer.js
+++ b/lib/bridge/MemberListSyncer.js
@@ -17,15 +17,12 @@ function MemberListSyncer(ircBridge, appServiceBot, server, appServiceUserId, in
     this._syncableRoomsPromise = null;
     this._memberLists = {
         matrix: {
-            //$roomId : [
-            //    {
-            //        id: roomId,
-            //        state: stateEvents,
-            //        realJoinedUsers: [],
-            //        remoteJoinedUsers: []
-            //    },
-            //    ...
-            //  ]
+            //$roomId : {
+            //    id: roomId,
+            //    state: stateEvents,
+            //    realJoinedUsers: [],
+            //    remoteJoinedUsers: []
+            //  }
         },
         irc: {
             //$channel : nick[]

--- a/lib/bridge/MemberListSyncer.js
+++ b/lib/bridge/MemberListSyncer.js
@@ -308,38 +308,29 @@ MemberListSyncer.prototype.updateIrcMemberList = Promise.coroutine(function*(cha
         return;
     }
 
-    let bridgedRoomIds = roomsForChannel.map((matrixRoom) => {
-        return matrixRoom.getId();
-    }).filter((roomId) => { // Filter rooms to remove those without member list data stored
-        return this._memberLists.matrix[roomId] &&
-            this._memberLists.matrix[roomId].remoteJoinedUsers;
-    });
-
-    if (bridgedRoomIds.length === 0) {
-        log.info(
-            `updateIrcMemberList: No rooms with known membership list data ` +
-            `bridged to channel ${channel}`
-        );
-        return;
-    }
-
     // If a userId is in remoteJoinedUsers, but not ircUserIds, intend on leaving roomId
-    let promises = bridgedRoomIds.map((roomId) => {
-        let userIdsToLeave = this._memberLists.matrix[roomId].remoteJoinedUsers.filter(
+    let promises = [];
+    roomsForChannel.forEach((matrixRoom) => {
+        let roomId = matrixRoom.getId();
+        if (!(
+                this._memberLists.matrix[roomId] &&
+                this._memberLists.matrix[roomId].remoteJoinedUsers
+            )) {
+                return;
+        }
+        this._memberLists.matrix[roomId].remoteJoinedUsers.forEach(
             (userId) => {
-                return ircUserIds.indexOf(userId) === -1;
+                if (ircUserIds.indexOf(userId) === -1) {
+                    promises.push(
+                        this.ircBridge.getAppServiceBridge().getIntent(userId).leave(roomId)
+                    );
+                }
             }
         );
-        log.info(
-            `updateIrcMemberList: Leaving ${userIdsToLeave.length} users from ${roomId} ` +
-            `because they are not in ${channel}.`
-        );
-        return userIdsToLeave.map(
-            (userId) => {
-                return this.ircBridge.getAppServiceBridge().getIntent(userId).leave(roomId);
-            }
-        );
-    }).reduce((a, b) => a.concat(b));
+    });
+    log.info(
+        `updateIrcMemberList: Leaving ${promises.length} users as they are not in ${channel}.`
+    );
     yield Promise.all(promises);
 });
 

--- a/lib/bridge/MemberListSyncer.js
+++ b/lib/bridge/MemberListSyncer.js
@@ -271,7 +271,10 @@ function joinMatrixUsersToChannels(rooms, server, injectJoinFn) {
 }
 
 MemberListSyncer.prototype.leaveIrcUsersFromRooms = function(rooms, server) {
-    log.info("leaveIrcUsersFromRooms");
+    log.info(
+        `leaveIrcUsersFromRooms: storing member list info for ${rooms.length} ` +
+        `rooms for server ${server.domain}`
+    );
 
     // Store the matrix room info in memory for later retrieval when NAMES is received
     // and updateIrcMemberList is called. At that point, we have enough information to

--- a/lib/bridge/MemberListSyncer.js
+++ b/lib/bridge/MemberListSyncer.js
@@ -310,6 +310,14 @@ MemberListSyncer.prototype.updateIrcMemberList = Promise.coroutine(function*(cha
             this._memberLists.matrix[roomId].remoteJoinedUsers;
     });
 
+    if (bridgedRoomIds.length === 0) {
+        log.info(
+            `updateIrcMemberList: No rooms with known membership list data ` +
+            `bridged to channel ${channel}`
+        );
+        return;
+    }
+
     // If a userId is in remoteJoinedUsers, but not ircUserIds, intend on leaving roomId
     let promises = bridgedRoomIds.map((roomId) => {
         let userIdsToLeave = this._memberLists.matrix[roomId].remoteJoinedUsers.filter(

--- a/lib/bridge/MemberListSyncer.js
+++ b/lib/bridge/MemberListSyncer.js
@@ -286,6 +286,15 @@ MemberListSyncer.prototype.leaveIrcUsersFromRooms = function(rooms, server) {
 // of names for this channel.
 MemberListSyncer.prototype.updateIrcMemberList = Promise.coroutine(function*(channel, names) {
     log.info(`updateIrcMemberList: Updating IRC member list for ${channel}`);
+    if (this._memberLists.irc[channel] !== undefined) {
+        log.info(`Names already received for ${channel}`);
+        return;
+    }
+    if (!this.server.shouldSyncMembershipToMatrix("initial", channel)) {
+        log.info(`Initial membership list syncing disabled for ${channel} and/or globally`);
+        return;
+    }
+
     this._memberLists.irc[channel] = Object.keys(names);
 
     // Convert the IRC channels nicks to userIds

--- a/lib/bridge/MemberListSyncer.js
+++ b/lib/bridge/MemberListSyncer.js
@@ -286,13 +286,9 @@ MemberListSyncer.prototype.leaveIrcUsersFromRooms = function(rooms, server) {
 // of names for this channel.
 MemberListSyncer.prototype.updateIrcMemberList = Promise.coroutine(function*(channel, names) {
     log.info(`updateIrcMemberList: Updating IRC member list for ${channel}`);
-    if (this._memberLists.irc[channel] !== undefined) {
-        log.info(`Names already received for ${channel}`);
-        return;
-    }
-    if (!this.server.shouldSyncMembershipToMatrix("initial", channel)) {
-        log.info(`Initial membership list syncing disabled for ${channel} and/or globally`);
-        return;
+    if (this._memberLists.irc[channel] !== undefined ||
+        !this.server.shouldSyncMembershipToMatrix("initial", channel)) {
+            return;
     }
 
     this._memberLists.irc[channel] = Object.keys(names);

--- a/lib/bridge/MemberListSyncer.js
+++ b/lib/bridge/MemberListSyncer.js
@@ -47,7 +47,6 @@ MemberListSyncer.prototype.sync = Promise.coroutine(function*() {
     let start = Date.now();
     let rooms = yield this._getSyncableRooms(server);
     log.info("Found %s syncable rooms (%sms)", rooms.length, Date.now() - start);
-    log.info("Marking Matrix rooms for cleanup when updateIrcMemberList called...");
     yield this.leaveIrcUsersFromRooms(rooms, server);
     start = Date.now();
     log.info("Joining Matrix users to IRC channels...");

--- a/lib/bridge/MemberListSyncer.js
+++ b/lib/bridge/MemberListSyncer.js
@@ -309,6 +309,9 @@ MemberListSyncer.prototype.updateIrcMemberList = Promise.coroutine(function*(cha
     // If a userId is in remoteJoinedUsers, but not ircUserIds, intend on leaving roomId
     yield Promise.all(roomsForChannel.map((matrixRoom) => {
         return matrixRoom.getId();
+    }).filter((roomId) => { // Filter rooms to remove those without member list data stored
+        return this._memberLists.matrix[roomId] &&
+            this._memberLists.matrix[roomId].remoteJoinedUsers;
     }).map((roomId) => {
         let userIdsToLeave = this._memberLists.matrix[roomId].remoteJoinedUsers.filter(
             (userId) => {

--- a/lib/irc/ClientPool.js
+++ b/lib/irc/ClientPool.js
@@ -318,9 +318,6 @@ ClientPool.prototype._onJoinError = Promise.coroutine(function*(bridgedClient, c
 ClientPool.prototype._onNames = Promise.coroutine(function*(bridgedClient, chan, names) {
     let mls = this._ircBridge.memberListSyncers[bridgedClient.server.domain];
     if (!mls) {
-        log.info(`MemberListSyncer does not exist for ${bridgedClient.server.domain}: ` +
-            `not calling updateIrcMemberList and not syncing leaves (for channel ${chan}).`
-        );
         return;
     }
     yield mls.updateIrcMemberList(chan, names);

--- a/lib/irc/ClientPool.js
+++ b/lib/irc/ClientPool.js
@@ -317,6 +317,12 @@ ClientPool.prototype._onJoinError = Promise.coroutine(function*(bridgedClient, c
 
 ClientPool.prototype._onNames = Promise.coroutine(function*(bridgedClient, chan, names) {
     let mls = this._ircBridge.memberListSyncers[bridgedClient.server.domain];
+    if (!mls) {
+        log.info(`MemberListSyncer does not exist for ${bridgedClient.server.domain}: ` +
+            `not calling updateIrcMemberList and not syncing leaves (for channel ${chan}).`
+        );
+        return;
+    }
     yield mls.updateIrcMemberList(chan, names);
 });
 

--- a/lib/irc/ClientPool.js
+++ b/lib/irc/ClientPool.js
@@ -84,6 +84,7 @@ ClientPool.prototype.createIrcClient = function(ircClientConfig, matrixUser, isB
     bridgedClient.on("client-disconnected", this._onClientDisconnected.bind(this));
     bridgedClient.on("nick-change", this._onNickChange.bind(this));
     bridgedClient.on("join-error", this._onJoinError.bind(this));
+    bridgedClient.on("irc-names", this._onNames.bind(this));
 
     // store the bridged client immediately in the pool even though it isn't
     // connected yet, else we could spawn 2 clients for a single user if this
@@ -312,6 +313,11 @@ ClientPool.prototype._onJoinError = Promise.coroutine(function*(bridgedClient, c
         );
     });
     yield Promise.all(promises);
+});
+
+ClientPool.prototype._onNames = Promise.coroutine(function*(bridgedClient, chan, names) {
+    let mls = this._ircBridge.memberListSyncers[bridgedClient.server.domain];
+    yield mls.updateIrcMemberList(chan, names);
 });
 
 module.exports = ClientPool;

--- a/lib/irc/IrcEventBroker.js
+++ b/lib/irc/IrcEventBroker.js
@@ -308,6 +308,11 @@ IrcEventBroker.prototype.addHooks = function(client, connInst) {
         });
     }
 
+    // When a names event is received, emit names event in the BridgedClient
+    connInst.addListener("names", (chan, names) => {
+        client.emit("irc-names", client, chan, names);
+    });
+
     // Listen for other events
 
     this._hookIfClaimed(client, connInst, "part", function(chan, nick, reason, msg) {


### PR DESCRIPTION
On startup, matrix member lists are stored in memory for later reference. They may not be entirely accurate long after startup, but it won't stop the majority of users being cleaned up.

The ClientPool listens for any "irc-names" events being emitted from `BridgedClient`s. This event is triggered whenever an IRC client receives NAMES. The `ClientPool` calls `updateIrcMemberList` on `MemberListSyncer`. This function leaves any matrix users that do not appear to be in the IRC member list of the channel whose mlist has just been updated from all bridged rooms of that channel.