### PR TITLE
Refine the colours to match the mIRC colours.

### DIFF
--- a/lib/irc/formatting.js
+++ b/lib/irc/formatting.js
@@ -2,28 +2,50 @@
 
 var sanitizeHtml = require('sanitize-html');
 var htmlNamesToColorCodes = {
-    white: ['\u000300'],
-    black: ['\u000301', '\u00031'],
-    navy: ['\u000302', '\u00032'],
-    green: ['\u000303', '\u00033'],
-    red: ['\u000304', '\u000305', '\u00034', '\u00035'],
-    purple: ['\u000306', '\u00036'],
-    olive: ['\u000307', '\u00037'],
-    yellow: ['\u000308', '\u00038'],
-    lime: ['\u000309', '\u00039'],
-    teal: ['\u000310'],
-    aqua: ['\u000311'],
-    blue: ['\u000312'],
-    fuchsia: ['\u000313'],
-    gray: ['\u000314'],
-    silver: ['\u000315']
+    white:     ['\u000300', '\u00030'],
+    black:     ['\u000301', '\u00031'],
+    navy:      ['\u000302', '\u00032'],
+    green:     ['\u000303', '\u00033'],
+    red:       ['\u000304', '\u00034'],
+    maroon:    ['\u000305', '\u00035'],
+    purple:    ['\u000306', '\u00036'],
+    orange:    ['\u000307', '\u00037'],
+    yellow:    ['\u000308', '\u00038'],
+    lime:      ['\u000309', '\u00039'],
+    teal:      ['\u000310'],
+    aqua:      ['\u000311'],
+    blue:      ['\u000312'],
+    fuchsia:   ['\u000313'],
+    gray:      ['\u000314'],
+    lightgrey: ['\u000315']
 };
+
+// These map the CSS color names to mIRC hex colors
+var htmlNamesToHex = {
+    white:     '#FFFFFF',
+    black:     '#000000',
+    navy:      '#00007F',
+    green:     '#009300',
+    red:       '#FF0000',
+    maroon:    '#7F0000',
+    purple:    '#9C009C',
+    orange:    '#FC7F00',
+    yellow:    '#FFFF00',
+    lime:      '#00FC00',
+    teal:      '#009393',
+    aqua:      '#00FFFF',
+    blue:      '#0000FC',
+    fuchsia:   '#FF00FF',
+    gray:      '#7F7F7F',
+    lightgrey: '#D2D2D2'
+};
+
 // store the reverse mapping
 var colorCodesToHtmlNames = {};
 var htmlNames = Object.keys(htmlNamesToColorCodes);
 htmlNames.forEach(function(htmlName) {
     htmlNamesToColorCodes[htmlName].forEach(function(colorCode) {
-        colorCodesToHtmlNames[colorCode] = htmlName;
+        colorCodesToHtmlNames[colorCode] = htmlNamesToHex[htmlName];
     });
 });
 

--- a/spec/integ/irc-to-matrix.spec.js
+++ b/spec/integ/irc-to-matrix.spec.js
@@ -180,8 +180,8 @@ describe("IRC-to-Matrix message bridging", function() {
             "this is a \u0002\u001f\u000303mix of all three";
         var tHtmlCloseTags = "</b></u></font>"; // any order allowed
         var tHtmlMain = "This text is <b>bold</b> and this is <u>underlined</u> " +
-            'and this is <font color="green">green</font>. Finally, ' +
-            'this is a <b><u><font color="green">mix of all three';
+            'and this is <font color="#009300">green</font>. Finally, ' +
+            'this is a <b><u><font color="#009300">mix of all three';
         var tFallback = "This text is bold and this is underlined and this is " +
             "green. Finally, this is a mix of all three";
         sdk.sendEvent.and.callFake(function(roomId, type, content) {
@@ -242,8 +242,8 @@ describe("IRC-to-Matrix message bridging", function() {
     "org.matrix.custom.html", function(done) {
         // $& = Inserts the matched substring.
         var tIrcFormattedText = "\u000303$& \u000304 world\u000303 ! \u000304";
-        var tHtmlMain = '<font color="green">$&amp; </font><font color="red"> world'+
-            '</font><font color="green"> ! </font>';
+        var tHtmlMain = '<font color="#009300">$&amp; </font><font color="#FF0000"> world' +
+            '</font><font color="#009300"> ! </font>';
         var tFallback = "$&  world ! ";
         sdk.sendEvent.and.callFake(function(roomId, type, content) {
             expect(roomId).toEqual(roomMapping.roomId);


### PR DESCRIPTION
The CSS/HTML colour names now better match the colours defined by mIRC.

Comparison (the first word/colour is 'white'):

![irccolours](https://user-images.githubusercontent.com/5798032/28995158-7fb30d8a-79e1-11e7-8de2-40201bbfaa55.png)

Sources: http://www.mirc.com/colors.html, https://en.wikichip.org/wiki/irc/colors