### PR TITLE
Use the new membership list APIs instead of /sync

### DIFF
--- a/lib/bridge/MemberListSyncer.js
+++ b/lib/bridge/MemberListSyncer.js
@@ -162,20 +162,55 @@ MemberListSyncer.prototype._getSyncableRooms = function(server, ignoreCache) {
         let attempts = 0;
         while (true) { // eslint-disable-line no-constant-condition
             try {
-                // roomDict = { room_id: RoomInfo }
-                let roomDict = yield self.appServiceBot.getMemberLists();
-                return Object.keys(roomDict).map(function(roomId) {
-                    return roomDict[roomId];
-                }).filter(function(roomInfo) {
+                let roomInfoList = [];
+                let joinedRoomIds = yield self.appServiceBot.getJoinedRooms();
+                for (let i = 0; i < joinedRoomIds.length; i++) {
+                    let roomId = joinedRoomIds[i];
+                    try {
+                        let userMap = yield self.appServiceBot.getJoinedMembers(roomId);
+                        let roomInfo = {
+                            id: roomId,
+                            state: [], // JSON objects (Matrix events)
+                            realJoinedUsers: [], // user IDs
+                            remoteJoinedUsers: [], // user IDs
+                        };
+                        Object.keys(userMap).forEach((userId) => {
+                            // TODO: Make this function public, it's useful!
+                            if (self.appServiceBot._isRemoteUser(roomId, userId)) {
+                                roomInfo.remoteJoinedUsers.push(userId);
+                            }
+                            else {
+                                roomInfo.realJoinedUsers.push(userId);
+                            }
+
+                            roomInfo.state.push({
+                                room_id: roomId,
+                                state_key: userId,
+                                user_id: userId,
+                                content: {
+                                    membership: "join",
+                                    display_name: userMap[userId].display_name,
+                                    avatar_url: userMap[userId].avatar_url,
+                                }
+                            });
+                        });
+                        roomInfoList.push(roomInfo);
+                    }
+                    catch (err) {
+                        log.error(`Failed to getJoinedMembers in room ${roomId}: ${err}`);
+                        i--; // try again
+                    }
+                }
+                return roomInfoList.filter(function(roomInfo) {
                     // filter out rooms with no real matrix users in them.
                     return roomInfo.realJoinedUsers.length > 0;
                 });
             }
             catch (err) {
-                log.error(
-                    `Failed to fetch syncable rooms after ${attempts} attempts: ` + err.stack
-                );
                 attempts += 1;
+                log.error(
+                    `Failed to fetch syncable rooms after ${attempts} attempts: ${err}`
+                );
                 yield Promise.delay(5000); // wait 5s and try again
             }
         }

--- a/lib/bridge/MemberListSyncer.js
+++ b/lib/bridge/MemberListSyncer.js
@@ -174,7 +174,9 @@ MemberListSyncer.prototype._getSyncableRooms = function(server, ignoreCache) {
                             realJoinedUsers: [], // user IDs
                             remoteJoinedUsers: [], // user IDs
                         };
-                        Object.keys(userMap).forEach((userId) => {
+                        let userIds = Object.keys(userMap);
+                        for (let j = 0; j < userIds.length; j++) {
+                            let userId = userIds[j];
                             // TODO: Make this function public, it's useful!
                             if (self.appServiceBot._isRemoteUser(roomId, userId)) {
                                 roomInfo.remoteJoinedUsers.push(userId);
@@ -193,7 +195,7 @@ MemberListSyncer.prototype._getSyncableRooms = function(server, ignoreCache) {
                                     avatar_url: userMap[userId].avatar_url,
                                 }
                             });
-                        });
+                        }
                         roomInfoList.push(roomInfo);
                     }
                     catch (err) {


### PR DESCRIPTION
/sync is slow (#288) and unreliable (#303) when the response is large. Use
dedicated membership list APIs instead.

Currently, this PR is just a literal translation of the new APIs from /sync.
To make full use of this API, we need to change when we begin processing the
results, as we can now do so incrementally.