### PR TITLE
Start adding MemberListSyncer tests

### DIFF
--- a/lib/bridge/IrcBridge.js
+++ b/lib/bridge/IrcBridge.js
@@ -332,7 +332,7 @@ IrcBridge.prototype.run = Promise.coroutine(function*(port) {
         // TODO Remove injectJoinFn bodge
         this.memberListSyncers[server.domain] = new MemberListSyncer(
             this, this._bridge.getBot(), server, this.appServiceUserId,
-            (roomId, joiningUserId, isFrontier) => {
+            (roomId, joiningUserId, displayName, isFrontier) => {
                 var req = new BridgeRequest(
                     this._bridge.getRequestFactory().newRequest(), false
                 );
@@ -345,7 +345,8 @@ IrcBridge.prototype.run = Promise.coroutine(function*(port) {
                     state_key: joiningUserId,
                     user_id: joiningUserId,
                     content: {
-                        membership: "join"
+                        membership: "join",
+                        displayname: displayName,
                     },
                     _injected: true,
                     _frontier: isFrontier

--- a/lib/bridge/MemberListSyncer.js
+++ b/lib/bridge/MemberListSyncer.js
@@ -154,7 +154,6 @@ MemberListSyncer.prototype.checkBotPartRoom = Promise.coroutine(function*(ircRoo
 // returns [
 //   {
 //       id: roomId,
-//       state: stateEvents,
 //       realJoinedUsers: [],
 //       remoteJoinedUsers: []
 //   },
@@ -184,7 +183,7 @@ MemberListSyncer.prototype._getSyncableRooms = function() {
             }
             let roomInfo = {
                 id: roomId,
-                state: [], // JSON objects (Matrix events)
+                displayNames: {}, // user ID => Display Name
                 realJoinedUsers: [], // user IDs
                 remoteJoinedUsers: [], // user IDs
             };
@@ -202,16 +201,9 @@ MemberListSyncer.prototype._getSyncableRooms = function() {
                     roomInfo.realJoinedUsers.push(userId);
                 }
 
-                roomInfo.state.push({
-                    room_id: roomId,
-                    state_key: userId,
-                    user_id: userId,
-                    content: {
-                        membership: "join",
-                        display_name: userMap[userId].display_name,
-                        avatar_url: userMap[userId].avatar_url,
-                    }
-                });
+                if (userMap[userId].display_name) {
+                    roomInfo.displayNames[userId] = userMap[userId].display_name;
+                }
             }
             roomInfoList.push(roomInfo);
             log.info(
@@ -267,7 +259,7 @@ function joinMatrixUsersToChannels(rooms, server, injectJoinFn) {
         roomInfo.realJoinedUsers.forEach(function(uid, index) {
             entries.push({
                 roomId: roomInfo.id,
-                displayName: "",
+                displayName: roomInfo.displayNames[uid],
                 userId: uid,
                 // Mark the first real matrix user f.e room so we can inject
                 // them first to get back up and running more quickly when there
@@ -303,7 +295,7 @@ function joinMatrixUsersToChannels(rooms, server, injectJoinFn) {
             "Injecting join event for %s in %s (%s left) is_frontier=%s",
             entry.userId, entry.roomId, entries.length, entry.frontier
         );
-        injectJoinFn(entry.roomId, entry.userId, entry.frontier).timeout(
+        injectJoinFn(entry.roomId, entry.userId, entry.displayName, entry.frontier).timeout(
             server.getMemberListFloodDelayMs()
         ).then(() => {
             joinNextUser();

--- a/lib/bridge/MemberListSyncer.js
+++ b/lib/bridge/MemberListSyncer.js
@@ -267,6 +267,7 @@ function joinMatrixUsersToChannels(rooms, server, injectJoinFn) {
         roomInfo.realJoinedUsers.forEach(function(uid, index) {
             entries.push({
                 roomId: roomInfo.id,
+                displayName: "",
                 userId: uid,
                 // Mark the first real matrix user f.e room so we can inject
                 // them first to get back up and running more quickly when there

--- a/spec/integ/MemberListSyncer.spec.js
+++ b/spec/integ/MemberListSyncer.spec.js
@@ -1,0 +1,102 @@
+"use strict";
+let test = require("../util/test");
+let Promise = require("bluebird");
+
+// set up integration testing mocks
+let env = test.mkEnv();
+
+// set up test config
+let config = env.config;
+let roomMapping = {
+    server: config._server,
+    botNick: config._botnick,
+    channel: config._chan,
+    roomId: config._roomid
+};
+
+describe("MemberListSyncer", function() {
+    let botClient = null;
+
+    beforeEach(test.coroutine(function*() {
+        config.ircService.servers[roomMapping.server].membershipLists.enabled = true;
+        config.ircService.servers[roomMapping.server].membershipLists.floodDelayMs = 0;
+        config.ircService.servers[
+            roomMapping.server
+        ].membershipLists.global.ircToMatrix.initial = true;
+        config.ircService.servers[
+            roomMapping.server
+        ].membershipLists.global.matrixToIrc.initial = true;
+        yield test.beforeEach(this, env); // eslint-disable-line no-invalid-this
+
+        // make the bot automatically connect and join the mapped channel
+        env.ircMock._autoConnectNetworks(
+            roomMapping.server, roomMapping.botNick, roomMapping.server
+        );
+        env.ircMock._autoJoinChannels(
+            roomMapping.server, roomMapping.botNick, roomMapping.channel
+        );
+
+        botClient = env.clientMock._client(config._botUserId);
+    }));
+
+    afterEach(test.coroutine(function*() {
+        yield test.afterEach(this, env); // eslint-disable-line no-invalid-this
+    }));
+
+    it("should sync initial joins from Matrix to IRC", test.coroutine(function*() {
+        botClient._http.authedRequestWithPrefix.and.callFake(
+        (cb, method, path, qps, data) => {
+            if (method === "GET" && path === "/joined_rooms") {
+                return Promise.resolve({
+                    joined_rooms: [roomMapping.roomId]
+                });
+            }
+            else if (method === "GET" &&
+                    path === `/rooms/${encodeURIComponent(roomMapping.roomId)}/joined_members`) {
+                return Promise.resolve({
+                    joined: {
+                        "@alice:bar": {
+                            display_name: null,
+                            avatar_url: null,
+                        },
+                        "@bob:bar": {
+                            display_name: "Bob",
+                            avatar_url: null,
+                        }
+                    },
+                });
+            }
+            return Promise.reject("unhandled path");
+        });
+
+        let aliceNick = "M-alice";
+        let bobNick = "M-Bob";
+        let aliceJoined = false;
+        let bobJoined = false;
+
+        // expect connects and joins for these 2 users
+        env.ircMock._whenClient(roomMapping.server, aliceNick, "connect", function(client, cb) {
+            client._invokeCallback(cb);
+        });
+        env.ircMock._whenClient(roomMapping.server, bobNick, "connect", function(client, cb) {
+            client._invokeCallback(cb);
+        });
+        env.ircMock._whenClient(roomMapping.server, aliceNick, "join", function(client, chan, cb) {
+            expect(chan).toEqual(roomMapping.channel);
+            aliceJoined = true;
+            client._invokeCallback(cb);
+        });
+        env.ircMock._whenClient(roomMapping.server, bobNick, "join", function(client, chan, cb) {
+            expect(chan).toEqual(roomMapping.channel);
+            bobJoined = true;
+            client._invokeCallback(cb);
+        });
+
+        yield test.initEnv(env);
+        yield Promise.delay(59);
+        console.log("FIN");
+
+        expect(aliceJoined).toBe(true, "Alice did not join the channel");
+        expect(bobJoined).toBe(true, "Bob did not join the channel");
+    }));
+});

--- a/spec/integ/MemberListSyncer.spec.js
+++ b/spec/integ/MemberListSyncer.spec.js
@@ -66,7 +66,7 @@ describe("MemberListSyncer", function() {
                     },
                 });
             }
-            return Promise.reject("unhandled path");
+            return Promise.reject(new Error("unhandled path"));
         });
 
         let alicePromise = new Promise((resolve, reject) => {

--- a/spec/util/client-sdk-mock.js
+++ b/spec/util/client-sdk-mock.js
@@ -13,6 +13,7 @@ function MockClient(config) {
         userId: config.userId
     };
     this._http = { opts: {} };
+    this._http.authedRequestWithPrefix = jasmine.createSpy("sdk.authedRequestWithPrefix");
     this.register = jasmine.createSpy("sdk.register(username, password)");
     this.createRoom = jasmine.createSpy("sdk.createRoom(opts)");
     this.joinRoom = jasmine.createSpy("sdk.joinRoom(idOrAlias, opts)");


### PR DESCRIPTION
Based on https://github.com/matrix-org/matrix-appservice-irc/pull/323

Add M->I join test annnnd fix the first bug as a result. Turns out `MemberListSyncer` was not
passing a `displayname` through to `onJoin` so the generated IRC nicks would
incorrectly be based off the user ID! Also removed the `state` mapping as nothing used it.