### PR TITLE
Export prometheus-style metrics corresponding to existing 'statsd' ones

### DIFF
--- a/lib/bridge/IrcBridge.js
+++ b/lib/bridge/IrcBridge.js
@@ -22,6 +22,7 @@ var DataStore = require("../DataStore");
 var log = require("../logging").get("IrcBridge");
 var Bridge = require("matrix-appservice-bridge").Bridge;
 var MatrixUser = require("matrix-appservice-bridge").MatrixUser;
+var AgeCounters = require("matrix-appservice-bridge").PrometheusMetrics.AgeCounters;
 var DebugApi = require("../DebugApi");
 var Provisioner = require("../provisioning/Provisioner.js");
 var PublicitySyncer = require("./PublicitySyncer.js");
@@ -87,7 +88,28 @@ function IrcBridge(config, registration) {
     });
 
     if (this.config.ircService.metrics && this.config.ircService.metrics.enabled) {
+        var zeroAge = new AgeCounters();
+
         this._bridge.getPrometheusMetrics();
+        this._bridge.registerBridgeGauges(() => {
+            return {
+                // TODO(paul): actually fill some of these in
+                matrixRoomConfigs: 0,
+                remoteRoomConfigs: 0,
+
+                remoteGhosts: 0,
+                // matrixGhosts is provided automatically by the bridge
+
+                // TODO(paul) IRC bridge doesn't maintain mtimes at the moment.
+                //   Should probably make these metrics optional to most
+                //   exporters
+                matrixRoomsByAge: zeroAge,
+                remoteRoomsByAge: zeroAge,
+
+                matrixUsersByAge: zeroAge,
+                remoteUsersByAge: zeroAge,
+            };
+        });
     }
 
     this._ircEventBroker = new IrcEventBroker(

--- a/lib/bridge/IrcBridge.js
+++ b/lib/bridge/IrcBridge.js
@@ -87,6 +87,7 @@ function IrcBridge(config, registration) {
         }
     });
 
+    this._timers = null; // lazy map of Histogram instances used as metrics
     if (this.config.ircService.metrics && this.config.ircService.metrics.enabled) {
         this._initialiseMetrics();
     }
