### PR TITLE
Clear timeouts on disconnect to allow faster GC cycles

### DIFF
--- a/app.js
+++ b/app.js
@@ -3,7 +3,6 @@ var Cli = require("matrix-appservice-bridge").Cli;
 var log = require("./lib/logging").get("CLI");
 var main = require("./lib/main");
 var path = require("path");
-require("heapdump");
 
 const REG_PATH = "appservice-registration-irc.yaml";
 

--- a/app.js
+++ b/app.js
@@ -3,6 +3,7 @@ var Cli = require("matrix-appservice-bridge").Cli;
 var log = require("./lib/logging").get("CLI");
 var main = require("./lib/main");
 var path = require("path");
+require("heapdump");
 
 const REG_PATH = "appservice-registration-irc.yaml";
 

--- a/app.js
+++ b/app.js
@@ -3,7 +3,7 @@ var Cli = require("matrix-appservice-bridge").Cli;
 var log = require("./lib/logging").get("CLI");
 var main = require("./lib/main");
 var path = require("path");
-
+require("heapdump");
 const REG_PATH = "appservice-registration-irc.yaml";
 
 new Cli({

--- a/app.js
+++ b/app.js
@@ -3,7 +3,7 @@ var Cli = require("matrix-appservice-bridge").Cli;
 var log = require("./lib/logging").get("CLI");
 var main = require("./lib/main");
 var path = require("path");
-require("heapdump");
+
 const REG_PATH = "appservice-registration-irc.yaml";
 
 new Cli({

--- a/lib/irc/BridgedClient.js
+++ b/lib/irc/BridgedClient.js
@@ -589,6 +589,9 @@ BridgedClient.prototype._onConnectionCreated = function(connInst, nameInfo) {
             "Your connection to the IRC network '" + self.server.domain +
             "' has been lost. "
         );
+        self.connInst = null;
+        connInst = null;
+        clearTimeout(self._idleTimeout);
     };
 
     this._eventBroker.addHooks(this, connInst);

--- a/lib/irc/BridgedClient.js
+++ b/lib/irc/BridgedClient.js
@@ -589,8 +589,6 @@ BridgedClient.prototype._onConnectionCreated = function(connInst, nameInfo) {
             "Your connection to the IRC network '" + self.server.domain +
             "' has been lost. "
         );
-        self.connInst = null;
-        connInst = null;
         clearTimeout(self._idleTimeout);
     };
 

--- a/lib/irc/ConnectionInstance.js
+++ b/lib/irc/ConnectionInstance.js
@@ -100,7 +100,18 @@ ConnectionInstance.prototype.disconnect = function(reason) {
     );
     this.dead = true;
 
-    let notifyDisconnect = () => {
+    return new Promise((resolve, reject) => {
+        // close the connection
+        this.client.disconnect(reason);
+        // remove timers
+        if (this._pingRateTimerId) {
+            clearTimeout(this._pingRateTimerId);
+            this._pingRateTimerId = null;
+        }
+        if (this._clientSidePingTimeoutTimerId) {
+            clearTimeout(this._clientSidePingTimeoutTimerId);
+            this._clientSidePingTimeoutTimerId = null;
+        }
         if (this.state !== "connected") {
             // we never resolved this defer, so reject it.
             this._connectDefer.reject(new Error(reason));
@@ -111,40 +122,9 @@ ConnectionInstance.prototype.disconnect = function(reason) {
             // call this now it would potentially invoke this 3 times (once per
             // connection instance!). Each time would have dead=false as they are
             // separate objects.
-            if (this._pingRateTimerId) {
-                clearTimeout(this._pingRateTimerId);
-            }
-            if (this._clientSidePingTimeoutTimerId) {
-                clearTimeout(this._clientSidePingTimeoutTimerId);
-            }
             this.onDisconnect();
         }
-    };
-
-    return new Promise((resolve, reject) => {
-        let timedOut = false;
-        let disconnectTimerId = setTimeout(() => {
-            log.error(
-                "%s@%s Timed out waiting for disconnect callback",
-                this.nick, this.domain
-            );
-            timedOut = true;
-            notifyDisconnect();
-            reject(new Error("Timed out when calling client.disconnect()"));
-        }, 1000);
-
-        this.client.disconnect(reason, () => {
-            if (timedOut) {
-                log.error(
-                    "%s@%s disconnect callback invoked too late",
-                    this.nick, this.domain
-                );
-                return;
-            }
-            notifyDisconnect();
-            clearTimeout(disconnectTimerId);
-            resolve();
-        });
+        resolve();
     });
 };
 

--- a/lib/irc/ConnectionInstance.js
+++ b/lib/irc/ConnectionInstance.js
@@ -102,7 +102,7 @@ ConnectionInstance.prototype.disconnect = function(reason) {
 
     return new Promise((resolve, reject) => {
         // close the connection
-        this.client.disconnect(reason);
+        this.client.disconnect(reason, function(){});
         // remove timers
         if (this._pingRateTimerId) {
             clearTimeout(this._pingRateTimerId);

--- a/lib/irc/ConnectionInstance.js
+++ b/lib/irc/ConnectionInstance.js
@@ -51,6 +51,7 @@ function ConnectionInstance(ircClient, domain, nick) {
     this.state = "created"; // created|connecting|connected
     this._connectDefer = promiseutil.defer();
     this._pingRateTimerId = null;
+    this._clientSidePingTimeoutTimerId = null;
 }
 
 /**
@@ -110,13 +111,19 @@ ConnectionInstance.prototype.disconnect = function(reason) {
             // call this now it would potentially invoke this 3 times (once per
             // connection instance!). Each time would have dead=false as they are
             // separate objects.
+            if (this._pingRateTimerId) {
+                clearTimeout(this._pingRateTimerId);
+            }
+            if (this._clientSidePingTimeoutTimerId) {
+                clearTimeout(this._clientSidePingTimeoutTimerId);
+            }
             this.onDisconnect();
         }
     };
 
     return new Promise((resolve, reject) => {
         let timedOut = false;
-        let timerId = setTimeout(() => {
+        let disconnectTimerId = setTimeout(() => {
             log.error(
                 "%s@%s Timed out waiting for disconnect callback",
                 this.nick, this.domain
@@ -135,7 +142,7 @@ ConnectionInstance.prototype.disconnect = function(reason) {
                 return;
             }
             notifyDisconnect();
-            clearTimeout(timerId);
+            clearTimeout(disconnectTimerId);
             resolve();
         });
     });
@@ -243,12 +250,11 @@ ConnectionInstance.prototype._listenForPings = function() {
     var self = this;
     var domain = self.domain;
     var nick = self.nick;
-    var clientSidePingTimeoutTimerId;
     function _keepAlivePing() { // refresh the ping timer
-        if (clientSidePingTimeoutTimerId) {
-            clearTimeout(clientSidePingTimeoutTimerId);
+        if (self._clientSidePingTimeoutTimerId) {
+            clearTimeout(self._clientSidePingTimeoutTimerId);
         }
-        clientSidePingTimeoutTimerId = setTimeout(function() {
+        self._clientSidePingTimeoutTimerId = setTimeout(function() {
             log.info(
                 "Ping timeout: knifing connection for %s on %s",
                 domain, nick

--- a/lib/irc/ConnectionInstance.js
+++ b/lib/irc/ConnectionInstance.js
@@ -102,7 +102,7 @@ ConnectionInstance.prototype.disconnect = function(reason) {
 
     return new Promise((resolve, reject) => {
         // close the connection
-        this.client.disconnect(reason, function(){});
+        this.client.disconnect(reason, function() {});
         // remove timers
         if (this._pingRateTimerId) {
             clearTimeout(this._pingRateTimerId);


### PR DESCRIPTION
Otherwise we'll be holding onto references to clients for up to the idle timeout time, which can be days!