### PR TITLE
Add support for setting default user modes on IRC clients

### DIFF
--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -271,6 +271,13 @@ ircService:
         # side instead of potentially spamming IRC and getting the IRC client kicked.
         # Default: 3.
         lineLimit: 3
+        # A list of user modes to set on every IRC client. For example, "RiG" would set
+        # +R, +i and +G on every IRC connection when they have successfully connected.
+        # User modes vary wildly depending on the IRC network you're connecting to,
+        # so check before setting this value. Some modes may not work as intended
+        # through the bridge e.g. caller ID as there is no way to /ACCEPT.
+        # Default: "" (no user modes)
+        # userModes: "R"
 
   # Configuration for an ident server. If you are running a public bridge it is
   # advised you setup an ident server so IRC mods can ban specific matrix users

--- a/lib/config/schema.yml
+++ b/lib/config/schema.yml
@@ -279,4 +279,6 @@ properties:
                                             pattern: "[ABCDEFabcdef0123456789:]+"
                                 lineLimit:
                                     type: "integer"
+                                userModes:
+                                    type: "string"
         required: ["databaseUri", "servers"]

--- a/lib/irc/BridgedClient.js
+++ b/lib/irc/BridgedClient.js
@@ -146,10 +146,22 @@ BridgedClient.prototype.connect = Promise.coroutine(function*() {
         this._connectDefer.resolve();
         this._keepAlive();
 
-        this._eventBroker.sendMetadata(this,
-            `You've been connected to the IRC network '${this.server.domain}' as ` +
-            `${this.nick}. `
+        let connectText = (
+            `You've been connected to the IRC network '${this.server.domain}' as ${this.nick}.`
         );
+
+        let userModes = this.server.getUserModes();
+        if (userModes.length > 0) {
+            // These can fail, but the generic error listener will catch them and send them
+            // into the same room as the connect text, so it's probably good enough to not
+            // explicitly handle them.
+            this.unsafeClient.setUserMode("+" + userModes);
+            connectText += (
+                ` User modes +${userModes} have been set.`
+            );
+        }
+
+        this._eventBroker.sendMetadata(this, connectText);
 
         connInst.client.addListener("nick", (old, newNick) => {
             if (old === this.nick) {

--- a/lib/irc/ConnectionInstance.js
+++ b/lib/irc/ConnectionInstance.js
@@ -165,7 +165,8 @@ ConnectionInstance.prototype._listenForErrors = function() {
             "err_alreadyregistred", "err_noprivileges", "err_chanoprivsneeded",
             "err_banonchan", "err_nickcollision", "err_nicknameinuse",
             "err_erroneusnickname", "err_nonicknamegiven", "err_eventnickchange",
-            "err_nicktoofast", "err_unknowncommand", "err_unavailresource"
+            "err_nicktoofast", "err_unknowncommand", "err_unavailresource",
+            "err_umodeunknownflag"
         ];
         if (err && err.command) {
             if (failCodes.indexOf(err.command) !== -1) {

--- a/lib/irc/IrcServer.js
+++ b/lib/irc/IrcServer.js
@@ -91,6 +91,10 @@ IrcServer.prototype.isBotEnabled = function() {
     return this.config.botConfig.enabled;
 };
 
+IrcServer.prototype.getUserModes = function() {
+    return this.config.ircClients.userModes || "";
+}
+
 IrcServer.prototype.getJoinRule = function() {
     return this.config.dynamicChannels.joinRule;
 };


### PR DESCRIPTION
Via the config option `ircClients.userModes`.

Requires https://github.com/matrix-org/node-irc/pull/16