### PR TITLE
Add config option for dropping old Matrix messages

### DIFF
--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -11,6 +11,18 @@ homeserver:
   #
   # media_url: "http://media.repo:8008"
 
+  # Drop Matrix messages which are older than this number of seconds, according to
+  # the event's origin_server_ts.
+  # If the bridge is down for a while, the homeserver will attempt to send all missed
+  # events on reconnection. These events may be hours old, which can be confusing to
+  # IRC users if they are then bridged. This option allows these old messages to be
+  # dropped.
+  # CAUTION: This is a very coarse heuristic. Federated homeservers may have different
+  # clock times and hence produce different origin_server_ts values, which may be old
+  # enough to cause *all* events from the homeserver to be dropped.
+  # Default: 0 (don't ever drop)
+  # dropMatrixMessagesAfterSecs: 300 # 5 minutes
+
   # The 'domain' part for user IDs on this home server. Usually (but not always)
   # is the "domain name" part of the HS URL.
   domain: "localhost"

--- a/lib/bridge/IrcBridge.js
+++ b/lib/bridge/IrcBridge.js
@@ -480,7 +480,8 @@ IrcBridge.prototype._onEvent = Promise.coroutine(function*(baseRequest, context)
     if (event.type === "m.room.message") {
         if (event.origin_server_ts && this.config.homeserver.dropMatrixMessagesAfterSecs) {
             let now = Date.now();
-            if ((now - event.origin_server_ts) > (1000 * this.config.homeserver.dropMatrixMessagesAfterSecs)) {
+            if ((now - event.origin_server_ts) >
+                    (1000 * this.config.homeserver.dropMatrixMessagesAfterSecs)) {
                 log.info(
                     "Dropping old m.room.message event %s timestamped %d",
                     event.event_id, event.origin_server_ts

--- a/lib/bridge/IrcBridge.js
+++ b/lib/bridge/IrcBridge.js
@@ -478,6 +478,16 @@ IrcBridge.prototype._onEvent = Promise.coroutine(function*(baseRequest, context)
     var event = baseRequest.getData();
     var request = new BridgeRequest(baseRequest, false);
     if (event.type === "m.room.message") {
+        if (event.origin_server_ts && this.config.homeserver.dropMatrixMessagesAfterSecs) {
+            let now = Date.now();
+            if ((now - event.origin_server_ts) > (1000 * this.config.homeserver.dropMatrixMessagesAfterSecs)) {
+                log.info(
+                    "Dropping old m.room.message event %s timestamped %d",
+                    event.event_id, event.origin_server_ts
+                );
+                return;
+            }
+        }
         yield this.matrixHandler.onMessage(request, event);
     }
     else if (event.type === "m.room.topic" && event.state_key === "") {

--- a/lib/config/schema.yml
+++ b/lib/config/schema.yml
@@ -1,38 +1,18 @@
 "$schema": "http://json-schema.org/draft-04/schema#"
 type: "object"
 properties:
-    appService:
+    homeserver:
         type: "object"
         properties:
-            homeserver:
-                type: "object"
-                properties:
-                    url:
-                        type: "string"
-                    media_url:
-                        type: "string"
-                    domain:
-                        type: "string"
-                required: ["url", "domain"]
-            appservice:
-                type: "object"
-                properties:
-                    url:
-                        type: "string"
-                    token:
-                        type: "string"
-                required: ["url", "token"]
-            http:
-                type: "object"
-                properties:
-                    port:
-                        type: "integer"
-                    maxSize:
-                        type: "integer"
-                required: ["port"]
-            localpart:
-                "type": "string"
-        required: ["homeserver", "appservice", "http"]
+            url:
+                type: "string"
+            media_url:
+                type: "string"
+            domain:
+                type: "string"
+            dropMatrixMessagesAfterSecs:
+                type: "integer"
+        required: ["url", "domain"]
     ircService:
         type: "object"
         properties:
@@ -92,6 +72,8 @@ properties:
                         type: "boolean"
                     requestTimeoutSeconds:
                         type: "number"
+            passwordEncryptionKeyPath:
+                type: "string"
             servers:
                 type: "object"
                 # all properties must follow the following

--- a/lib/main.js
+++ b/lib/main.js
@@ -34,6 +34,9 @@ var _toServer = function(domain, serverConfig, homeserverDomain) {
 
 module.exports.defaultConfig = function() {
     return {
+        homeserver: {
+            dropMatrixMessagesAfterSecs: 0,
+        },
         ircService: {
             ident: {
                 enabled: false,

--- a/spec/integ/matrix-to-irc.spec.js
+++ b/spec/integ/matrix-to-irc.spec.js
@@ -524,9 +524,9 @@ describe("Matrix-to-IRC message bridging with media URL and drop time", function
         yield test.afterEach(this, env); // eslint-disable-line no-invalid-this
     }));
 
-    it("should NOT bridge old matrix messages older than the drop time", test.coroutine(function*() {
+    it("should NOT bridge old matrix messages older than the drop time",
+    test.coroutine(function*() {
         var tBody = "Hello world";
-        var sdk = env.clientMock._client(config._botUserId);
 
         var said = false;
         env.ircMock._whenClient(roomMapping.server, testUser.nick, "say",
@@ -550,7 +550,6 @@ describe("Matrix-to-IRC message bridging with media URL and drop time", function
 
     it("should bridge old matrix messages younger than the drop time", test.coroutine(function*() {
         var tBody = "Hello world";
-        var sdk = env.clientMock._client(config._botUserId);
 
         var said = false;
         env.ircMock._whenClient(roomMapping.server, testUser.nick, "say",

--- a/spec/integ/matrix-to-irc.spec.js
+++ b/spec/integ/matrix-to-irc.spec.js
@@ -489,7 +489,7 @@ describe("Matrix-to-Matrix message bridging", function() {
     }));
 });
 
-describe("Matrix-to-IRC message bridging with media URL set", function() {
+describe("Matrix-to-IRC message bridging with media URL and drop time", function() {
     var testUser = {
         id: "@flibble:wibble",
         nick: "M-flibble"
@@ -498,8 +498,7 @@ describe("Matrix-to-IRC message bridging with media URL set", function() {
     beforeEach(test.coroutine(function*() {
         // Set the media URL
         env.config.homeserver.media_url = mediaUrl;
-
-        console.log(env.config.homeserver);
+        env.config.homeserver.dropMatrixMessagesAfterSecs = 300; // 5 min
 
         yield test.beforeEach(this, env); // eslint-disable-line no-invalid-this
 
@@ -523,6 +522,58 @@ describe("Matrix-to-IRC message bridging with media URL set", function() {
 
     afterEach(test.coroutine(function*() {
         yield test.afterEach(this, env); // eslint-disable-line no-invalid-this
+    }));
+
+    it("should NOT bridge old matrix messages older than the drop time", test.coroutine(function*() {
+        var tBody = "Hello world";
+        var sdk = env.clientMock._client(config._botUserId);
+
+        var said = false;
+        env.ircMock._whenClient(roomMapping.server, testUser.nick, "say",
+        function(client, channel, text) {
+            said = true;
+        });
+
+        yield env.mockAppService._trigger("type:m.room.message", {
+            content: {
+                body: tBody,
+                msgtype: "m.text"
+            },
+            user_id: testUser.id,
+            room_id: roomMapping.roomId,
+            type: "m.room.message",
+            origin_server_ts: Date.now() - (1000 * 60 * 6), // 6 mins old
+        });
+
+        expect(said).toBe(false);
+    }));
+
+    it("should bridge old matrix messages younger than the drop time", test.coroutine(function*() {
+        var tBody = "Hello world";
+        var sdk = env.clientMock._client(config._botUserId);
+
+        var said = false;
+        env.ircMock._whenClient(roomMapping.server, testUser.nick, "say",
+        function(client, channel, text) {
+            expect(client.nick).toEqual(testUser.nick);
+            expect(client.addr).toEqual(roomMapping.server);
+            expect(channel).toEqual(roomMapping.channel);
+            expect(text).toEqual(tBody);
+            said = true;
+        });
+
+        yield env.mockAppService._trigger("type:m.room.message", {
+            content: {
+                body: tBody,
+                msgtype: "m.text"
+            },
+            user_id: testUser.id,
+            room_id: roomMapping.roomId,
+            type: "m.room.message",
+            origin_server_ts: Date.now() - (1000 * 60 * 4), // 4 mins old
+        });
+
+        expect(said).toBe(true);
     }));
 
     it("should bridge matrix files as IRC text with a configured media URL", function(done) {


### PR DESCRIPTION
With tests. I also tweaked the config schema for the `homeserver` - `appService` has not been a valid config option for a very long time!

This only concerns **messages** as we still always want to sync membership list states.

Fixes #301 