### PR TITLE
Breaking: rotate logs based on time rather than size

### DIFF
--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -334,8 +334,6 @@ ircService:
     errfile: "errors.log"
     # Whether to log to the console or not.
     toConsole: true
-    # The max size each file can get to in bytes before a new file is created.
-    maxFileSizeBytes: 134217728 # 128 MB
     # The max number of files to keep. Files will be overwritten eventually due
     # to rotations.
     maxFiles: 5

--- a/lib/logging.js
+++ b/lib/logging.js
@@ -10,7 +10,6 @@ var loggerConfig = {
     logfile: undefined, // path to file
     errfile: undefined, // path to file
     toConsole: true, // make a console logger
-    maxFileSizeBytes: (1024 * 1024 * 128), // 128 MB
     maxFiles: 5,
     verbose: false
 };
@@ -44,28 +43,28 @@ var makeTransports = function() {
         }));
     }
     if (loggerConfig.logfile) {
-        transports.push(new (winston.transports.File)({
+        transports.push(new (winston.transports.DailyRotateFile)({
             filename: loggerConfig.logfile,
             json: false,
             name: "logfile",
             level: loggerConfig.level,
             timestamp: timestampFn,
             formatter: formatterFn,
-            maxsize: loggerConfig.maxFileSizeBytes,
             maxFiles: loggerConfig.maxFiles,
+            datePattern: ".yyyy-MM-dd",
             tailable: true // most recent stuff always in filename.0.log
         }));
     }
     if (loggerConfig.errfile) {
-        transports.push(new (winston.transports.File)({
+        transports.push(new (winston.transports.DailyRotateFile)({
             filename: loggerConfig.errfile,
             json: false,
             name: "errorfile",
             level: "error",
             timestamp: timestampFn,
             formatter: formatterFn,
-            maxsize: loggerConfig.maxFileSizeBytes,
             maxFiles: loggerConfig.maxFiles,
+            datePattern: ".yyyy-MM-dd",
             tailable: true // most recent stuff always in filename.0.log
         }));
     }

--- a/lib/logging.js
+++ b/lib/logging.js
@@ -52,7 +52,7 @@ var makeTransports = function() {
             formatter: formatterFn,
             maxFiles: loggerConfig.maxFiles,
             datePattern: ".yyyy-MM-dd",
-            tailable: true // most recent stuff always in filename.0.log
+            tailable: true
         }));
     }
     if (loggerConfig.errfile) {
@@ -65,7 +65,7 @@ var makeTransports = function() {
             formatter: formatterFn,
             maxFiles: loggerConfig.maxFiles,
             datePattern: ".yyyy-MM-dd",
-            tailable: true // most recent stuff always in filename.0.log
+            tailable: true
         }));
     }
     // by default, EventEmitters will whine if you set more than 10 listeners on


### PR DESCRIPTION
This is a breaking change since I don't really want to maintain 2 separate
ways to rotate logs. Fixes #326 and gives me @erikjohnston's undying love.

We still have support for `maxFiles` though to only keep the most recent N
days of logs.