### PR TITLE
Set a sensible HTTP(S) socket limit

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -14,6 +14,11 @@ var ident = require("./irc/ident");
 var logging = require("./logging");
 var log = logging.get("main");
 
+// Allow up to 1000 HTTP(S) sockets. Default is Infinity, which means that a slow HS coupled
+// with lots of traffic could consume up to the fd ulimit on a process.
+require("http").globalAgent.maxSockets = 1000;
+require("https").globalAgent.maxSockets = 1000;
+
 process.on("unhandledRejection", function(reason, promise) {
     log.error(reason ? reason.stack : "No reason given");
 });


### PR DESCRIPTION
Manually tested on a `localhost` Synapse by artificially `sleep(5)`ing calls to
`/joined_members` with a limit of 1 and checking it did requests sequentially.

Fixes #345.