### PR TITLE
Current separator causes confusion for some users

### DIFF
--- a/lib/models/MatrixAction.js
+++ b/lib/models/MatrixAction.js
@@ -54,7 +54,7 @@ MatrixAction.fromEvent = function(client, event, mediaUrl) {
             }
 
             text = ContentRepo.getHttpUriForMxc(mediaUrl, event.content.url) +
-                    " - " + event.content.body + fileSize;
+                    " ::: " + event.content.body + fileSize;
         }
     }
     return new MatrixAction(type, text, htmlText);


### PR DESCRIPTION
The current separator causes confusion when people are mentally parsing the link. Creating PR to make an obvious distinction that this is not part of the URL. Someone suggested using "GNU Parallel" syntax.