### PR TITLE
Allow IPv6 connections and add option to require IPv6.

### DIFF
--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -264,15 +264,17 @@ ircService:
         # disconnected and replaced.
         # Optional. Default: 30.
         maxClients: 30
-        #
-        # Optional. The IPv6 prefix to use for generating unique addresses for each
-        # connected user. If not specified, all users will connect from the same
-        # (default) address. This may require additional OS-specific work to allow
-        # for the node process to bind to multiple different source addresses
-        # e.g IP_FREEBIND on Linux, which requires an LD_PRELOAD with the library
-        # https://github.com/matrix-org/freebindfree as Node does not expose setsockopt.
-        # ipv6:
-        #   prefix: "2001:0db8:85a3::"  # modify appropriately
+        # IPv6 configuration.
+        ipv6:
+          # Optional. Set to true to force IPv6 for outgoing connections.
+          only: false
+          # Optional. The IPv6 prefix to use for generating unique addresses for each
+          # connected user. If not specified, all users will connect from the same
+          # (default) address. This may require additional OS-specific work to allow
+          # for the node process to bind to multiple different source addresses
+          # e.g IP_FREEBIND on Linux, which requires an LD_PRELOAD with the library
+          # https://github.com/matrix-org/freebindfree as Node does not expose setsockopt.
+          # prefix: "2001:0db8:85a3::"  # modify appropriately
         #
         # The maximum amount of time in seconds that the client can exist
         # without sending another message before being disconnected. Use 0 to

--- a/lib/config/schema.yml
+++ b/lib/config/schema.yml
@@ -264,11 +264,12 @@ properties:
                                     type: "boolean"
                                 ipv6:
                                     type: "object"
-                                    required: ["prefix"]
                                     properties:
                                         prefix:
                                             type: "string"
                                             pattern: "[ABCDEFabcdef0123456789:]+"
+                                        only:
+                                            type: "boolean"
                                 lineLimit:
                                     type: "integer"
                                 userModes:

--- a/lib/irc/ConnectionInstance.js
+++ b/lib/irc/ConnectionInstance.js
@@ -309,7 +309,7 @@ ConnectionInstance.create = function(server, opts, onCreatedCallback) {
         port: server.getPort(),
         selfSigned: server.useSslSelfSigned(),
         retryCount: 0,
-        family: server.getIpv6Prefix() ? 6 : 4,
+        family: server.getIpv6Prefix() || server.getIpv6Only() ? 6 : null,
         bustRfc3484: true,
     };
 

--- a/lib/irc/IrcServer.js
+++ b/lib/irc/IrcServer.js
@@ -179,6 +179,10 @@ IrcServer.prototype.getIpv6Prefix = function() {
     return this.config.ircClients.ipv6.prefix;
 };
 
+IrcServer.prototype.getIpv6Only = function() {
+    return this.config.ircClients.ipv6.only;
+};
+
 IrcServer.prototype.getLineLimit = function() {
     return this.config.ircClients.lineLimit;
 };
@@ -469,7 +473,7 @@ IrcServer.DEFAULT_CONFIG = {
         idleTimeout: 172800,
         reconnectIntervalMs: 5000,
         allowNickChanges: false,
-        ipv6: {},
+        ipv6: {only: false},
         lineLimit: 3
     },
     membershipLists: {


### PR DESCRIPTION
This change allows IPv6 connections to IRC servers when there is no `prefix` option in `ipv6` section.
Also, it adds `only` boolean option to `ipv6` section that forces using IPv6 only for connection to server.