### PR TITLE
Remove 'this' from beforeEach/afterEach as they don't exist in Jasmine 2

### DIFF
--- a/spec/integ/admin-rooms.spec.js
+++ b/spec/integ/admin-rooms.spec.js
@@ -18,7 +18,7 @@ var botUserId = config._botUserId;
 describe("Creating admin rooms", function() {
 
     beforeEach(test.coroutine(function*() {
-        yield test.beforeEach(this, env); // eslint-disable-line no-invalid-this
+        yield test.beforeEach(env);
 
         env.ircMock._autoConnectNetworks(
             roomMapping.server, roomMapping.botNick, roomMapping.server
@@ -31,7 +31,7 @@ describe("Creating admin rooms", function() {
     }));
 
     afterEach(test.coroutine(function*() {
-        yield test.afterEach(this, env); // eslint-disable-line no-invalid-this
+        yield test.afterEach(env);
     }));
 
     it("should be possible by sending an invite to the bot's user ID",
@@ -63,7 +63,7 @@ describe("Admin rooms", function() {
     var userIdNick = "M-someone";
 
     beforeEach(test.coroutine(function*() {
-        yield test.beforeEach(this, env); // eslint-disable-line no-invalid-this
+        yield test.beforeEach(env);
 
         // enable nick changes
         config.ircService.servers[roomMapping.server].ircClients.allowNickChanges = true;
@@ -125,7 +125,7 @@ describe("Admin rooms", function() {
 
     afterEach(test.coroutine(function*() {
         jasmine.clock().uninstall();
-        yield test.afterEach(this, env); // eslint-disable-line no-invalid-this
+        yield test.afterEach(env);
     }));
 
     it("should respond to bad !nick commands with a help notice",

--- a/spec/integ/dynamic-channels.spec.js
+++ b/spec/integ/dynamic-channels.spec.js
@@ -21,7 +21,7 @@ describe("Dynamic channels", function() {
 
     beforeEach(test.coroutine(function*() {
         config.ircService.servers[roomMapping.server].dynamicChannels.enabled = true;
-        yield test.beforeEach(this, env); // eslint-disable-line no-invalid-this
+        yield test.beforeEach(env);
 
         // accept connection requests
         env.ircMock._autoConnectNetworks(
@@ -38,7 +38,7 @@ describe("Dynamic channels", function() {
     }));
 
     afterEach(test.coroutine(function*() {
-        yield test.afterEach(this, env); // eslint-disable-line no-invalid-this
+        yield test.afterEach(env);
     }));
 
     it("should join IRC channels when it receives special alias queries",
@@ -186,7 +186,7 @@ describe("Dynamic channels (federation disabled)", function() {
     };
 
     beforeEach(test.coroutine(function*() {
-        yield test.beforeEach(this, env); // eslint-disable-line no-invalid-this
+        yield test.beforeEach(env);
 
         config.ircService.servers[
             roomMapping.server].dynamicChannels.enabled = true;
@@ -207,7 +207,7 @@ describe("Dynamic channels (federation disabled)", function() {
     }));
 
     afterEach(test.coroutine(function*() {
-        yield test.afterEach(this, env); // eslint-disable-line no-invalid-this
+        yield test.afterEach(env);
     }));
 
     it("should create non federated room when joining channel and federation is disabled",
@@ -260,7 +260,7 @@ describe("Dynamic channels (disabled)", function() {
 
     beforeEach(test.coroutine(function*() {
         config.ircService.servers[roomMapping.server].dynamicChannels.enabled = false;
-        yield test.beforeEach(this, env); // eslint-disable-line no-invalid-this
+        yield test.beforeEach(env);
 
         // accept connection requests
         env.ircMock._autoConnectNetworks(
@@ -278,7 +278,7 @@ describe("Dynamic channels (disabled)", function() {
     }));
 
     afterEach(test.coroutine(function*() {
-        yield test.afterEach(this, env); // eslint-disable-line no-invalid-this
+        yield test.afterEach(env);
     }));
 
     it("should NOT join IRC channels when it receives special alias queries",

--- a/spec/integ/hs-queries.spec.js
+++ b/spec/integ/hs-queries.spec.js
@@ -20,7 +20,7 @@ describe("Homeserver user queries", function() {
     );
 
     beforeEach(test.coroutine(function*() {
-        yield test.beforeEach(this, env); // eslint-disable-line no-invalid-this
+        yield test.beforeEach(env);
 
         // accept connection requests
         env.ircMock._autoConnectNetworks(
@@ -32,7 +32,7 @@ describe("Homeserver user queries", function() {
     }));
 
     afterEach(test.coroutine(function*() {
-        yield test.afterEach(this, env); // eslint-disable-line no-invalid-this
+        yield test.afterEach(env);
     }));
 
     it("should always create a new Matrix user for the specified ID",
@@ -70,7 +70,7 @@ describe("Homeserver alias queries", function() {
     );
 
     beforeEach(test.coroutine(function*() {
-        yield test.beforeEach(this, env); // eslint-disable-line no-invalid-this
+        yield test.beforeEach(env);
 
         // accept connection requests
         env.ircMock._autoConnectNetworks(
@@ -88,7 +88,7 @@ describe("Homeserver alias queries", function() {
     }));
 
     afterEach(test.coroutine(function*() {
-        yield test.afterEach(this, env); // eslint-disable-line no-invalid-this
+        yield test.afterEach(env);
     }));
 
     it("should make the AS start tracking the channel specified in the alias.",

--- a/spec/integ/init.spec.js
+++ b/spec/integ/init.spec.js
@@ -22,11 +22,11 @@ describe("Initialisation", function() {
     var ircChannel = roomMapping.channel;
 
     beforeEach(test.coroutine(function*() {
-        yield test.beforeEach(this, env); // eslint-disable-line no-invalid-this
+        yield test.beforeEach(env);
     }));
 
     afterEach(test.coroutine(function*() {
-        yield test.afterEach(this, env); // eslint-disable-line no-invalid-this
+        yield test.afterEach(env);
     }));
 
     it("should connect to the IRC network and channel in the config",

--- a/spec/integ/invite-rooms.spec.js
+++ b/spec/integ/invite-rooms.spec.js
@@ -27,7 +27,7 @@ describe("Invite-only rooms", function() {
     };
 
     beforeEach(test.coroutine(function*() {
-        yield test.beforeEach(this, env); // eslint-disable-line no-invalid-this
+        yield test.beforeEach(env);
 
         env.ircMock._autoConnectNetworks(
             roomMapping.server, roomMapping.botNick, roomMapping.server
@@ -38,7 +38,7 @@ describe("Invite-only rooms", function() {
     }));
 
     afterEach(test.coroutine(function*() {
-        yield test.afterEach(this, env); // eslint-disable-line no-invalid-this
+        yield test.afterEach(env);
     }));
 
     it("should be joined by the bot if the AS does know the room ID",

--- a/spec/integ/irc-client-cycling.spec.js
+++ b/spec/integ/irc-client-cycling.spec.js
@@ -20,7 +20,7 @@ describe("IRC client cycling", function() {
     var testUsers = null;
 
     beforeEach(test.coroutine(function*() {
-        yield test.beforeEach(this, env); // eslint-disable-line no-invalid-this
+        yield test.beforeEach(env);
 
         // set client cycling to 2 for these tests. This is slightly brittle since we
         // assume that this means when the limit is reached we disconnect a client
@@ -77,7 +77,7 @@ describe("IRC client cycling", function() {
     }));
 
     afterEach(test.coroutine(function*() {
-        yield test.afterEach(this, env); // eslint-disable-line no-invalid-this
+        yield test.afterEach(env);
     }));
 
     it("should disconnect the oldest (last message time) client",

--- a/spec/integ/irc-connections.spec.js
+++ b/spec/integ/irc-connections.spec.js
@@ -24,7 +24,7 @@ describe("IRC connections", function() {
     };
 
     beforeEach(test.coroutine(function*() {
-        yield test.beforeEach(this, env); // eslint-disable-line no-invalid-this
+        yield test.beforeEach(env);
 
         // make the bot automatically connect and join the mapped channel
         env.ircMock._autoConnectNetworks(
@@ -44,7 +44,7 @@ describe("IRC connections", function() {
     }));
 
     afterEach(test.coroutine(function*() {
-        yield test.afterEach(this, env); // eslint-disable-line no-invalid-this
+        yield test.afterEach(env);
     }));
 
     it("should use the matrix user's display name if they have one",

--- a/spec/integ/irc-modes.spec.js
+++ b/spec/integ/irc-modes.spec.js
@@ -29,7 +29,7 @@ describe("IRC-to-Matrix mode bridging", function() {
         ].dynamicChannels.joinRule;
 
     beforeEach(test.coroutine(function*() {
-        yield test.beforeEach(this, env); // eslint-disable-line no-invalid-this
+        yield test.beforeEach(env);
 
         sdk = env.clientMock._client(config._botUserId);
         // add registration mock impl:
@@ -51,7 +51,7 @@ describe("IRC-to-Matrix mode bridging", function() {
     }));
 
     afterEach(test.coroutine(function*() {
-        yield test.afterEach(this, env); // eslint-disable-line no-invalid-this
+        yield test.afterEach(env);
     }));
 
     it("should set join_rules to 'invite' on +k.",

--- a/spec/integ/irc-to-matrix.spec.js
+++ b/spec/integ/irc-to-matrix.spec.js
@@ -33,7 +33,7 @@ describe("IRC-to-Matrix message bridging", function() {
     };
 
     beforeEach(test.coroutine(function*() {
-        yield test.beforeEach(this, env); // eslint-disable-line no-invalid-this
+        yield test.beforeEach(env);
 
         sdk = env.clientMock._client(tUserId);
         // add registration mock impl:
@@ -55,7 +55,7 @@ describe("IRC-to-Matrix message bridging", function() {
     }));
 
     afterEach(test.coroutine(function*() {
-        yield test.afterEach(this, env); // eslint-disable-line no-invalid-this
+        yield test.afterEach(env);
     }));
 
     it("should bridge IRC text as Matrix message's m.text",
@@ -247,7 +247,7 @@ describe("IRC-to-Matrix name bridging", function() {
                   config.homeserver.domain;
 
     beforeEach(test.coroutine(function*() {
-        yield test.beforeEach(this, env); // eslint-disable-line no-invalid-this
+        yield test.beforeEach(env);
 
         config.ircService.servers[roomMapping.server].matrixClients.displayName = (
             "Test $NICK and $SERVER"
@@ -270,7 +270,7 @@ describe("IRC-to-Matrix name bridging", function() {
     }));
 
     afterEach(test.coroutine(function*() {
-        yield test.afterEach(this, env); // eslint-disable-line no-invalid-this
+        yield test.afterEach(env);
     }));
 
     it("should set the matrix display name from the config file template", function(done) {

--- a/spec/integ/kicking.spec.js
+++ b/spec/integ/kicking.spec.js
@@ -17,7 +17,7 @@ describe("Kicking", function() {
     };
 
     beforeEach(test.coroutine(function*() {
-        yield test.beforeEach(this, env); // eslint-disable-line no-invalid-this
+        yield test.beforeEach(env);
 
         // accept connection requests from eeeeeeeeveryone!
         env.ircMock._autoConnectNetworks(
@@ -67,7 +67,7 @@ describe("Kicking", function() {
     }));
 
     afterEach(test.coroutine(function*() {
-        yield test.afterEach(this, env); // eslint-disable-line no-invalid-this
+        yield test.afterEach(env);
     }));
 
     describe("IRC users on IRC", function() {

--- a/spec/integ/matrix-to-irc.spec.js
+++ b/spec/integ/matrix-to-irc.spec.js
@@ -25,7 +25,7 @@ describe("Matrix-to-IRC message bridging", function() {
     };
 
     beforeEach(test.coroutine(function*() {
-        yield test.beforeEach(this, env); // eslint-disable-line no-invalid-this
+        yield test.beforeEach(env);
 
         // accept connection requests
         env.ircMock._autoConnectNetworks(
@@ -46,7 +46,7 @@ describe("Matrix-to-IRC message bridging", function() {
     }));
 
     afterEach(test.coroutine(function*() {
-        yield test.afterEach(this, env); // eslint-disable-line no-invalid-this
+        yield test.afterEach(env);
     }));
 
     it("should bridge matrix messages as IRC text", function(done) {
@@ -340,7 +340,7 @@ describe("Matrix-to-Matrix message bridging", function() {
     let mirroredUserId =`@${roomMapping.server}_${testUser.nick}:${config.homeserver.domain}`;
 
     beforeEach(test.coroutine(function*() {
-        yield test.beforeEach(this, env); // eslint-disable-line no-invalid-this
+        yield test.beforeEach(env);
 
         // accept connection requests
         env.ircMock._autoConnectNetworks(
@@ -373,7 +373,7 @@ describe("Matrix-to-Matrix message bridging", function() {
     }));
 
     afterEach(test.coroutine(function*() {
-        yield test.afterEach(this, env); // eslint-disable-line no-invalid-this
+        yield test.afterEach(env);
     }));
 
     it("should bridge matrix messages to other mapped matrix rooms", function(done) {
@@ -500,7 +500,7 @@ describe("Matrix-to-IRC message bridging with media URL and drop time", function
         env.config.homeserver.media_url = mediaUrl;
         env.config.homeserver.dropMatrixMessagesAfterSecs = 300; // 5 min
 
-        yield test.beforeEach(this, env); // eslint-disable-line no-invalid-this
+        yield test.beforeEach(env);
 
         // accept connection requests
         env.ircMock._autoConnectNetworks(
@@ -521,7 +521,7 @@ describe("Matrix-to-IRC message bridging with media URL and drop time", function
     }));
 
     afterEach(test.coroutine(function*() {
-        yield test.afterEach(this, env); // eslint-disable-line no-invalid-this
+        yield test.afterEach(env);
     }));
 
     it("should NOT bridge old matrix messages older than the drop time",

--- a/spec/integ/mirroring.spec.js
+++ b/spec/integ/mirroring.spec.js
@@ -30,7 +30,7 @@ describe("Mirroring", function() {
     };
 
     beforeEach(test.coroutine(function*() {
-        yield test.beforeEach(this, env); // eslint-disable-line no-invalid-this
+        yield test.beforeEach(env);
 
         // accept connection requests
         env.ircMock._autoConnectNetworks(
@@ -48,7 +48,7 @@ describe("Mirroring", function() {
     }));
 
     afterEach(test.coroutine(function*() {
-        yield test.afterEach(this, env); // eslint-disable-line no-invalid-this
+        yield test.afterEach(env);
     }));
 
     describe("Matrix users on IRC", function() {

--- a/spec/integ/pm.spec.js
+++ b/spec/integ/pm.spec.js
@@ -23,7 +23,7 @@ describe("Matrix-to-IRC PMing", function() {
     var tIrcUserId = "@" + tUserLocalpart + ":" + config.homeserver.domain;
 
     beforeEach(test.coroutine(function*() {
-        yield test.beforeEach(this, env); // eslint-disable-line no-invalid-this
+        yield test.beforeEach(env);
 
         env.ircMock._autoConnectNetworks(
             roomMapping.server, roomMapping.botNick, roomMapping.server
@@ -33,7 +33,7 @@ describe("Matrix-to-IRC PMing", function() {
     }));
 
     afterEach(test.coroutine(function*() {
-        yield test.afterEach(this, env); // eslint-disable-line no-invalid-this
+        yield test.afterEach(env);
     }));
 
     it("should join 1:1 rooms invited from matrix",
@@ -217,7 +217,7 @@ describe("IRC-to-Matrix PMing", function() {
     var tText = "ello ello ello";
 
     beforeEach(test.coroutine(function*() {
-        yield test.beforeEach(this, env); // eslint-disable-line no-invalid-this
+        yield test.beforeEach(env);
         sdk = env.clientMock._client(tVirtualUserId);
 
         // add registration mock impl:
@@ -255,7 +255,7 @@ describe("IRC-to-Matrix PMing", function() {
     }));
 
     afterEach(test.coroutine(function*() {
-        yield test.afterEach(this, env); // eslint-disable-line no-invalid-this
+        yield test.afterEach(env);
     }));
 
     it("should create a 1:1 matrix room and invite the real matrix user when " +
@@ -358,7 +358,7 @@ describe("IRC-to-Matrix Non-Federated PMing", function() {
 
     beforeEach(test.coroutine(function*() {
         config.ircService.servers[roomMapping.server].privateMessages.federate = false;
-        yield test.beforeEach(this, env); // eslint-disable-line no-invalid-this
+        yield test.beforeEach(env);
         sdk = env.clientMock._client(tVirtualUserId);
 
         // add registration mock impl:
@@ -396,7 +396,7 @@ describe("IRC-to-Matrix Non-Federated PMing", function() {
     }));
 
     afterEach(test.coroutine(function*() {
-        yield test.afterEach(this, env); // eslint-disable-line no-invalid-this
+        yield test.afterEach(env);
     }));
 
     it("should create a non-federated 1:1 matrix room and invite the real matrix user when " +

--- a/spec/integ/provisioning.spec.js
+++ b/spec/integ/provisioning.spec.js
@@ -26,7 +26,7 @@ describe("Provisioning API", function() {
     };
 
     let doSetup = test.coroutine(function*() {
-        yield test.beforeEach(this, env); // eslint-disable-line no-invalid-this
+        yield test.beforeEach(env);
 
         // accept connection requests from eeeeeeeeveryone!
         env.ircMock._autoConnectNetworks(
@@ -279,7 +279,7 @@ describe("Provisioning API", function() {
         beforeEach(doSetup);
 
         afterEach(test.coroutine(function*() {
-            yield test.afterEach(this, env); // eslint-disable-line no-invalid-this
+            yield test.afterEach(env);
         }));
 
         describe("link endpoint", function() {
@@ -380,7 +380,7 @@ describe("Provisioning API", function() {
             //  It is a copy because otherwise there is not other way
             //  to alter config before running.
 
-            yield test.beforeEach(this, env); // eslint-disable-line no-invalid-this
+            yield test.beforeEach(env);
 
             // accept connection requests from eeeeeeeeveryone!
             env.ircMock._autoConnectNetworks(
@@ -459,7 +459,7 @@ describe("Provisioning API", function() {
         }));
 
         afterEach(test.coroutine(function*() {
-            yield test.afterEach(this, env); // eslint-disable-line no-invalid-this
+            yield test.afterEach(env);
         }));
 
         it("should not create a M<--->I link of the same link id",
@@ -470,7 +470,7 @@ describe("Provisioning API", function() {
     describe("message sending and joining", function() {
         beforeEach(test.coroutine(function*() {
             config.ircService.servers[config._server].mappings = {};
-            yield test.beforeEach(this, env); // eslint-disable-line no-invalid-this
+            yield test.beforeEach(env);
 
             // Ignore bot connecting
             env.ircMock._autoConnectNetworks(
@@ -510,7 +510,7 @@ describe("Provisioning API", function() {
         }));
 
         afterEach(test.coroutine(function*() {
-            yield test.afterEach(this, env); // eslint-disable-line no-invalid-this
+            yield test.afterEach(env);
         }));
 
         it("should allow IRC to send messages via the new link",
@@ -745,7 +745,7 @@ describe("Provisioning API", function() {
 
     describe("listings endpoint", function() {
         beforeEach(test.coroutine(function*() {
-            yield test.beforeEach(this, env); // eslint-disable-line no-invalid-this
+            yield test.beforeEach(env);
 
             // accept connection requests from eeeeeeeeveryone!
             env.ircMock._autoConnectNetworks(
@@ -807,7 +807,7 @@ describe("Provisioning API", function() {
         }));
 
         afterEach(test.coroutine(function*() {
-            yield test.afterEach(this, env); // eslint-disable-line no-invalid-this
+            yield test.afterEach(env);
         }));
 
         it("should return an empty list when no mappings have been provisioned",
@@ -1030,7 +1030,7 @@ describe("Provisioning API", function() {
         beforeEach(doSetup);
 
         afterEach(test.coroutine(function*() {
-            yield test.afterEach(this, env); // eslint-disable-line no-invalid-this
+            yield test.afterEach(env);
         }));
 
         it("when the link is successful",
@@ -1048,7 +1048,7 @@ describe("Provisioning API", function() {
         beforeEach(doSetup);
 
         afterEach(test.coroutine(function*() {
-            yield test.afterEach(this, env); // eslint-disable-line no-invalid-this
+            yield test.afterEach(env);
         }));
 
         it("when the op did not authorise after a certain timeout",

--- a/spec/util/test.js
+++ b/spec/util/test.js
@@ -56,10 +56,9 @@ module.exports.initEnv = function(env, customConfig) {
 /**
  * Reset the test environment for a new test case that has just run.
  * This kills the bridge.
- * @param {TestCase} testCase : The finished test case.
  * @param {Object} env : The test environment.
  */
-module.exports.afterEach = Promise.coroutine(function*(testCase, env) {
+module.exports.afterEach = Promise.coroutine(function*(env) {
     // If there was a previous bridge running, kill it
     // This is prevent IRC clients spamming the logs
     if (env.main) {
@@ -69,10 +68,9 @@ module.exports.afterEach = Promise.coroutine(function*(testCase, env) {
 
 /**
  * Reset the test environment for a new test case. This resets all mocks.
- * @param {TestCase} testCase : The new test case.
  * @param {Object} env : The pre-initialised test environment.
  */
-module.exports.beforeEach = Promise.coroutine(function*(testCase, env) {
+module.exports.beforeEach = Promise.coroutine(function*(env) {
     MockAppService.resetInstance();
     if (env) {
         env.ircMock._reset();


### PR DESCRIPTION
We were using it to log the test case name but we do this in different ways now.