### PR TITLE
Do not publish any created rooms to global dir

### DIFF
--- a/lib/bridge/IrcHandler.js
+++ b/lib/bridge/IrcHandler.js
@@ -283,9 +283,7 @@ IrcHandler.prototype.onInvite = Promise.coroutine(function*(req, server, fromUse
             options: {
                 room_alias_name: roomAlias.split(":")[0].substring(1), // localpart
                 name: channel,
-                visibility: (
-                    server.shouldPublishRooms() ? "public" : "private"
-                ),
+                visibility: "private",
                 creation_content: {
                     "m.federate": server.shouldFederate()
                 },

--- a/lib/bridge/MatrixHandler.js
+++ b/lib/bridge/MatrixHandler.js
@@ -397,9 +397,7 @@ MatrixHandler.prototype._onAdminMessage = Promise.coroutine(function*(req, event
             ).createRoom({
                 options: {
                     name: ircChannel,
-                    visibility: (
-                        ircServer.shouldPublishRooms() ? "public" : "private"
-                    ),
+                    visibility: "private",
                     creation_content: {
                         "m.federate": ircServer.shouldFederate()
                     },
@@ -1294,9 +1292,7 @@ MatrixHandler.prototype._onAliasQuery = Promise.coroutine(function*(req, roomAli
                 options: {
                     room_alias_name: roomAlias.split(":")[0].substring(1), // localpart
                     name: channelInfo.channel,
-                    visibility: (
-                        channelInfo.server.shouldPublishRooms() ? "public" : "private"
-                    ),
+                    visibility: "private",
                     creation_content: {
                         "m.federate": channelInfo.server.shouldFederate()
                     },

--- a/spec/integ/hs-queries.spec.js
+++ b/spec/integ/hs-queries.spec.js
@@ -96,7 +96,7 @@ describe("Homeserver alias queries", function() {
         var sdk = env.clientMock._client(config._botUserId);
         sdk.createRoom.and.callFake(function(opts) {
             expect(opts.room_alias_name).toEqual(testLocalpart);
-            expect(opts.visibility).toEqual("public");
+            expect(opts.visibility).toEqual("private");
             return Promise.resolve({
                 room_id: "!something:somewhere"
             });


### PR DESCRIPTION
The PublicitySyncer will take care of doing all publishing.

I've tested this by creating an alias to an existing channel. It is indeed only published to the AS-specific dir and only when +s is not set on the bridged channel.