@@ -115,7 +116,8 @@ function IrcBridge(config, registration) {
 IrcBridge.prototype._initialiseMetrics = function() {
     var zeroAge = new AgeCounters();
 
-    this._bridge.getPrometheusMetrics();
+    var metrics = this._bridge.getPrometheusMetrics();
+
     this._bridge.registerBridgeGauges(() => {
         return {
             // TODO(paul): actually fill these in
@@ -134,6 +136,19 @@ IrcBridge.prototype._initialiseMetrics = function() {
             matrixUsersByAge: zeroAge,
             remoteUsersByAge: zeroAge,
         };
+    });
+
+    var timers = this._timers = {};
+
+    timers.matrix_requests = metrics.addTimer({
+        name: "matrix_requests",
+        help: "Histogram of processing durations of received Matrix messages",
+        labels: ["outcome"],
+    });
+    timers.remote_requests = metrics.addTimer({
+        name: "remote_requests",
+        help: "Histogram of processing durations of received remote messages",
+        labels: ["outcome"],
     });
 };
 
@@ -226,6 +241,10 @@ IrcBridge.prototype.run = Promise.coroutine(function*(port) {
         this.onLog("[" + req.getId() + "] DEAD (" + req.getDuration() + "ms)");
         var isFromIrc = Boolean((req.getData() || {}).isFromIrc);
         stats.request(isFromIrc, "fail", req.getDuration());
+        if (this._timers) {
+            var timer = this._timers[isFromIrc ? "remote_requests" : "matrix_requests"];
+            timer.observe({outcome: "fail"}, req.getDuration() / 1000);
+        }
     }, DEAD_TIME_MS);
     this._bridge.getRequestFactory().addDefaultResolveCallback((req, res) => {
         if (res === BridgeRequest.ERR_VIRTUAL_USER) {
@@ -238,10 +257,18 @@ IrcBridge.prototype.run = Promise.coroutine(function*(port) {
         }
         var isFromIrc = Boolean((req.getData() || {}).isFromIrc);
         stats.request(isFromIrc, "success", req.getDuration());
+        if (this._timers) {
+            var timer = this._timers[isFromIrc ? "remote_requests" : "matrix_requests"];
+            timer.observe({outcome: "success"}, req.getDuration() / 1000);
+        }
     });
     this._bridge.getRequestFactory().addDefaultRejectCallback((req) => {
         var isFromIrc = Boolean((req.getData() || {}).isFromIrc);
         stats.request(isFromIrc, "fail", req.getDuration());
+        if (this._timers) {
+            var timer = this._timers[isFromIrc ? "remote_requests" : "matrix_requests"];
+            timer.observe({outcome: "fail"}, req.getDuration() / 1000);
+        }
     });
 
     if (this.config.appService) {

--- a/lib/bridge/IrcBridge.js
+++ b/lib/bridge/IrcBridge.js
@@ -86,6 +86,10 @@ function IrcBridge(config, registration) {
         }
     });
 
+    if (this.config.ircService.metrics && this.config.ircService.metrics.enabled) {
+        this._bridge.getPrometheusMetrics();
+    }
+
     this._ircEventBroker = new IrcEventBroker(
         this._bridge, this._clientPool, this.ircHandler
     );

--- a/lib/bridge/IrcBridge.js
+++ b/lib/bridge/IrcBridge.js
@@ -88,28 +88,7 @@ function IrcBridge(config, registration) {
     });
 
     if (this.config.ircService.metrics && this.config.ircService.metrics.enabled) {
-        var zeroAge = new AgeCounters();
-
-        this._bridge.getPrometheusMetrics();
-        this._bridge.registerBridgeGauges(() => {
-            return {
-                // TODO(paul): actually fill these in
-                matrixRoomConfigs: 0,
-                remoteRoomConfigs: 0,
-
-                remoteGhosts: this._clientPool.countTotalConnections(),
-                // matrixGhosts is provided automatically by the bridge
-
-                // TODO(paul) IRC bridge doesn't maintain mtimes at the moment.
-                //   Should probably make these metrics optional to most
-                //   exporters
-                matrixRoomsByAge: zeroAge,
-                remoteRoomsByAge: zeroAge,
-
-                matrixUsersByAge: zeroAge,
-                remoteUsersByAge: zeroAge,
-            };
-        });
+        this._initialiseMetrics();
     }
 
     this._ircEventBroker = new IrcEventBroker(
@@ -132,6 +111,31 @@ function IrcBridge(config, registration) {
 
     this.publicitySyncer = new PublicitySyncer(this);
 }
+
+IrcBridge.prototype._initialiseMetrics = function() {
+    var zeroAge = new AgeCounters();
+
+    this._bridge.getPrometheusMetrics();
+    this._bridge.registerBridgeGauges(() => {
+        return {
+            // TODO(paul): actually fill these in
+            matrixRoomConfigs: 0,
+            remoteRoomConfigs: 0,
+
+            remoteGhosts: this._clientPool.countTotalConnections(),
+            // matrixGhosts is provided automatically by the bridge
+
+            // TODO(paul) IRC bridge doesn't maintain mtimes at the moment.
+            //   Should probably make these metrics optional to most
+            //   exporters
+            matrixRoomsByAge: zeroAge,
+            remoteRoomsByAge: zeroAge,
+
+            matrixUsersByAge: zeroAge,
+            remoteUsersByAge: zeroAge,
+        };
+    });
+};
 
 IrcBridge.prototype.getAppServiceUserId = function() {
     return this.appServiceUserId;

--- a/lib/bridge/IrcBridge.js
+++ b/lib/bridge/IrcBridge.js
@@ -93,11 +93,11 @@ function IrcBridge(config, registration) {
         this._bridge.getPrometheusMetrics();
         this._bridge.registerBridgeGauges(() => {
             return {
-                // TODO(paul): actually fill some of these in
+                // TODO(paul): actually fill these in
                 matrixRoomConfigs: 0,
                 remoteRoomConfigs: 0,
 
-                remoteGhosts: 0,
+                remoteGhosts: this._clientPool.countTotalConnections(),
                 // matrixGhosts is provided automatically by the bridge
 
                 // TODO(paul) IRC bridge doesn't maintain mtimes at the moment.

--- a/lib/bridge/IrcBridge.js
+++ b/lib/bridge/IrcBridge.js
@@ -140,13 +140,13 @@ IrcBridge.prototype._initialiseMetrics = function() {
 
     var timers = this._timers = {};
 
-    timers.matrix_requests = metrics.addTimer({
-        name: "matrix_requests",
+    timers.matrix_request_seconds = metrics.addTimer({
+        name: "matrix_request_seconds",
         help: "Histogram of processing durations of received Matrix messages",
         labels: ["outcome"],
     });
-    timers.remote_requests = metrics.addTimer({
-        name: "remote_requests",
+    timers.remote_request_seconds = metrics.addTimer({
+        name: "remote_request_seconds",
         help: "Histogram of processing durations of received remote messages",
         labels: ["outcome"],
     });
@@ -242,7 +242,9 @@ IrcBridge.prototype.run = Promise.coroutine(function*(port) {
         var isFromIrc = Boolean((req.getData() || {}).isFromIrc);
         stats.request(isFromIrc, "fail", req.getDuration());
         if (this._timers) {
-            var timer = this._timers[isFromIrc ? "remote_requests" : "matrix_requests"];
+            var timer = this._timers[
+                isFromIrc ? "remote_request_seconds" : "matrix_request_seconds"
+            ];
             timer.observe({outcome: "fail"}, req.getDuration() / 1000);
         }
     }, DEAD_TIME_MS);
@@ -258,7 +260,9 @@ IrcBridge.prototype.run = Promise.coroutine(function*(port) {
         var isFromIrc = Boolean((req.getData() || {}).isFromIrc);
         stats.request(isFromIrc, "success", req.getDuration());
         if (this._timers) {
-            var timer = this._timers[isFromIrc ? "remote_requests" : "matrix_requests"];
+            var timer = this._timers[
+                isFromIrc ? "remote_request_seconds" : "matrix_request_seconds"
+            ];
             timer.observe({outcome: "success"}, req.getDuration() / 1000);
         }
     });
@@ -266,7 +270,9 @@ IrcBridge.prototype.run = Promise.coroutine(function*(port) {
         var isFromIrc = Boolean((req.getData() || {}).isFromIrc);
         stats.request(isFromIrc, "fail", req.getDuration());
         if (this._timers) {
-            var timer = this._timers[isFromIrc ? "remote_requests" : "matrix_requests"];
+            var timer = this._timers[
+                isFromIrc ? "remote_request_seconds" : "matrix_request_seconds"
+            ];
             timer.observe({outcome: "fail"}, req.getDuration() / 1000);
         }
     });

--- a/lib/config/schema.yml
+++ b/lib/config/schema.yml
@@ -38,6 +38,11 @@ properties:
         properties:
             databaseUri:
                 type: "string"
+            metrics:
+                type: "object"
+                properties:
+                    enabled:
+                        type: "boolean"
             statsd:
                 type: "object"
                 properties:

--- a/lib/irc/ClientPool.js
+++ b/lib/irc/ClientPool.js
@@ -208,11 +208,8 @@ ClientPool.prototype.countTotalConnections = function() {
     var count = 0;
 
     Object.keys(this._virtualClients).forEach((domain) => {
-        var clients = this._virtualClients[domain];
-
-        Object.keys(clients).forEach((nick) => {
-            if (clients[nick]) { count++ }
-        });
+        let server = this._ircBridge.getServer(domain);
+        count += this._getNumberOfConnections(server);
     });
 
     return count;

--- a/lib/irc/ClientPool.js
+++ b/lib/irc/ClientPool.js
@@ -208,7 +208,7 @@ ClientPool.prototype.countTotalConnections = function() {
     var count = 0;
 
     Object.keys(this._virtualClients).forEach((domain) => {
-        var clients = this._virtualClients;
+        var clients = this._virtualClients[domain];
 
         Object.keys(clients).forEach((nick) => {
             if (clients[nick]) { count++ }

--- a/lib/irc/ClientPool.js
+++ b/lib/irc/ClientPool.js
@@ -204,6 +204,20 @@ ClientPool.prototype._getNumberOfConnections = function(server) {
     return numConnectedNicks;
 };
 
+ClientPool.prototype.countTotalConnections = function() {
+    var count = 0;
+
+    Object.keys(this._virtualClients).forEach((domain) => {
+        var clients = this._virtualClients;
+
+        Object.keys(clients).forEach((nick) => {
+            if (clients[nick]) { count++ }
+        });
+    });
+
+    return count;
+};
+
 ClientPool.prototype._sendConnectionMetric = function(server) {
     stats.ircClients(server.domain, this._getNumberOfConnections(server));
 };

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "irc": "matrix-org/node-irc#9bb3c68938f0979ab5b9e1398edf76403ee28a88",
     "jayschema": "^0.3.1",
     "js-yaml": "^3.2.7",
-    "matrix-appservice-bridge": "^1.3.2",
+    "matrix-appservice-bridge": "matrix-org/matrix-appservice-bridge#ca40ff5",
     "nedb": "^1.1.2",
     "nopt": "^3.0.1",
     "request": "^2.54.0",


### PR DESCRIPTION
This PR doesn't yet attempt to address all of the "bridge gauge" metrics, only enough to cover the same statistics as exported by the current `statsd`-based code.

Part of #296 