### PR TITLE
Redo the !help message

### DIFF
--- a/lib/bridge/MatrixHandler.js
+++ b/lib/bridge/MatrixHandler.js
@@ -201,16 +201,47 @@ MatrixHandler.prototype._onAdminMessage = Promise.coroutine(function*(req, event
     let args = segments;
 
     if (cmd === "!help") {
-        let notice = new MatrixAction("notice",
-            `This is an IRC admin room for sending commands directly to IRC. Commands ` +
-            `can be sent in this format, but these will not produce a reply:\n`+
-            `\t!cmd [irc.server] COMMAND [arg0 [arg1 [...]]]\n\n` +
-            `Or if feedback is desired, the following commands can be used:\n` +
-            `\t!join irc.example.com #channel [key]\n` +
-            `\t!nick irc.example.com DesiredNick\n` +
-            `\t!whois nick\n` +
-            `\t!storepass [irc.example.com] passw0rd\n` +
-            `\t!removepass [irc.example.com]\n`
+        let helpCommands = {
+            "!join": {
+                example: `!join irc.example.com #channel [key]`,
+                summary: `Join a channel (with optional channel key)`,
+            },
+            "!nick": {
+                example: `!nick irc.example.com DesiredNick`,
+                summary: `Change your nick`,
+            },
+            "!whois": {
+                example: `!whois nick`,
+                summary: `Do a /whois lookup`,
+            },
+            "!storepass": {
+                example: `!storepass [irc.example.com] passw0rd`,
+                summary: `Store a NickServ password (server password)`,
+            },
+            "!removepass": {
+                example: `!removepass [irc.example.com]`,
+                summary: `Remove a previously stored NickServ password`,
+            },
+            "!quit": {
+                example: `!quit`,
+                summary: `Leave all bridged channels and remove your connection to IRC`,
+            },
+            "!cmd": {
+                example: `!cmd [irc.server] COMMAND [arg0 [arg1 [...]]]`,
+                summary: `Issue a raw IRC command. These will not produce a reply.`,
+            },
+        };
+
+
+        let notice = new MatrixAction("notice", null,
+            `This is an IRC admin room for controlling your IRC connection and sending commands directly to IRC. ` +
+            `The following commands are available:<br/><ul>\n\t` +
+            Object.keys(helpCommands).map((c) => {
+                return (
+                    `<li><strong>${helpCommands[c].example}</strong> : ${helpCommands[c].summary}</li>`
+                );
+            }).join(`\n\t`) +
+            `</ul>`
         );
         yield this.ircBridge.sendMatrixAction(adminRoom, botUser, notice, req);
         return;
@@ -565,7 +596,7 @@ MatrixHandler.prototype._onAdminMessage = Promise.coroutine(function*(req, event
         try {
             yield this.ircBridge.getStore().removePass(userId, domain);
             notice = new MatrixAction(
-                "notice", `Successfully removed password`
+                "notice", `Successfully removed password.`
             );
         }
         catch (err) {

--- a/lib/bridge/MatrixHandler.js
+++ b/lib/bridge/MatrixHandler.js
@@ -234,11 +234,14 @@ MatrixHandler.prototype._onAdminMessage = Promise.coroutine(function*(req, event
 
 
         let notice = new MatrixAction("notice", null,
-            `This is an IRC admin room for controlling your IRC connection and sending commands directly to IRC. ` +
+            `This is an IRC admin room for controlling your IRC connection and sending ` +
+            `commands directly to IRC. ` +
             `The following commands are available:<br/><ul>\n\t` +
             Object.keys(helpCommands).map((c) => {
                 return (
-                    `<li><strong>${helpCommands[c].example}</strong> : ${helpCommands[c].summary}</li>`
+                    `<li>` +
+                    `<strong>${helpCommands[c].example}</strong> : ${helpCommands[c].summary}` +
+                    `</li>`
                 );
             }).join(`\n\t`) +
             `</ul>`


### PR DESCRIPTION
Now with more bold and bullet points! The text preserves the previous `\n\t`
whitespace so the Matrix plaintext `body` renders just as good as the HTML form. Example plaintext:

```
This is an IRC admin room for controlling your IRC connection and sending commands directly to IRC. The following commands are available:
	!join irc.example.com #channel [key] : Join a channel (with optional channel key)
	!nick irc.example.com DesiredNick : Change your nick
	!whois nick : Do a /whois lookup
	!storepass [irc.example.com] passw0rd : Store a NickServ password (server password)
	!removepass [irc.example.com] : Remove a previously stored NickServ password
	!quit : Leave all bridged channels and remove your connection to IRC
	!cmd [irc.server] COMMAND [arg0 [arg1 [...]]] : Issue a raw IRC command. These will not produce a reply.
```

As HTML, this renders as the following:


This is an IRC admin room for controlling your IRC connection and sending commands directly to IRC. The following commands are available:
 * **!join irc.example.com #channel [key]** : Join a channel (with optional channel key)
 * **!nick irc.example.com DesiredNick** : Change your nick
 * **!whois nick** : Do a /whois lookup
 * **!storepass [irc.example.com] passw0rd** : Store a NickServ password (server password)
 * **!removepass [irc.example.com]** : Remove a previously stored NickServ password
 * **!quit** : Leave all bridged channels and remove your connection to IRC
 * **!cmd [irc.server] COMMAND [arg0 [arg1 [...]]]** : Issue a raw IRC command. These will not produce a reply.