### PR TITLE
Allow multiple in-flight /joined_members requests at once

### DIFF
--- a/lib/bridge/MemberListSyncer.js
+++ b/lib/bridge/MemberListSyncer.js
@@ -136,10 +136,8 @@ MemberListSyncer.prototype.checkBotPartRoom = Promise.coroutine(function*(ircRoo
 });
 
 // grab all rooms the bot knows about which have at least 1 real user in them.
-// ignoreCache exists because this function hammers /initialSync and that is expeeeensive,
-// so we don't do it unless they need absolutely fresh data. On startup, this can be called
-// multiple times, so we cache the first request's promise and return that instead of making
-// double hits.
+// On startup, this can be called multiple times, so we cache the first request's promise
+// and return that instead of making double hits.
 //
 // returns [
 //   {
@@ -156,68 +154,60 @@ MemberListSyncer.prototype._getSyncableRooms = function(server, ignoreCache) {
         return this._syncableRoomsPromise;
     }
 
-    // hit /initialSync on the bot to pull in room state for all rooms.
     let self = this;
     let fetchRooms = Promise.coroutine(function*() {
-        let attempts = 0;
-        while (true) { // eslint-disable-line no-constant-condition
-            try {
-                let roomInfoList = [];
-                let joinedRoomIds = yield self.appServiceBot.getJoinedRooms();
-                for (let i = 0; i < joinedRoomIds.length; i++) {
-                    let roomId = joinedRoomIds[i];
-                    try {
-                        let userMap = yield self.appServiceBot.getJoinedMembers(roomId);
-                        let roomInfo = {
-                            id: roomId,
-                            state: [], // JSON objects (Matrix events)
-                            realJoinedUsers: [], // user IDs
-                            remoteJoinedUsers: [], // user IDs
-                        };
-                        let userIds = Object.keys(userMap);
-                        for (let j = 0; j < userIds.length; j++) {
-                            let userId = userIds[j];
-                            // TODO: Make this function public, it's useful!
-                            if (self.appServiceBot._isRemoteUser(roomId, userId)) {
-                                roomInfo.remoteJoinedUsers.push(userId);
-                            }
-                            else {
-                                roomInfo.realJoinedUsers.push(userId);
-                            }
-
-                            roomInfo.state.push({
-                                room_id: roomId,
-                                state_key: userId,
-                                user_id: userId,
-                                content: {
-                                    membership: "join",
-                                    display_name: userMap[userId].display_name,
-                                    avatar_url: userMap[userId].avatar_url,
-                                }
-                            });
-                        }
-                        roomInfoList.push(roomInfo);
-                    }
-                    catch (err) {
-                        log.error(`Failed to getJoinedMembers in room ${roomId}: ${err}`);
-                        i--; // try again
-                    }
+        let roomInfoList = [];
+        let joinedRoomIds = yield self.appServiceBot.getJoinedRooms();
+        // fetch joined members allowing 5 in-flight reqs at a time
+        let pool = new QueuePool(5, Promise.coroutine(function*(roomId) {
+            let userMap = null;
+            while (!userMap) {
+                try {
+                    userMap = yield self.appServiceBot.getJoinedMembers(roomId);
                 }
-                return roomInfoList.filter(function(roomInfo) {
-                    // filter out rooms with no real matrix users in them.
-                    return roomInfo.realJoinedUsers.length > 0;
+                catch (err) {
+                    log.error(`Failed to getJoinedMembers in room ${roomId}: ${err}`);
+                }
+            }
+            let roomInfo = {
+                id: roomId,
+                state: [], // JSON objects (Matrix events)
+                realJoinedUsers: [], // user IDs
+                remoteJoinedUsers: [], // user IDs
+            };
+            let userIds = Object.keys(userMap);
+            for (let j = 0; j < userIds.length; j++) {
+                let userId = userIds[j];
+                // TODO: Make this function public, it's useful!
+                if (self.appServiceBot._isRemoteUser(roomId, userId)) {
+                    roomInfo.remoteJoinedUsers.push(userId);
+                }
+                else {
+                    roomInfo.realJoinedUsers.push(userId);
+                }
+
+                roomInfo.state.push({
+                    room_id: roomId,
+                    state_key: userId,
+                    user_id: userId,
+                    content: {
+                        membership: "join",
+                        display_name: userMap[userId].display_name,
+                        avatar_url: userMap[userId].avatar_url,
+                    }
                 });
             }
-            catch (err) {
-                attempts += 1;
-                log.error(
-                    `Failed to fetch syncable rooms after ${attempts} attempts: ${err}`
-                );
-                yield Promise.delay(5000); // wait 5s and try again
-            }
-        }
-        log.error("Failed to fetch syncable rooms: Giving up.");
-        return [];
+            roomInfoList.push(roomInfo);
+        }));
+        // wait for all the requests to go through
+        yield Promise.all(joinedRoomIds.map((roomId) => {
+            return pool.enqueue(roomId, roomId);
+        }));
+
+        return roomInfoList.filter(function(roomInfo) {
+            // filter out rooms with no real matrix users in them.
+            return roomInfo.realJoinedUsers.length > 0;
+        });
     });
 
     this._syncableRoomsPromise = fetchRooms();

--- a/lib/bridge/MemberListSyncer.js
+++ b/lib/bridge/MemberListSyncer.js
@@ -159,7 +159,7 @@ MemberListSyncer.prototype._getSyncableRooms = function() {
     let fetchRooms = Promise.coroutine(function*() {
         let roomInfoList = [];
         let joinedRoomIds = yield self.appServiceBot.getJoinedRooms();
-        // fetch joined members allowing 5 in-flight reqs at a time
+        // fetch joined members allowing 50 in-flight reqs at a time
         let pool = new QueuePool(50, Promise.coroutine(function*(roomId) {
             let userMap = null;
             while (!userMap) {
@@ -168,6 +168,7 @@ MemberListSyncer.prototype._getSyncableRooms = function() {
                 }
                 catch (err) {
                     log.error(`Failed to getJoinedMembers in room ${roomId}: ${err}`);
+                    yield Promise.delay(3000); // wait a bit before retrying
                 }
             }
             let roomInfo = {

--- a/lib/bridge/MemberListSyncer.js
+++ b/lib/bridge/MemberListSyncer.js
@@ -8,6 +8,7 @@ var Promise = require("bluebird");
 var promiseutil = require("../promiseutil");
 var log = require("../logging").get("MemberListSyncer");
 var stats = require("../config/stats");
+var QueuePool = require("../util/QueuePool");
 
 function MemberListSyncer(ircBridge, appServiceBot, server, appServiceUserId, injectJoinFn) {
     this.ircBridge = ircBridge;
@@ -43,7 +44,7 @@ MemberListSyncer.prototype.sync = Promise.coroutine(function*() {
     }
     log.info("Checking membership lists for syncing on %s", server.domain);
     let start = Date.now();
-    let rooms = yield this._getSyncableRooms(server);
+    let rooms = yield this._getSyncableRooms();
     log.info("Found %s syncable rooms (%sms)", rooms.length, Date.now() - start);
     this.leaveIrcUsersFromRooms(rooms, server);
     start = Date.now();
@@ -58,7 +59,7 @@ MemberListSyncer.prototype.sync = Promise.coroutine(function*() {
 MemberListSyncer.prototype.getChannelsToJoin = Promise.coroutine(function*() {
     let server = this.server;
     log.debug("getChannelsToJoin => %s", server.domain);
-    let rooms = yield this._getSyncableRooms(server);
+    let rooms = yield this._getSyncableRooms();
 
     // map room IDs to channels on this server.
     let channels = new Set();
@@ -148,8 +149,8 @@ MemberListSyncer.prototype.checkBotPartRoom = Promise.coroutine(function*(ircRoo
 //   },
 //   ...
 // ]
-MemberListSyncer.prototype._getSyncableRooms = function(server, ignoreCache) {
-    if (!ignoreCache && this._syncableRoomsPromise) {
+MemberListSyncer.prototype._getSyncableRooms = function() {
+    if (this._syncableRoomsPromise) {
         log.debug("Returning existing _getSyncableRooms Promise");
         return this._syncableRoomsPromise;
     }
@@ -159,7 +160,7 @@ MemberListSyncer.prototype._getSyncableRooms = function(server, ignoreCache) {
         let roomInfoList = [];
         let joinedRoomIds = yield self.appServiceBot.getJoinedRooms();
         // fetch joined members allowing 5 in-flight reqs at a time
-        let pool = new QueuePool(5, Promise.coroutine(function*(roomId) {
+        let pool = new QueuePool(50, Promise.coroutine(function*(roomId) {
             let userMap = null;
             while (!userMap) {
                 try {
@@ -201,6 +202,11 @@ MemberListSyncer.prototype._getSyncableRooms = function(server, ignoreCache) {
                 });
             }
             roomInfoList.push(roomInfo);
+            log.info(
+                "%s has %s real Matrix users and %s remote users (%s/%s)",
+                roomId, roomInfo.realJoinedUsers.length, roomInfo.remoteJoinedUsers.length,
+                roomInfoList.length, joinedRoomIds.length
+            );
         }));
         // wait for all the requests to go through
         yield Promise.all(joinedRoomIds.map((roomId) => {

--- a/lib/util/Queue.js
+++ b/lib/util/Queue.js
@@ -32,7 +32,7 @@ function Queue(processFn, intervalMs) {
 }
 
 /**
- * Return the length of the queue.
+ * Return the length of the queue, including the currently processed item.
  * @return {Number} The length of the queue.
  */
 Queue.prototype.size = function() {
@@ -41,7 +41,7 @@ Queue.prototype.size = function() {
 
 /**
  * Return a promise which is resolved when this queue is free (0 items in queue).
- * @return {Promise}
+ * @return {Promise<Queue>} Resolves to the Queue itself.
  */
 Queue.prototype.onceFree = function() {
     if (this.size() === 0) {
@@ -54,7 +54,7 @@ Queue.prototype.onceFree = function() {
 
 Queue.prototype._fireOnceFree = function() {
     this._onceFreeDefers.forEach((d) => {
-        d.resolve();
+        d.resolve(this);
     });
     this._onceFreeDefers = [];
 }

--- a/lib/util/Queue.js
+++ b/lib/util/Queue.js
@@ -17,6 +17,7 @@ function Queue(processFn, intervalMs) {
     this._queue = [];
     this._processing = null;
     this._procFn = processFn; // critical section Promise<result> = fn(item)
+    this._onceFreeDefers = [];
 
     if (intervalMs !== undefined && !(Number.isInteger(intervalMs) && intervalMs >= 0) ) {
         throw new Error('intervalMs must be a positive integer');
@@ -28,6 +29,34 @@ function Queue(processFn, intervalMs) {
         // Start consuming
         this._consume();
     }
+}
+
+/**
+ * Return the length of the queue.
+ * @return {Number} The length of the queue.
+ */
+Queue.prototype.size = function() {
+    return this._queue.length + (this._processing ? 1 : 0);
+};
+
+/**
+ * Return a promise which is resolved when this queue is free (0 items in queue).
+ * @return {Promise}
+ */
+Queue.prototype.onceFree = function() {
+    if (this.size() === 0) {
+        return Promise.resolve();
+    }
+    let defer = promiseutil.defer();
+    this._onceFreeDefers.push(defer);
+    return defer.promise;
+};
+
+Queue.prototype._fireOnceFree = function() {
+    this._onceFreeDefers.forEach((d) => {
+        d.resolve();
+    });
+    this._onceFreeDefers = [];
 }
 
 /**
@@ -73,6 +102,7 @@ Queue.prototype._consume = Promise.coroutine(function*() {
         if (this._intervalMs) {
             this._retry();
         }
+        this._fireOnceFree();
         return;
     }
     try {

--- a/lib/util/QueuePool.js
+++ b/lib/util/QueuePool.js
@@ -1,5 +1,4 @@
 "use strict";
-let Promise = require("bluebird");
 let Queue = require("./Queue");
 
 class QueuePool {
@@ -25,17 +24,17 @@ class QueuePool {
 	// which queue to put the item into.
 	enqueue(id, item, index) {
 		if (index === undefined) {
-			this.queues[this.roundRobinIndex].enqueue(id, item);
-			this.roundRobinIndex++; 
+			let promise = this.queues[this.roundRobinIndex].enqueue(id, item);
+			this.roundRobinIndex++;
 			if (this.roundRobinIndex >= this.size) {
 				this.roundRobinIndex = 0;
 			}
-			return;
+			return promise;
 		}
 		if (index >= this.size || index < 0) {
 			throw new Error(`enqueue: index ${index} is out of bounds`);
 		}
-		this.queues[index].enqueue(id, item);
+		return this.queues[index].enqueue(id, item);
 	}
 
 }

--- a/lib/util/QueuePool.js
+++ b/lib/util/QueuePool.js
@@ -1,0 +1,43 @@
+"use strict";
+let Promise = require("bluebird");
+let Queue = require("./Queue");
+
+class QueuePool {
+
+	// Construct a new Queue Pool.
+	// This consists of multiple queues. Items will be round-robined into
+	// each queue, unless an index is given when enqueuing.
+	constructor(poolSize, fn) {
+		if (poolSize < 1) {
+			throw new Error("Pool size must be at least 1");
+		}
+		this.size = poolSize;
+		this.fn = fn;
+		this.queues = [];
+		for (let i = 0; i < poolSize; i++) {
+			this.queues.push(new Queue(fn));
+		}
+		this.roundRobinIndex = 0;
+	}
+
+	// Add an item to the queue. ID and item are passed directly to the Queue.
+	// Index is optional and should be between 0 - poolSize. It determines
+	// which queue to put the item into.
+	enqueue(id, item, index) {
+		if (index === undefined) {
+			this.queues[this.roundRobinIndex].enqueue(id, item);
+			this.roundRobinIndex++; 
+			if (this.roundRobinIndex >= this.size) {
+				this.roundRobinIndex = 0;
+			}
+			return;
+		}
+		if (index >= this.size || index < 0) {
+			throw new Error(`enqueue: index ${index} is out of bounds`);
+		}
+		this.queues[index].enqueue(id, item);
+	}
+
+}
+
+module.exports = QueuePool;

--- a/lib/util/QueuePool.js
+++ b/lib/util/QueuePool.js
@@ -2,13 +2,17 @@
 let Promise = require("bluebird");
 let Queue = require("./Queue");
 
+// A Queue Pool is a queue which is backed by a pool of queues which can be serviced
+// concurrently. The number of items which can be processed concurrently is the size
+// of the queue. The QueuePool always operates in a FIFO manner, even when all queues
+// are occupied.
 class QueuePool {
 
     // Construct a new Queue Pool.
     // This consists of multiple queues. Items will be inserted into
     // the first available free queue. If no queue is free, items will
     // be put in a FIFO overflow queue. You can also use an index when
-    // enqueuing to override this.
+    // enqueuing to override this behaviour.
     constructor(poolSize, fn) {
         if (poolSize < 1) {
             throw new Error("Pool size must be at least 1");
@@ -23,30 +27,35 @@ class QueuePool {
     }
 
     // Add an item to the queue. ID and item are passed directly to the Queue.
-    // Index is optional and should be between 0 - poolSize. It determines
+    // Index is optional and should be between 0 ~ poolSize-1. It determines
     // which queue to put the item into.
+    // Returns: A promise which resolves when the item has been serviced, and
+    //          the promise returned by the queue function has resolved.
     enqueue(id, item, index) {
-        // no index specified: first free queue gets it.
-        if (index === undefined) {
-            let queue = this._freeQueue();
-            if (!queue) {
-                // the overflow queue promise is resolved when the item is pushed
-                // onto the queue pool. We want to return a promise which resolves
-                // after the item has finished executing on the queue pool, hence
-                // the promise chain here.
-                return this.overflow.enqueue(id, {
-                    id: id,
-                    item: item,
-                }).then((req) => {
-                    return req.p;
-                });
+        if (index !== undefined) {
+            if (index >= this.size || index < 0) {
+                throw new Error(`enqueue: index ${index} is out of bounds`);
             }
+            return this.queues[index].enqueue(id, item);
+        }
+
+        // no index specified: first free queue gets it.
+        let queue = this._freeQueue();
+        if (queue) {
+            // push it to the queue pool immediately.
             return queue.enqueue(id, item);
         }
-        if (index >= this.size || index < 0) {
-            throw new Error(`enqueue: index ${index} is out of bounds`);
-        }
-        return this.queues[index].enqueue(id, item);
+        // All the queues are busy.
+        // The overflow queue promise is resolved when the item is pushed
+        // onto the queue pool. We want to return a promise which resolves
+        // after the item has finished executing on the queue pool, hence
+        // the promise chain here.
+        return this.overflow.enqueue(id, {
+            id: id,
+            item: item,
+        }).then((req) => {
+            return req.p;
+        });
     }
 
     // This is called when a request is at the front of the overflow queue.
@@ -54,7 +63,7 @@ class QueuePool {
         let queue = this._freeQueue();
         if (queue) {
             // cannot return the raw promise else it will be waited on, whereas we want to return
-            // the actual promise to the caller of QueuePool.enqueue();
+            // the actual promise to the caller of QueuePool.enqueue(); so wrap it up in an object.
             return Promise.resolve({
                 p: queue.enqueue(req.id, req.item)
             });

--- a/lib/util/QueuePool.js
+++ b/lib/util/QueuePool.js
@@ -28,7 +28,7 @@ class QueuePool {
 
     // Add an item to the queue. ID and item are passed directly to the Queue.
     // Index is optional and should be between 0 ~ poolSize-1. It determines
-    // which queue to put the item into.
+    // which queue to put the item into, which will bypass the overflow queue.
     // Returns: A promise which resolves when the item has been serviced, and
     //          the promise returned by the queue function has resolved.
     enqueue(id, item, index) {
@@ -72,13 +72,12 @@ class QueuePool {
         let promises = this.queues.map((q) => {
             return q.onceFree();
         });
-        return Promise.any(promises).then(() => {
-            queue = this._freeQueue();
-            if (!queue) {
+        return Promise.any(promises).then((q) => {
+            if (q.size() !== 0) {
                 throw new Error(`QueuePool overflow: starvation. No free queues.`);
             }
             return {
-                p: queue.enqueue(req.id, req.item),
+                p: q.enqueue(req.id, req.item),
             };
         })
     }

--- a/lib/util/QueuePool.js
+++ b/lib/util/QueuePool.js
@@ -1,41 +1,87 @@
 "use strict";
+let Promise = require("bluebird");
 let Queue = require("./Queue");
 
 class QueuePool {
 
-	// Construct a new Queue Pool.
-	// This consists of multiple queues. Items will be round-robined into
-	// each queue, unless an index is given when enqueuing.
-	constructor(poolSize, fn) {
-		if (poolSize < 1) {
-			throw new Error("Pool size must be at least 1");
-		}
-		this.size = poolSize;
-		this.fn = fn;
-		this.queues = [];
-		for (let i = 0; i < poolSize; i++) {
-			this.queues.push(new Queue(fn));
-		}
-		this.roundRobinIndex = 0;
-	}
+    // Construct a new Queue Pool.
+    // This consists of multiple queues. Items will be inserted into
+    // the first available free queue. If no queue is free, items will
+    // be put in a FIFO overflow queue. You can also use an index when
+    // enqueuing to override this.
+    constructor(poolSize, fn) {
+        if (poolSize < 1) {
+            throw new Error("Pool size must be at least 1");
+        }
+        this.size = poolSize;
+        this.fn = fn;
+        this.queues = [];
+        for (let i = 0; i < poolSize; i++) {
+            this.queues.push(new Queue(fn));
+        }
+        this.overflow = new Queue(this._overflow.bind(this));
+    }
 
-	// Add an item to the queue. ID and item are passed directly to the Queue.
-	// Index is optional and should be between 0 - poolSize. It determines
-	// which queue to put the item into.
-	enqueue(id, item, index) {
-		if (index === undefined) {
-			let promise = this.queues[this.roundRobinIndex].enqueue(id, item);
-			this.roundRobinIndex++;
-			if (this.roundRobinIndex >= this.size) {
-				this.roundRobinIndex = 0;
-			}
-			return promise;
-		}
-		if (index >= this.size || index < 0) {
-			throw new Error(`enqueue: index ${index} is out of bounds`);
-		}
-		return this.queues[index].enqueue(id, item);
-	}
+    // Add an item to the queue. ID and item are passed directly to the Queue.
+    // Index is optional and should be between 0 - poolSize. It determines
+    // which queue to put the item into.
+    enqueue(id, item, index) {
+        // no index specified: first free queue gets it.
+        if (index === undefined) {
+            let queue = this._freeQueue();
+            if (!queue) {
+                // the overflow queue promise is resolved when the item is pushed
+                // onto the queue pool. We want to return a promise which resolves
+                // after the item has finished executing on the queue pool, hence
+                // the promise chain here.
+                return this.overflow.enqueue(id, {
+                    id: id,
+                    item: item,
+                }).then((req) => {
+                    return req.p;
+                });
+            }
+            return queue.enqueue(id, item);
+        }
+        if (index >= this.size || index < 0) {
+            throw new Error(`enqueue: index ${index} is out of bounds`);
+        }
+        return this.queues[index].enqueue(id, item);
+    }
+
+    // This is called when a request is at the front of the overflow queue.
+    _overflow(req) {
+        let queue = this._freeQueue();
+        if (queue) {
+            // cannot return the raw promise else it will be waited on, whereas we want to return
+            // the actual promise to the caller of QueuePool.enqueue();
+            return Promise.resolve({
+                p: queue.enqueue(req.id, req.item)
+            });
+        }
+        // wait for any queue to become available
+        let promises = this.queues.map((q) => {
+            return q.onceFree();
+        });
+        return Promise.any(promises).then(() => {
+            queue = this._freeQueue();
+            if (!queue) {
+                throw new Error(`QueuePool overflow: starvation. No free queues.`);
+            }
+            return {
+                p: queue.enqueue(req.id, req.item),
+            };
+        })
+    }
+
+    _freeQueue() {
+        for (let i = 0; i < this.queues.length; i++) {
+            if (this.queues[i].size() === 0) {
+                return this.queues[i];
+            }
+        }
+        return null;
+    }
 
 }
 

--- a/spec/unit/QueuePool.spec.js
+++ b/spec/unit/QueuePool.spec.js
@@ -1,0 +1,56 @@
+"use strict";
+
+let Promise = require("bluebird");
+let QueuePool = require("../../lib/util/QueuePool");
+let test = require("../util/test");
+let promiseutil = require("../../lib/promiseutil");
+
+describe("QueuePool", function() {
+    const size = 3;
+    let pool;
+    let procFn;
+    let itemToDeferMap;
+
+    beforeEach(function() {
+        procFn = jasmine.createSpy("procFn");
+        pool = new QueuePool(size, procFn);
+        itemToDeferMap = {
+            // $item: Deferred
+        };
+        procFn.andCallFake((item) => {
+            console.log("procFn " + item);
+            itemToDeferMap[item] = new promiseutil.defer();
+            return itemToDeferMap[item].promise;
+        })
+    });
+
+    xit("should let multiple items be processed at once", function(done) {
+        pool.enqueue("a", "a");
+        pool.enqueue("b", "b");
+        // procFn is called on the next tick so check they've been called after
+        process.nextTick(() => {
+            expect(Object.keys(itemToDeferMap).length).toBe(2);
+            done();
+        });
+    });
+
+    it("should not let more items than the pool size be processed at once",
+    function(done) {
+        pool.enqueue("a", "a");
+        pool.enqueue("b", "b");
+        pool.enqueue("c", "c");
+        pool.enqueue("d", "d");
+        process.nextTick(() => {
+            // first 3 items
+            expect(Object.keys(itemToDeferMap).sort()).toEqual(["a","b","c"]);
+            if (!itemToDeferMap["b"]) { done(); }
+            itemToDeferMap["b"].resolve();
+            delete itemToDeferMap["b"];
+
+            setTimeout(() => {
+                expect(Object.keys(itemToDeferMap).sort()).toEqual(["a","c","d"]);
+                done();
+            }, 10);
+        });
+    });
+});

--- a/spec/unit/QueuePool.spec.js
+++ b/spec/unit/QueuePool.spec.js
@@ -1,8 +1,5 @@
 "use strict";
-
-let Promise = require("bluebird");
 let QueuePool = require("../../lib/util/QueuePool");
-let test = require("../util/test");
 let promiseutil = require("../../lib/promiseutil");
 
 describe("QueuePool", function() {
@@ -18,13 +15,12 @@ describe("QueuePool", function() {
             // $item: Deferred
         };
         procFn.andCallFake((item) => {
-            console.log("procFn " + item);
             itemToDeferMap[item] = new promiseutil.defer();
             return itemToDeferMap[item].promise;
         })
     });
 
-    xit("should let multiple items be processed at once", function(done) {
+    it("should let multiple items be processed at once", function(done) {
         pool.enqueue("a", "a");
         pool.enqueue("b", "b");
         // procFn is called on the next tick so check they've been called after
@@ -42,13 +38,13 @@ describe("QueuePool", function() {
         pool.enqueue("d", "d");
         process.nextTick(() => {
             // first 3 items
-            expect(Object.keys(itemToDeferMap).sort()).toEqual(["a","b","c"]);
+            expect(Object.keys(itemToDeferMap).sort()).toEqual(["a", "b", "c"]);
             if (!itemToDeferMap["b"]) { done(); }
             itemToDeferMap["b"].resolve();
             delete itemToDeferMap["b"];
 
             setTimeout(() => {
-                expect(Object.keys(itemToDeferMap).sort()).toEqual(["a","c","d"]);
+                expect(Object.keys(itemToDeferMap).sort()).toEqual(["a", "c", "d"]);
                 done();
             }, 10);
         });

--- a/spec/unit/QueuePool.spec.js
+++ b/spec/unit/QueuePool.spec.js
@@ -97,8 +97,8 @@ describe("QueuePool", function() {
         pool.enqueue("e", "e");
         yield nextTick();
         expect(Object.keys(itemToDeferMap).sort()).toEqual(["a", "b", "c"]);
-        pool.enqueue("f", "f");
         resolveItem("b");
+        pool.enqueue("f", "f");
         yield nextTick();
         expect(Object.keys(itemToDeferMap).sort()).toEqual(["a", "c", "d"]);
         resolveItem("a");

--- a/spec/unit/QueuePool.spec.js
+++ b/spec/unit/QueuePool.spec.js
@@ -17,11 +17,11 @@ describe("QueuePool", function() {
     let procFn;
     let itemToDeferMap;
 
-    let resolveItem = function(id) {
+    let resolveItem = function(id, resolveWith) {
         if (!itemToDeferMap[id]) {
             return;
         }
-        itemToDeferMap[id].resolve();
+        itemToDeferMap[id].resolve(resolveWith);
         delete itemToDeferMap[id];
     }
 
@@ -44,6 +44,16 @@ describe("QueuePool", function() {
         // procFn is called on the next tick so check they've been called after
         yield nextTick();
         expect(Object.keys(itemToDeferMap).length).toBe(2);
+    }));
+
+    it("should resolve enqueued items when they resolve",
+    test.coroutine(function*() {
+        pool.enqueue("a", "a");
+        let promise = pool.enqueue("b", "b");
+        yield nextTick();
+        resolveItem("b", "stuff");
+        let res = yield promise;
+        expect(res).toEqual("stuff");
     }));
 
     it("should not let more items than the pool size be processed at once",


### PR DESCRIPTION
Add a new utility class:
 - `QueuePool` : A number of `Queues` all of which can be active at once. New items are put into the first free `Queue` in a FIFO manner.

Use `QueuePool` to make multiple in-flight requests at once. Set to 50 as this seems good enough for Freenode/matrix.org (1m30s for 12k rooms).