### PR TITLE
Do not apply userModes to the bridge bot

### DIFF
--- a/lib/irc/BridgedClient.js
+++ b/lib/irc/BridgedClient.js
@@ -151,7 +151,7 @@ BridgedClient.prototype.connect = Promise.coroutine(function*() {
         );
 
         let userModes = this.server.getUserModes();
-        if (userModes.length > 0) {
+        if (userModes.length > 0 && !this.isBot) {
             // These can fail, but the generic error listener will catch them and send them
             // into the same room as the connect text, so it's probably good enough to not
             // explicitly handle them.


### PR DESCRIPTION
Fixes #354 - This isn't a spam vector because messages to the bot don't ever
get bridged to Matrix.