### PR TITLE
Extend !whois and document !nick without args

### DIFF
--- a/lib/bridge/MatrixHandler.js
+++ b/lib/bridge/MatrixHandler.js
@@ -208,11 +208,13 @@ MatrixHandler.prototype._onAdminMessage = Promise.coroutine(function*(req, event
             },
             "!nick": {
                 example: `!nick irc.example.com DesiredNick`,
-                summary: `Change your nick`,
+                summary: "Change your nick. If no arguments are supplied, " +
+                         "your current nick is shown.",
             },
             "!whois": {
-                example: `!whois nick`,
-                summary: `Do a /whois lookup`,
+                example: `!whois nick|mxid`,
+                summary: "Do a /whois lookup. If a Matrix User ID is supplied, " +
+                         "return information about that user's IRC connection.",
             },
             "!storepass": {
                 example: `!storepass [irc.example.com] passw0rd`,
@@ -466,8 +468,30 @@ MatrixHandler.prototype._onAdminMessage = Promise.coroutine(function*(req, event
         if (!whoisNick) {
             yield this.ircBridge.sendMatrixAction(
                 adminRoom, botUser,
-                new MatrixAction("notice", "Format: '!whois nick'"), req
+                new MatrixAction("notice", "Format: '!whois nick|mxid'"), req
             );
+            return;
+        }
+
+        if (whoisNick[0] === "@") {
+            // querying a Matrix user - whoisNick is the matrix user ID
+            req.log.info("%s wants whois info on %s", event.user_id, whoisNick);
+            let whoisClient = this.ircBridge.getIrcUserFromCache(ircServer, whoisNick);
+            try {
+                let noticeRes = new MatrixAction(
+                    "notice",
+                    whoisClient ?
+                    `${whoisNick} is connected to ${ircServer.domain} as '${whoisClient.nick}'.` :
+                    `${whoisNick} has no IRC connection via this bridge.`);
+                yield this.ircBridge.sendMatrixAction(adminRoom, botUser, noticeRes, req);
+            }
+            catch (err) {
+                if (err.stack) {
+                    req.log.error(err);
+                }
+                let noticeErr = new MatrixAction("notice", "Failed to perform whois query.");
+                yield this.ircBridge.sendMatrixAction(adminRoom, botUser, noticeErr, req);
+            }
             return;
         }
 

--- a/lib/bridge/MatrixHandler.js
+++ b/lib/bridge/MatrixHandler.js
@@ -212,7 +212,7 @@ MatrixHandler.prototype._onAdminMessage = Promise.coroutine(function*(req, event
                          "your current nick is shown.",
             },
             "!whois": {
-                example: `!whois nick|mxid`,
+                example: `!whois NickName|@alice:matrix.org`,
                 summary: "Do a /whois lookup. If a Matrix User ID is supplied, " +
                          "return information about that user's IRC connection.",
             },


### PR DESCRIPTION
- `!nick` without args shows your current nick. Document it in `!help`.
- `!whois` has now been extended to allow Matrix user IDs to be used. This
  then returns information about that user's IRC connection (nick/server).
  The presence of a leading `@` determines the difference between querying
  on IRC vs Matrix because IRC nicks cannot start with a leading `@` and
  Matrix user IDs all start with a leading `@`.

Fixes https://github.com/vector-im/riot-web/issues/2939