### PR TITLE
Check dropMatrixMessagesAfterSecs just before sending to IRC

### DIFF
--- a/lib/bridge/IrcBridge.js
+++ b/lib/bridge/IrcBridge.js
@@ -221,7 +221,10 @@ IrcBridge.prototype.run = Promise.coroutine(function*(port) {
         let completeConfig = extend(
             true, {}, IrcServer.DEFAULT_CONFIG, this.config.ircService.servers[domain]
         );
-        let server = new IrcServer(domain, completeConfig, this.config.homeserver.domain);
+        let server = new IrcServer(
+            domain, completeConfig, this.config.homeserver.domain,
+            this.config.homeserver.dropMatrixMessagesAfterSecs
+        );
         // store the config mappings in the DB to keep everything in one place.
         yield this._dataStore.setServerFromConfig(server, completeConfig);
         this.ircServers.push(server);

--- a/lib/irc/BridgedClient.js
+++ b/lib/irc/BridgedClient.js
@@ -306,13 +306,17 @@ BridgedClient.prototype.kick = function(nick, channel, reason) {
 
 BridgedClient.prototype.sendAction = function(room, action) {
     this._keepAlive();
+    let expiryTs = 0;
+    if (action.ts) {
+        expiryTs = action.ts + 6000 * 1000;
+    }
     switch (action.type) {
         case "message":
-            return this._sendMessage(room, "message", action.text);
+            return this._sendMessage(room, "message", action.text, expiryTs);
         case "notice":
-            return this._sendMessage(room, "notice", action.text);
+            return this._sendMessage(room, "notice", action.text, expiryTs);
         case "emote":
-            return this._sendMessage(room, "action", action.text);
+            return this._sendMessage(room, "action", action.text, expiryTs);
         case "topic":
             return this._setTopic(room, action.text);
         default:
@@ -603,13 +607,20 @@ BridgedClient.prototype._setTopic = function(room, topic) {
     });
 }
 
-BridgedClient.prototype._sendMessage = function(room, msgType, text) {
+BridgedClient.prototype._sendMessage = function(room, msgType, text, expiryTs) {
     // join the room if we haven't already
     var defer = promiseutil.defer();
     msgType = msgType || "message";
     this._connectDefer.promise.then(() => {
         return this._joinChannel(room.channel);
     }).done(() => {
+        // re-check timestamp to see if we should send it now
+        if (expiryTs && Date.now() > expiryTs) {
+            this.log.error(`Dropping event: too old (expired at ${expiryTs})`);
+            defer.resolve();
+            return;
+        }
+
         if (msgType == "action") {
             this.unsafeClient.action(room.channel, text);
         }

--- a/lib/irc/BridgedClient.js
+++ b/lib/irc/BridgedClient.js
@@ -307,8 +307,8 @@ BridgedClient.prototype.kick = function(nick, channel, reason) {
 BridgedClient.prototype.sendAction = function(room, action) {
     this._keepAlive();
     let expiryTs = 0;
-    if (action.ts) {
-        expiryTs = action.ts + 6000 * 1000;
+    if (action.ts && this.server.getExpiryTimeSeconds()) {
+        expiryTs = action.ts + (this.server.getExpiryTimeSeconds() * 1000);
     }
     switch (action.type) {
         case "message":

--- a/lib/irc/IrcServer.js
+++ b/lib/irc/IrcServer.js
@@ -11,8 +11,12 @@ var log = logging.get("IrcServer");
  * @constructor
  * @param {string} domain : The IRC network address
  * @param {Object} serverConfig : The config options for this network.
+ * @param {string} homeserverDomain : The domain of the homeserver
+ * e.g "matrix.org"
+ * @param {Number} expiryTimeSeconds : The max number of seconds a
+ * message can be in order for it to be sent to this server.
  */
-function IrcServer(domain, serverConfig, homeserverDomain) {
+function IrcServer(domain, serverConfig, homeserverDomain, expiryTimeSeconds) {
     this.domain = domain;
     this.config = serverConfig;
 
@@ -22,6 +26,16 @@ function IrcServer(domain, serverConfig, homeserverDomain) {
     }
     this._addresses.push(domain);
     this._homeserverDomain = homeserverDomain;
+    this._expiryTimeSeconds = expiryTimeSeconds;
+}
+
+/**
+ * Get the max number of seconds a message can be before it is dropped from
+ * being sent to this server.
+ * @return {Number} The number of seconds
+ */
+IrcServer.prototype.getExpiryTimeSeconds = function() {
+    return this._expiryTimeSeconds || 0;
 }
 
 /**

--- a/lib/irc/IrcServer.js
+++ b/lib/irc/IrcServer.js
@@ -13,8 +13,8 @@ var log = logging.get("IrcServer");
  * @param {Object} serverConfig : The config options for this network.
  * @param {string} homeserverDomain : The domain of the homeserver
  * e.g "matrix.org"
- * @param {Number} expiryTimeSeconds : The max number of seconds a
- * message can be in order for it to be sent to this server.
+ * @param {Number} expiryTimeSeconds : How old a matrix message can be
+ * before it is considered 'expired' and not sent to IRC.
  */
 function IrcServer(domain, serverConfig, homeserverDomain, expiryTimeSeconds) {
     this.domain = domain;
@@ -30,8 +30,8 @@ function IrcServer(domain, serverConfig, homeserverDomain, expiryTimeSeconds) {
 }
 
 /**
- * Get the max number of seconds a message can be before it is dropped from
- * being sent to this server.
+ * Get how old a matrix message can be (in seconds) before it is considered
+ * 'expired' and not sent to IRC.
  * @return {Number} The number of seconds
  */
 IrcServer.prototype.getExpiryTimeSeconds = function() {

--- a/lib/irc/IrcServer.js
+++ b/lib/irc/IrcServer.js
@@ -14,7 +14,8 @@ var log = logging.get("IrcServer");
  * @param {string} homeserverDomain : The domain of the homeserver
  * e.g "matrix.org"
  * @param {Number} expiryTimeSeconds : How old a matrix message can be
- * before it is considered 'expired' and not sent to IRC.
+ * before it is considered 'expired' and not sent to IRC. If 0, messages
+ * will never expire.
  */
 function IrcServer(domain, serverConfig, homeserverDomain, expiryTimeSeconds) {
     this.domain = domain;
@@ -32,7 +33,7 @@ function IrcServer(domain, serverConfig, homeserverDomain, expiryTimeSeconds) {
 /**
  * Get how old a matrix message can be (in seconds) before it is considered
  * 'expired' and not sent to IRC.
- * @return {Number} The number of seconds
+ * @return {Number} The number of seconds. If 0, they never expire.
  */
 IrcServer.prototype.getExpiryTimeSeconds = function() {
     return this._expiryTimeSeconds || 0;

--- a/lib/models/IrcAction.js
+++ b/lib/models/IrcAction.js
@@ -4,12 +4,13 @@ var log = require("../logging").get("IrcAction");
 
 const ACTION_TYPES = ["message", "emote", "topic", "notice"];
 
-function IrcAction(type, text) {
+function IrcAction(type, text, timestamp) {
     if (ACTION_TYPES.indexOf(type) === -1) {
         throw new Error("Unknown IrcAction type: " + type);
     }
     this.type = type;
     this.text = text;
+    this.ts = timestamp || 0;
 }
 IrcAction.fromMatrixAction = function(matrixAction) {
     switch (matrixAction.type) {
@@ -22,17 +23,21 @@ IrcAction.fromMatrixAction = function(matrixAction) {
                     ircText = matrixAction.text; // fallback
                 }
                 // irc formatted text is the main text part
-                return new IrcAction(matrixAction.type, ircText)
+                return new IrcAction(matrixAction.type, ircText, matrixAction.ts)
             }
-            return new IrcAction(matrixAction.type, matrixAction.text);
+            return new IrcAction(matrixAction.type, matrixAction.text, matrixAction.ts);
         case "image":
-            return new IrcAction("emote", "uploaded an image: " + matrixAction.text);
+            return new IrcAction(
+                "emote", "uploaded an image: " + matrixAction.text, matrixAction.ts
+            );
         case "video":
-            return new IrcAction("emote", "uploaded a video: " + matrixAction.text);
+            return new IrcAction(
+                "emote", "uploaded a video: " + matrixAction.text, matrixAction.ts
+            );
         case "file":
-            return new IrcAction("emote", "posted a file: " + matrixAction.text);
+            return new IrcAction("emote", "posted a file: " + matrixAction.text, matrixAction.ts);
         case "topic":
-            return new IrcAction(matrixAction.type, matrixAction.text);
+            return new IrcAction(matrixAction.type, matrixAction.text, matrixAction.ts);
         default:
             log.error("IrcAction.fromMatrixAction: Unknown action: %s", matrixAction.type);
             return null;

--- a/lib/models/MatrixAction.js
+++ b/lib/models/MatrixAction.js
@@ -16,13 +16,14 @@ const MSGTYPE_TO_TYPE = {
     "m.file": "file"
 };
 
-function MatrixAction(type, text, htmlText) {
+function MatrixAction(type, text, htmlText, timestamp) {
     if (ACTION_TYPES.indexOf(type) === -1) {
         throw new Error("Unknown MatrixAction type: " + type);
     }
     this.type = type;
     this.text = text;
     this.htmlText = htmlText;
+    this.ts = timestamp || 0;
 }
 MatrixAction.fromEvent = function(client, event, mediaUrl) {
     event.content = event.content || {};
@@ -59,7 +60,7 @@ MatrixAction.fromEvent = function(client, event, mediaUrl) {
                 ContentRepo.getHttpUriForMxc(mediaUrl, event.content.url);
         }
     }
-    return new MatrixAction(type, text, htmlText);
+    return new MatrixAction(type, text, htmlText, event.origin_server_ts);
 };
 MatrixAction.fromIrcAction = function(ircAction) {
     switch (ircAction.type) {

--- a/spec/integ/matrix-to-irc.spec.js
+++ b/spec/integ/matrix-to-irc.spec.js
@@ -568,7 +568,8 @@ describe("Matrix-to-IRC message bridging with media URL and drop time", function
         let connected = false;
         env.ircMock._whenClient(roomMapping.server, testUser2.nick, "connect",
         function(client, cb) {
-            jasmine.clock().tick(20 * 1000); // advance 20s to take it over the drop time
+            // advance 20s to take it over dropMatrixMessagesAfterSecs time
+            jasmine.clock().tick(20 * 1000);
             client._invokeCallback(cb);
             connected = true;
         });

--- a/spec/integ/matrix-to-irc.spec.js
+++ b/spec/integ/matrix-to-irc.spec.js
@@ -499,6 +499,7 @@ describe("Matrix-to-IRC message bridging with media URL and drop time", function
         // Set the media URL
         env.config.homeserver.media_url = mediaUrl;
         env.config.homeserver.dropMatrixMessagesAfterSecs = 300; // 5 min
+        jasmine.clock().install();
 
         yield test.beforeEach(env);
 
@@ -521,6 +522,7 @@ describe("Matrix-to-IRC message bridging with media URL and drop time", function
     }));
 
     afterEach(test.coroutine(function*() {
+        jasmine.clock().uninstall();
         yield test.afterEach(env);
     }));
 
@@ -545,6 +547,47 @@ describe("Matrix-to-IRC message bridging with media URL and drop time", function
             origin_server_ts: Date.now() - (1000 * 60 * 6), // 6 mins old
         });
 
+        expect(said).toBe(false);
+    }));
+
+    it("should NOT bridge old matrix messages younger than the drop time on receive, which " +
+    "then go over the drop time whilst processing", test.coroutine(function*() {
+        const tBody = "Hello world";
+        const testUser2 = {
+            id: "@tester:wibble",
+            nick: "M-tester"
+        };
+        jasmine.clock().mockDate();
+
+        let said = false;
+        env.ircMock._whenClient(roomMapping.server, testUser2.nick, "say",
+        function(client, channel, text) {
+            said = true;
+        });
+
+        let connected = false;
+        env.ircMock._whenClient(roomMapping.server, testUser2.nick, "connect",
+        function(client, cb) {
+            jasmine.clock().tick(20 * 1000); // advance 20s to take it over the drop time
+            client._invokeCallback(cb);
+            connected = true;
+        });
+
+        env.ircMock._autoJoinChannels(
+            roomMapping.server, testUser2.nick, roomMapping.channel
+        );
+        yield env.mockAppService._trigger("type:m.room.message", {
+            content: {
+                body: tBody,
+                msgtype: "m.text"
+            },
+            user_id: testUser2.id,
+            room_id: roomMapping.roomId,
+            type: "m.room.message",
+            origin_server_ts: Date.now() - (1000 * 60 * 4) - (1000 * 50), // 4m50s old
+        });
+
+        expect(connected).toBe(true);
         expect(said).toBe(false);
     }));
 


### PR DESCRIPTION
This is to handle cases where it is set to drop messages after
5 minutes, the message arrives at 4m30s and it takes 1 minute
to go through the bridge (establish connection, join channel, etc).
Previously, the message would go through, 5m30s after the initial
send. Now, it won't go through.

Fixes issues mentioned in #388 by @justjanne