### PR TITLE
Let the bridge appear in the thirdparty/protocols API

### DIFF
--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -48,6 +48,10 @@ ircService:
       # An ID for uniquely identifying this server amongst other servers being bridged.
       # networkId: "example"
 
+      # URL to an icon used as the network icon whenever this network appear in
+      # a network list. (Like in the riot room directory, for instance.)
+      # icon: https://example.com/images/hash.png
+
       # The port to connect to. Optional.
       port: 6697
       # Whether to use SSL or not. Default: false.

--- a/lib/main.js
+++ b/lib/main.js
@@ -110,6 +110,10 @@ module.exports.generateRegistration = Promise.coroutine(function*(reg, config) {
     // connect, for example on startup.
     reg.setRateLimited(false);
 
+    // Set protocols to IRC, so that the bridge appears in the list of
+    // thirdparty protocols
+    reg.setProtocols(["irc"]);
+
     let serverDomains = Object.keys(config.ircService.servers);
     serverDomains.sort().forEach(function(domain) {
         let server = _toServer(domain, config.ircService.servers[domain], config.homeserver.domain);


### PR DESCRIPTION
In order to be listed in the thirdparty/protocols API, the
resigtration file must set the protocols setting.  Optionally an icon
can be set in the bridge configuration, that is used in the
thirdparty/protocols API accodingly. This makes the bridged network
to show up in the network pull-down list in the riot room directory,
for instance.