### PR TITLE
Do not treat invites for unknown user IDs as errors

### DIFF
--- a/lib/bridge/IrcBridge.js
+++ b/lib/bridge/IrcBridge.js
@@ -692,15 +692,18 @@ IrcBridge.prototype.aliasToIrcChannel = function(alias) {
     };
 };
 
-IrcBridge.prototype.matrixToIrcUser = function(user) {
-    var server = null;
-    var servers = this.getServers();
-    for (var i = 0; i < servers.length; i++) {
-        if (servers[i].claimsUserId(user.getId())) {
-            server = servers[i];
-            break;
+IrcBridge.prototype.getServerForUserId = function(userId) {
+    let servers = this.getServers();
+    for (let i = 0; i < servers.length; i++) {
+        if (servers[i].claimsUserId(userId)) {
+            return servers[i];
         }
     }
+    return null;
+}
+
+IrcBridge.prototype.matrixToIrcUser = function(user) {
+    var server = this.getServerForUserId(user.getId());
     var ircInfo = {
         server: server,
         nick: server ? server.getNickFromUserId(user.getId()) : null

--- a/lib/bridge/MatrixHandler.js
+++ b/lib/bridge/MatrixHandler.js
@@ -692,7 +692,8 @@ MatrixHandler.prototype._onInvite = Promise.coroutine(function*(req, event, invi
      * [1] MX  --invite--> VMX  (starting a PM chat)
      * [2] bot --invite--> VMX  (invite-only room that the bot is in who is inviting virtuals)
      * [3] MX  --invite--> BOT  (admin room; auth)
-     * [4] bot --invite--> MX   (bot telling real mx user IRC conn state)
+     * [4] bot --invite--> MX   (bot telling real mx user IRC conn state) - Ignore.
+     * [5] irc --invite--> MX   (real irc user PMing a Matrix user) - Ignore.
      */
     req.log.info("onInvite: %s", JSON.stringify(event));
     this._onMemberEvent(req, event);
@@ -706,31 +707,25 @@ MatrixHandler.prototype._onInvite = Promise.coroutine(function*(req, event, invi
     });
 
     // work out which flow we're dealing with and fork off asap
-    // First, try to map the invitee to an IRC user.
-    try {
+    // is the invitee the bot?
+    if (this.ircBridge.getAppServiceUserId() === event.state_key) {
+        // case [3]
+        yield this._handleAdminRoomInvite(req, event, inviter, invitee);
+    }
+    // else is the invitee a real matrix user? If they are, there will be no IRC server
+    else if (!this.ircBridge.getServerForUserId(event.state_key)) {
+        // cases [4] and [5] : We cannot accept on behalf of real matrix users, so nop
+        return BridgeRequest.ERR_NOT_MAPPED;
+    }
+    else {
+        // cases [1] and [2] : The invitee represents a real IRC user
         let ircUser = yield this.ircBridge.matrixToIrcUser(invitee);
-        // the invitee does map to an IRC user: is the invite from the
-        // bot?
+        // is the invite from the bot?
         if (this.ircBridge.getAppServiceUserId() === event.user_id) {
             yield this._handleInviteFromBot(req, event, ircUser); // case [2]
         }
         else {
             yield this._handleInviteFromUser(req, event, ircUser); // case [1]
-        }
-    }
-    catch (err) {
-        // failed to map invitee to an IRC user; is the invitee the bot?
-        if (this.ircBridge.getAppServiceUserId() === event.state_key) {
-            // case [3]
-            yield this._handleAdminRoomInvite(req, event, inviter, invitee);
-        }
-        // failed to map invitee to an IRC user, is the inviter the bot?
-        else if (this.ircBridge.getAppServiceUserId() === event.user_id) {
-            // case [4] - ignore.
-            return;
-        }
-        else if (err && err.stack) { // syntax error possibly
-            throw err;
         }
     }
 });


### PR DESCRIPTION
Fixes #261

The bridge will get invites *it has sent* mirrored back to itself.
These were previously treated as FAILED because we didn't explicitly
handle this case. We now handle this case, and no longer have a bulk
try/catch around converting the invitee to an IRC user. This was part
of the problem as it was impossible to know if the error was due to
no mapping existing or a `TypeError` or equiv.