### PR TITLE
Fix 'No Client' error when handing multiples joins from Matrix in quick succession

### DIFF
--- a/lib/irc/BridgedClient.js
+++ b/lib/irc/BridgedClient.js
@@ -629,6 +629,12 @@ BridgedClient.prototype._sendMessage = function(room, msgType, text) {
 BridgedClient.prototype._joinChannel = function(channel, key, attemptCount) {
     attemptCount = attemptCount || 1;
     if (!this.unsafeClient) {
+        // we may be trying to join before we've connected, so check and wait
+        if (this._connectDefer && this._connectDefer.promise.isPending()) {
+            return this._connectDefer.promise.then(() => {
+                return this._joinChannel(channel, key, attemptCount);
+            });
+        }
         return Promise.reject(new Error("No client"));
     }
     if (Object.keys(this.unsafeClient.chans).indexOf(channel) !== -1) {

--- a/spec/integ/mirroring.spec.js
+++ b/spec/integ/mirroring.spec.js
@@ -47,6 +47,15 @@ describe("Mirroring", function() {
         env.ircMock._autoJoinChannels(
             roomMapping.server, roomMapping.botNick, roomMapping.channel
         );
+        env.ircMock._autoJoinChannels(
+            roomMapping.server, roomMapping.botNick, "#a"
+        );
+        env.ircMock._autoJoinChannels(
+            roomMapping.server, roomMapping.botNick, "#b"
+        );
+        env.ircMock._autoJoinChannels(
+            roomMapping.server, roomMapping.botNick, "#c"
+        );
 
         // do the init
         yield test.initEnv(env);
@@ -174,6 +183,9 @@ describe("Mirroring", function() {
                 id: "@newuser:localhost",
                 nick: "M-newuser"
             };
+            env.ircMock._autoConnectNetworks(
+                roomMapping.server, newUser.nick, roomMapping.server
+            );
 
             const expectJoins = ["#a", "#b", "#c"];
             const joined = [];

--- a/spec/util/client-sdk-mock.js
+++ b/spec/util/client-sdk-mock.js
@@ -31,6 +31,9 @@ function MockClient(config) {
     this.mxcUrlToHttp = jasmine.createSpy("sdk.mxcUrlToHttp(mxc, w, h, method)");
     this.getHomeserverUrl = jasmine.createSpy("sdk.getHomeserverUrl()");
     this.setPowerLevel = jasmine.createSpy("sdk.setPowerLevel()");
+    this.setPresence = jasmine.createSpy("sdk.setPresence()");
+
+    this.setPresence.and.returnValue(Promise.resolve({}));
 
     // mock up joinRoom immediately since it is called when joining mapped IRC<-->Matrix rooms
     this.joinRoom.and.callFake(function() {


### PR DESCRIPTION
Fixes #272 and #260.