### PR TITLE
Fix invalid call to q() when not sending a message

### DIFF
--- a/scripts/unbridge.js
+++ b/scripts/unbridge.js
@@ -126,11 +126,12 @@ function setInviteJoinRules(url, roomId, token) {
 }
 
 function sendMessage(url, roomId, token, msg) {
+    var d = promiseutil.defer();
     if (!msg) {
         console.log("No message provided. Skipping.");
-        return q();
+        d.resolve();
+        return d.promise
     }
-    var d = promiseutil.defer();
     var encRoomId = encodeURIComponent(roomId);
     request({
         url: joinUrl(


### PR DESCRIPTION
It turns out that `q` was undefined, which causes the following:

```
ReferenceError: q is not defined
    at sendMessage (/var/lib/ircbridge/matrix-appservice-irc/scripts/unbridge.js:131:16)
    at /var/lib/ircbridge/matrix-appservice-irc/scripts/unbridge.js:63:16
    at tryCatcher (/var/lib/ircbridge/matrix-appservice-irc/node_modules/bluebird/js/release/util.js:16:23)
    at Promise._settlePromiseFromHandler (/var/lib/ircbridge/matrix-appservice-irc/node_modules/bluebird/js/release/promise.js:512:31)
    at Promise._settlePromise (/var/lib/ircbridge/matrix-appservice-irc/node_modules/bluebird/js/release/promise.js:569:18)
    at Promise._settlePromise0 (/var/lib/ircbridge/matrix-appservice-irc/node_modules/bluebird/js/release/promise.js:614:10)
    at Promise._settlePromises (/var/lib/ircbridge/matrix-appservice-irc/node_modules/bluebird/js/release/promise.js:693:18)
    at Async._drainQueue (/var/lib/ircbridge/matrix-appservice-irc/node_modules/bluebird/js/release/async.js:133:16)
    at Async._drainQueues (/var/lib/ircbridge/matrix-appservice-irc/node_modules/bluebird/js/release/async.js:143:10)
    at Immediate.Async.drainQueues [as _onImmediate] (/var/lib/ircbridge/matrix-appservice-irc/node_modules/bluebird/js/release/async.js:17:14)
    at processImmediate [as _immediateCallback] (timers.js:396:17)
FAILED
[ReferenceError: q is not defined]
```

---

This is the same as #422 which was incorrectly based on `master` (ooops).