### PR TITLE
Don't log stack traces when disconnect() times out

### DIFF
--- a/lib/irc/ConnectionInstance.js
+++ b/lib/irc/ConnectionInstance.js
@@ -25,6 +25,14 @@ const BANNED_TIME_MS = 6 * 60 * 60 * 1000; // once every 6 hours
 // that sometimes they don't get around to it and end up ping timing us out.
 const PING_RATE_MS = 1000 * 60;
 
+// Log an Error object to stderr
+function logError(err) {
+    if (!err || !err.message) {
+        return;
+    }
+    log.error(err.message);
+}
+
 /**
  * Create an IRC connection instance. Wraps the node-irc library to handle
  * connections correctly.
@@ -64,7 +72,7 @@ ConnectionInstance.prototype.connect = function() {
                 "%s@%s still not connected after %sms. Killing connection.",
                 self.nick, domain, CONNECT_TIMEOUT_MS
             );
-            self.disconnect("timeout");
+            self.disconnect("timeout").catch(logError);
         }
     }, CONNECT_TIMEOUT_MS);
 
@@ -174,23 +182,23 @@ ConnectionInstance.prototype._listenForErrors = function() {
             }
         }
         if (err && err.command === "err_yourebannedcreep") {
-            self.disconnect("banned");
+            self.disconnect("banned").catch(logError);
             return;
         }
-        self.disconnect("irc_error");
+        self.disconnect("irc_error").catch(logError);
     });
     self.client.addListener("netError", function(err) {
         log.error(
             "Server: %s (%s) Network Error: %s", domain, nick,
             JSON.stringify(err, undefined, 2)
         );
-        self.disconnect("net_error");
+        self.disconnect("net_error").catch(logError);
     });
     self.client.addListener("abort", function() {
         log.error(
             "Server: %s (%s) Connection Aborted", domain, nick
         );
-        self.disconnect("net_error");
+        self.disconnect("net_error").catch(logError);
     });
     self.client.addListener("raw", function(msg) {
         if (logging.isVerbose()) {
@@ -208,17 +216,17 @@ ConnectionInstance.prototype._listenForErrors = function() {
                 errText = errText.toLowerCase();
                 wasThrottled = errText.indexOf("throttl") !== -1;
                 if (wasThrottled) {
-                    self.disconnect("throttled");
+                    self.disconnect("throttled").catch(logError);
                     return;
                 }
                 var wasBanned = errText.indexOf("banned") !== -1;
                 if (wasBanned) {
-                    self.disconnect("banned");
+                    self.disconnect("banned").catch(logError);
                     return;
                 }
             }
             if (!wasThrottled) {
-                self.disconnect("raw_error");
+                self.disconnect("raw_error").catch(logError);
             }
         }
     });


### PR DESCRIPTION
It's misleading as it makes it look like a Bad Thing when really it isn't.
This logging was actually being done by bluebird, so we now set a rejection
handler which just logs the message.