### PR TITLE
Listen for err_yourebannedcreep and wait 6hrs before reconnecting

### DIFF
--- a/lib/irc/ConnectionInstance.js
+++ b/lib/irc/ConnectionInstance.js
@@ -172,7 +172,7 @@ ConnectionInstance.prototype._listenForErrors = function() {
                 return; // don't disconnect for these error codes.
             }
         }
-        if (err && err.command && err.command === "err_yourebannedcreep") {
+        if (err && err.command === "err_yourebannedcreep") {
             self.disconnect("banned");
             return;
         }

--- a/lib/irc/ConnectionInstance.js
+++ b/lib/irc/ConnectionInstance.js
@@ -18,7 +18,7 @@ const PING_TIMEOUT_MS = 1000 * 60 * 10;
 // due to throttling.
 const THROTTLE_WAIT_MS = 20 * 1000;
 
-const BANNED_TIME_MS = 60 * 60 * 1000; // once an hour
+const BANNED_TIME_MS = 6 * 60 * 60 * 1000; // once every 6 hours
 
 // The rate at which to send pings to the IRCd if the client is being quiet for a while.
 // Whilst the IRCd *should* be sending pings to us to keep the connection alive, it appears
@@ -171,6 +171,10 @@ ConnectionInstance.prototype._listenForErrors = function() {
             if (failCodes.indexOf(err.command) !== -1) {
                 return; // don't disconnect for these error codes.
             }
+        }
+        if (err && err.command && err.command === "err_yourebannedcreep") {
+            self.disconnect("banned");
+            return;
         }
         self.disconnect("irc_error");
     });


### PR DESCRIPTION
When `err_yourebannedcreep` is received, 2 events fire: `error` and `raw`. It
looks like `error` consistently happens before `raw`, which would lead to
`disconnect(irc_error)` which then flips the connection state to `dead`. When
the `raw` event fires, it tries to fail with `disconnect(banned)` but because
we've already flipped the connection state to `dead`, this does nothing.

As a consequence, banned connections would retry much more frequently than they
should.

This PR fixes this by looking for "banned" reasons in the `error` event, and failing
appropriately.