### PR TITLE
Forward invite events from IRC to Matrix

### DIFF
--- a/lib/bridge/IrcHandler.js
+++ b/lib/bridge/IrcHandler.js
@@ -234,6 +234,114 @@ IrcHandler.prototype.onPrivateMessage = Promise.coroutine(function*(req, server,
     yield this.ircBridge.sendMatrixAction(pmRoom, virtualMatrixUser, mxAction, req);
 });
 
+/**
+ * Called when the AS receives an IRC invite event.
+ * @param {IrcServer} server : The sending IRC server.
+ * @param {IrcUser} fromUser : The sender.
+ * @param {IrcUser} toUser : The target.
+ * @param {String} channel : The channel.
+ * @return {Promise} which is resolved/rejected when the request
+ * finishes.
+ */
+IrcHandler.prototype.onInvite = Promise.coroutine(function*(req, server, fromUser,
+                                                              toUser, channel) {
+    if (fromUser.isVirtual) {
+        return BridgeRequest.ERR_VIRTUAL_USER;
+    }
+
+    if (!toUser.isVirtual) {
+        req.log.error("Cannot route invite to %s", toUser);
+        return;
+    }
+
+    let bridgedIrcClient = this.ircBridge.getClientPool().getBridgedClientByNick(
+        toUser.server, toUser.nick
+    );
+    if (!bridgedIrcClient) {
+        req.log.error("Cannot route invite to %s - no client", toUser);
+        return;
+    }
+
+    if (bridgedIrcClient.isBot) {
+        req.log.info("Ignoring invite send to the bot");
+        return;
+    }
+
+    let virtualMatrixUser = yield this.ircBridge.getMatrixUser(fromUser);
+    req.log.info("Mapped to %s", JSON.stringify(virtualMatrixUser));
+    let matrixRooms = yield this.ircBridge.getStore().getMatrixRoomsForChannel(server, channel);
+    let roomAlias = server.getAliasFromChannel(channel);
+
+    if (matrixRooms.length === 0) {
+        let ircRoom = yield this.ircBridge.trackChannel(server, channel, null);
+        let response = yield this.ircBridge.getAppServiceBridge().getIntent(
+            virtualMatrixUser.getId()
+        ).createRoom({
+            options: {
+                room_alias_name: roomAlias.split(":")[0].substring(1), // localpart
+                name: channel,
+                visibility: (
+                    server.shouldPublishRooms() ? "public" : "private"
+                ),
+                creation_content: {
+                    "m.federate": server.shouldFederate()
+                },
+                initial_state: [
+                    {
+                        type: "m.room.join_rules",
+                        state_key: "",
+                        content: {
+                            join_rule: server.getJoinRule()
+                        }
+                    },
+                    {
+                        type: "m.room.history_visibility",
+                        state_key: "",
+                        content: {
+                            history_visibility: "joined"
+                        }
+                    }
+                ]
+            }
+        });
+
+        // store the mapping
+        let mxRoom = new MatrixRoom(response.room_id);
+        yield this.ircBridge.getStore().storeRoom(
+            ircRoom, mxRoom, 'join'
+        );
+
+        // /mode the channel AFTER we have created the mapping so we process +s and +i correctly.
+        this.ircBridge.publicitySyncer.initModeForChannel(
+            server, channel
+        ).catch((err) => {
+            req.log.error(
+                "Could not init mode channel %s on %s",
+                channel, server
+            );
+        });
+
+        req.log.info(
+            "Created a room to track %s on %s and invited %s",
+            ircRoom.channel, server.domain, virtualMatrixUser.user_id
+        );
+        matrixRooms.push(mxRoom);
+    }
+
+    // send invite
+    let invitePromises = matrixRooms.map((room) => {
+        req.log.info(
+            "Inviting %s to room %s", bridgedIrcClient.userId, room.getId()
+        );
+        return this.ircBridge.getAppServiceBridge().getIntent(
+            virtualMatrixUser.getId()
+        ).invite(
+            room.getId(), bridgedIrcClient.userId
+        );
+    });
+    yield Promise.all(invitePromises);
+});
+
 IrcHandler.prototype._serviceTopicQueue = Promise.coroutine(function*(item) {
     let promises = item.entries.map((entry) => {
         if (entry.matrix.topic === item.topic) {

--- a/lib/irc/IrcEventBroker.js
+++ b/lib/irc/IrcEventBroker.js
@@ -299,6 +299,12 @@ IrcEventBroker.prototype.addHooks = function(client, connInst) {
             ));
         }
     });
+    connInst.addListener("invite", function(channel, from) {
+        var req = createRequest();
+        complete(req, ircHandler.onInvite(
+            req, server, createUser(from), createUser(client.nick), channel
+        ));
+    });
 
     // Only a bot should issue a mode, so only the bot should listen for mode_is reply
     if (client.isBot) {


### PR DESCRIPTION
The IrcHandler now forward invite events from IRC to Matrix users. The room is created if needed.

I am just not sure about how to handle the case where many rooms are bridged with the channel. Now the code invite the user on every room bridged but it seems a little overkill. I think we should invite the user to only one room, but which one do we choose? Or maybe invite the user to all the rooms and let him choose is good enough?