### PR TITLE
Easier to click links in IRC

### DIFF
--- a/lib/models/MatrixAction.js
+++ b/lib/models/MatrixAction.js
@@ -53,8 +53,7 @@ MatrixAction.fromEvent = function(client, event, mediaUrl) {
                 mediaUrl = client.getHomeserverUrl();
             }
 
-            text = ContentRepo.getHttpUriForMxc(mediaUrl, event.content.url) +
-                    " - " + event.content.body + fileSize;
+            text = event.content.body + fileSize + " - " + ContentRepo.getHttpUriForMxc(mediaUrl, event.content.url);
         }
     }
     return new MatrixAction(type, text, htmlText);


### PR DESCRIPTION
Multiple IRC users complaining that they can't click link because of space