### PR TITLE
Fix ident response format

### DIFF
--- a/lib/irc/ident.js
+++ b/lib/irc/ident.js
@@ -30,11 +30,13 @@ var portMappings = {
 var respond = function(sock, localPort, remotePort, username) {
     var response;
     if (username) {
-        response = localPort + ", " + remotePort + " : USERID : UNIX : " + username;
+        response = localPort + "," + remotePort + ":USERID:UNIX:" + username;
     }
     else {
-        response = localPort + ", " + remotePort + " : ERROR : NO-USER";
+        response = localPort + "," + remotePort + ":ERROR:NO-USER";
     }
+    response += "\r\n";
+
     log.debug(response);
     sock.end(response);
 };


### PR DESCRIPTION
Remove the whitespace and add a CR-LF in order to follow the formal syntax specified in RFC1413.