### PR TITLE
Use AS-specific room publication API

### DIFF
--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -31,6 +31,9 @@ ircService:
       # A human-readable description string
       # description: "Example.com IRC network"
 
+      # An ID for uniquely identifying this server amongst other servers being bridged.
+      networkId: "example"
+
       # The port to connect to. Optional.
       port: 6697
       # Whether to use SSL or not. Default: false.

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -32,7 +32,7 @@ ircService:
       # description: "Example.com IRC network"
 
       # An ID for uniquely identifying this server amongst other servers being bridged.
-      networkId: "example"
+      # networkId: "example"
 
       # The port to connect to. Optional.
       port: 6697

--- a/lib/DataStore.js
+++ b/lib/DataStore.js
@@ -170,7 +170,7 @@ DataStore.prototype.getAllChannelMappings = Promise.coroutine(function*() {
             (e) => e.matrix_id === roomId
         ).map((e) => {
             return {
-                networkId: this._serverMappings[e.remote.domain],
+                networkId: this._serverMappings[e.remote.domain].getNetworkId(),
                 channel: e.remote.channel
             }
         });

--- a/lib/DataStore.js
+++ b/lib/DataStore.js
@@ -170,7 +170,7 @@ DataStore.prototype.getAllChannelMappings = Promise.coroutine(function*() {
             (e) => e.matrix_id === roomId
         ).map((e) => {
             return {
-                domain: e.remote.domain,
+                networkId: this._serverMappings[e.remote.domain],
                 channel: e.remote.channel
             }
         });

--- a/lib/bridge/IrcBridge.js
+++ b/lib/bridge/IrcBridge.js
@@ -560,7 +560,7 @@ IrcBridge.prototype.getThirdPartyProtocol = function(protocol) {
         },
         instances: servers.map((server) => {
             return {
-                network_id: server.config.name || server.domain,
+                network_id: server.domain,
                 bot_user_id: this.getAppServiceUserId(),
                 desc: server.config.name || server.domain,
                 icon: server.config.icon,

--- a/lib/bridge/IrcBridge.js
+++ b/lib/bridge/IrcBridge.js
@@ -560,7 +560,7 @@ IrcBridge.prototype.getThirdPartyProtocol = function(protocol) {
         },
         instances: servers.map((server) => {
             return {
-                network_id: server.domain,
+                network_id: server.getNetworkId(),
                 bot_user_id: this.getAppServiceUserId(),
                 desc: server.config.name || server.domain,
                 icon: server.config.icon,

--- a/lib/bridge/IrcBridge.js
+++ b/lib/bridge/IrcBridge.js
@@ -560,6 +560,7 @@ IrcBridge.prototype.getThirdPartyProtocol = function(protocol) {
         },
         instances: servers.map((server) => {
             return {
+                network_id: server.config.name || server.domain,
                 bot_user_id: this.getAppServiceUserId(),
                 desc: server.config.name || server.domain,
                 icon: server.config.icon,

--- a/lib/bridge/IrcHandler.js
+++ b/lib/bridge/IrcHandler.js
@@ -571,7 +571,7 @@ IrcHandler.prototype.onMode = Promise.coroutine(function*(req, server, channel, 
             req.log.info("Not syncing publicity: shouldPublishRooms is false");
             return Promise.resolve();
         }
-        const key = this.ircBridge.publicitySyncer.getIRCVisMapKey(server, channel);
+        const key = this.ircBridge.publicitySyncer.getIRCVisMapKey(server.getNetworkId(), channel);
 
         // Update the visibility for all rooms connected to this channel
         return this.ircBridge.publicitySyncer.updateVisibilityMap(

--- a/lib/bridge/IrcHandler.js
+++ b/lib/bridge/IrcHandler.js
@@ -571,9 +571,11 @@ IrcHandler.prototype.onMode = Promise.coroutine(function*(req, server, channel, 
             req.log.info("Not syncing publicity: shouldPublishRooms is false");
             return Promise.resolve();
         }
+        const key = this.ircBridge.publicitySyncer.getIRCVisMapKey(server, channel);
+
         // Update the visibility for all rooms connected to this channel
         return this.ircBridge.publicitySyncer.updateVisibilityMap(
-            true, server.getNetworkId() + ' ' + channel, enabled
+            true, key, enabled
         );
     }
 

--- a/lib/bridge/IrcHandler.js
+++ b/lib/bridge/IrcHandler.js
@@ -573,7 +573,7 @@ IrcHandler.prototype.onMode = Promise.coroutine(function*(req, server, channel, 
         }
         // Update the visibility for all rooms connected to this channel
         return this.ircBridge.publicitySyncer.updateVisibilityMap(
-            true, server.domain + ' ' + channel, enabled
+            true, server.getNetworkId() + ' ' + channel, enabled
         );
     }
 

--- a/lib/bridge/PublicitySyncer.js
+++ b/lib/bridge/PublicitySyncer.js
@@ -61,6 +61,21 @@ PublicitySyncer.prototype.initModes = Promise.coroutine(function*(server) {
     });
 });
 
+/**
+ * Returns the key used when calling `updateVisibilityMap` for updating an IRC channel
+ * visibility mode (+s or -s).
+ * ```
+ * const key = publicitySyncer.getIRCVisMapKey(server, channel);
+ * publicitySyncer.updateVisibilityMap(true, key, true); // Set channel on server to be +s
+ * ```
+ * @param {IRCServer} server
+ * @param {string} channel
+ * @returns {string}
+ */
+PublicitySyncer.prototype.getIRCVisMapKey = function(server, channel) {
+    return server.getNetworkId() + ' ' + channel;
+}
+
 // This is used so that any updates to the visibility map will cause the syncer to
 // reset a timer and begin counting down again to the eventual call to solve any
 // inconsistencies in the visibility map.

--- a/lib/bridge/PublicitySyncer.js
+++ b/lib/bridge/PublicitySyncer.js
@@ -181,8 +181,12 @@ PublicitySyncer.prototype._solveVisibility = Promise.coroutine(function*() {
         let currentState = this._visibilityMap.roomVisibilities[roomId];
         let correctState = shouldBePrivate(roomId, []) ? 'private' : 'public';
 
+        // Use the server domain of the first mapping
+        // 'localhost #channel1' => 'localhost'
+        const networkId = this._visibilityMap.mappings[roomId][0].split(' ')[0];
+
         if (currentState !== correctState) {
-            return cli.setRoomDirectoryVisibility(roomId, correctState).then(
+            return cli.setRoomDirectoryVisibilityAppService(networkId, roomId, correctState).then(
                 () => {
                     // Update cache
                     this._visibilityMap.roomVisibilities[roomId] = correctState;

--- a/lib/bridge/PublicitySyncer.js
+++ b/lib/bridge/PublicitySyncer.js
@@ -65,15 +65,16 @@ PublicitySyncer.prototype.initModes = Promise.coroutine(function*(server) {
  * Returns the key used when calling `updateVisibilityMap` for updating an IRC channel
  * visibility mode (+s or -s).
  * ```
- * const key = publicitySyncer.getIRCVisMapKey(server, channel);
- * publicitySyncer.updateVisibilityMap(true, key, true); // Set channel on server to be +s
+ * // Set channel on server to be +s
+ * const key = publicitySyncer.getIRCVisMapKey(server.getNetworkId(), channel);
+ * publicitySyncer.updateVisibilityMap(true, key, true);
  * ```
- * @param {IRCServer} server
+ * @param {string} networkId
  * @param {string} channel
  * @returns {string}
  */
-PublicitySyncer.prototype.getIRCVisMapKey = function(server, channel) {
-    return server.getNetworkId() + ' ' + channel;
+PublicitySyncer.prototype.getIRCVisMapKey = function(networkId, channel) {
+    return networkId + ' ' + channel;
 }
 
 // This is used so that any updates to the visibility map will cause the syncer to
@@ -140,7 +141,7 @@ PublicitySyncer.prototype._solveVisibility = Promise.coroutine(function*() {
 
     roomIds.forEach((roomId) => {
         this._visibilityMap.mappings[roomId] = mappings[roomId].map((mapping) => {
-            return mapping.networkId + ' ' + mapping.channel
+            return getIRCVisMapKey(mapping.networkId, mapping.channel);
         });
     });
 

--- a/lib/bridge/PublicitySyncer.js
+++ b/lib/bridge/PublicitySyncer.js
@@ -20,10 +20,10 @@ function PublicitySyncer(ircBridge) {
     // should be resolved by keeping the matrix side as private as necessary
     this._visibilityMap = {
         mappings: {
-            //room_id: ['server #channel1', 'server channel2',...]
+            //room_id: ['funNetwork #channel1', 'funNetwork channel2',...]
         },
         channelIsSecret: {
-            // '$server $channel': true | false
+            // '$networkId $channel': true | false
         },
         roomVisibilities: {
             // room_id: "private" | "public"
@@ -125,7 +125,7 @@ PublicitySyncer.prototype._solveVisibility = Promise.coroutine(function*() {
 
     roomIds.forEach((roomId) => {
         this._visibilityMap.mappings[roomId] = mappings[roomId].map((mapping) => {
-            return mapping.domain + ' ' + mapping.channel
+            return mapping.networkId + ' ' + mapping.channel
         });
     });
 
@@ -181,8 +181,8 @@ PublicitySyncer.prototype._solveVisibility = Promise.coroutine(function*() {
         let currentState = this._visibilityMap.roomVisibilities[roomId];
         let correctState = shouldBePrivate(roomId, []) ? 'private' : 'public';
 
-        // Use the server domain of the first mapping
-        // 'localhost #channel1' => 'localhost'
+        // Use the server network ID of the first mapping
+        // 'funNetwork #channel1' => 'funNetwork'
         const networkId = this._visibilityMap.mappings[roomId][0].split(' ')[0];
 
         if (currentState !== correctState) {

--- a/lib/bridge/PublicitySyncer.js
+++ b/lib/bridge/PublicitySyncer.js
@@ -141,7 +141,7 @@ PublicitySyncer.prototype._solveVisibility = Promise.coroutine(function*() {
 
     roomIds.forEach((roomId) => {
         this._visibilityMap.mappings[roomId] = mappings[roomId].map((mapping) => {
-            return getIRCVisMapKey(mapping.networkId, mapping.channel);
+            return this.getIRCVisMapKey(mapping.networkId, mapping.channel);
         });
     });
 

--- a/lib/config/schema.yml
+++ b/lib/config/schema.yml
@@ -114,7 +114,7 @@ properties:
                             type: "string"
                         networkId:
                             type: "string"
-                            pattern: "^[a-zA-Z0-9]*$"
+                            pattern: "^[a-zA-Z0-9]+$"
                         icon:
                             type: "string"
                         quitDebounce:

--- a/lib/config/schema.yml
+++ b/lib/config/schema.yml
@@ -112,6 +112,9 @@ properties:
                             type: "string"
                         description:
                             type: "string"
+                        networkId:
+                            type: "string"
+                            pattern: "^[a-zA-Z0-9]*$"
                         icon:
                             type: "string"
                         quitDebounce:

--- a/lib/irc/IrcServer.js
+++ b/lib/irc/IrcServer.js
@@ -34,8 +34,8 @@ IrcServer.prototype.getReadableName = function() {
 }
 
 /**
- * Return the network ID of this server, which should be unique for this
- * bridge across all servers/instances. Defaults to the domain of the server.
+ * Return the network ID of this server, which should be unique for this bridge
+ * across all IrcServers on the bridge. Defaults to the domain of the server.
  */
 IrcServer.prototype.getNetworkId = function() {
     return this.config.networkId || server.domain;

--- a/lib/irc/IrcServer.js
+++ b/lib/irc/IrcServer.js
@@ -34,6 +34,14 @@ IrcServer.prototype.getReadableName = function() {
 }
 
 /**
+ * Return the network ID of this server, which should be unique for this
+ * bridge across all servers/instances. Defaults to the domain of the server.
+ */
+IrcServer.prototype.getNetworkId = function() {
+    return this.config.networkId || server.domain;
+}
+
+/**
  * Returns whether the server is configured to wait getQuitDebounceDelayMs before
  * parting a user that has disconnected due to a net-split.
  * @return {Boolean} this.config.quitDebounce.enabled.

--- a/lib/irc/IrcServer.js
+++ b/lib/irc/IrcServer.js
@@ -34,8 +34,9 @@ IrcServer.prototype.getReadableName = function() {
 }
 
 /**
- * Return the network ID of this server, which should be unique for this bridge
- * across all IrcServers on the bridge. Defaults to the domain of the server.
+ * Returns the network ID of this server, which should be unique across all
+ * IrcServers on the bridge. Defaults to the domain of this IrcServer.
+ * @return {string} this.config.networkId || this.domain
  */
 IrcServer.prototype.getNetworkId = function() {
     return this.config.networkId || this.domain;

--- a/lib/irc/IrcServer.js
+++ b/lib/irc/IrcServer.js
@@ -38,7 +38,7 @@ IrcServer.prototype.getReadableName = function() {
  * across all IrcServers on the bridge. Defaults to the domain of the server.
  */
 IrcServer.prototype.getNetworkId = function() {
-    return this.config.networkId || server.domain;
+    return this.config.networkId || this.domain;
 }
 
 /**


### PR DESCRIPTION
Corresponds to the changes outlined here: matrix-org/synapse#1676

- `network_id` (which is an IRC `server.domain`) has been added to each instance returned by `/thirdparty/protocols`.
- When room visibility is changed, the new endpoint specifically for ASes is used, which specifies the `network_id` to be the `server.domain` of the first bridged channel in the list of channels mapped to that room.

This requires https://github.com/matrix-org/matrix-js-sdk/pull/306