### PR TITLE
Rewrite IRC to HTML parsing

### DIFF
--- a/lib/irc/formatting.js
+++ b/lib/irc/formatting.js
@@ -45,15 +45,21 @@ var colorCodesToHtmlNames = {};
 var htmlNames = Object.keys(htmlNamesToColorCodes);
 htmlNames.forEach(function(htmlName) {
     htmlNamesToColorCodes[htmlName].forEach(function(colorCode) {
-        colorCodesToHtmlNames[colorCode] = htmlNamesToHex[htmlName];
+        colorCodesToHtmlNames[colorCode.substr(1)] = htmlNamesToHex[htmlName];
     });
 });
 
-var STYLE_BOLD = '\u0002';
-var STYLE_ITALICS = '\u001d';
-var STYLE_UNDERLINE = '\u001f';
-var STYLE_CODES = [STYLE_BOLD, STYLE_ITALICS, STYLE_UNDERLINE];
-var RESET_CODE = '\u000f';
+const STYLE_BOLD = '\u0002';
+const STYLE_ITALICS = '\u001d';
+const STYLE_UNDERLINE = '\u001f';
+const STYLE_CODES = [STYLE_BOLD, STYLE_ITALICS, STYLE_UNDERLINE];
+const RESET_CODE = '\u000f';
+const REVERSE_CODE = '\u0016';
+const STYLE_DEFAULT_STATE = {
+    "color": null,
+    "bcolor": null,
+    "history": []
+};
 
 function escapeHtmlChars(text) {
     return text
@@ -62,6 +68,50 @@ function escapeHtmlChars(text) {
          .replace(/>/g, "&gt;")
          .replace(/"/g, "&quot;")
          .replace(/'/g, "&#39;"); // to work on HTML4 (&apos; is HTML5 only)
+}
+
+function htmlTag(state, name, open) {
+    let text = '';
+
+    if (typeof open === 'undefined') {
+        open = (state.history.indexOf(name) === -1);
+    }
+
+    if (open) {
+        state.history.push(name);
+        if (name === 'font') {
+            // Create style from state
+            let style = '';
+            if (state.color) {
+                style += ' color="' + state.color + '"';
+            }
+            if (state.bcolor) {
+                style += ' data-mx-bg-color="' + state.bcolor + '"';
+            }
+            text = '<font' + style + '>';
+        }
+        else {
+            text = '<' + name + '>';
+        }
+    }
+    else {
+        // Get tags that need to be closed
+        let index = name === 'all' ? 0 : state.history.lastIndexOf(name);
+        let tags = state.history.splice(index);
+
+        // Close tags
+        tags.reverse().forEach( function(t) {
+            text += '</' + t + '>';
+        });
+
+        // Open tags again
+        if (name !== 'all') {
+            tags.slice(0, -1).forEach( function (t) {
+                text += htmlTag(state, t, true);
+            });
+        }
+    }
+    return text;
 }
 
 module.exports.stripIrcFormatting = function(text) {
@@ -164,103 +214,67 @@ module.exports.htmlToIrc = function(html) {
 };
 
 module.exports.ircToHtml = function(text) {
-    text = escapeHtmlChars(text);
+    // Escape HTML characters and add reset character to close all tags at the end.
+    text = escapeHtmlChars(text) + '\x0f';
 
-    // Color codes look like 003xx or 003xx,yy (xx=foreground, yy=background)
-    // We want to match until it hits another color (starting 003) or hits the
-    // reset code 000f. That is the 'end tag', represented as a non-greedy match
-    // for the reset code, or any character until 003.
-    //
-    //                  Foreground          Background      End 'tag'
-    //                 ______|_______       ____|____    _______|________
-    //                /              \     /         \  /                \
-    var colorRegex = /(\003[0-9]{1,2})[,]?([0-9]{1,2})?(.*?\u000f|[^\003]+)/;
-    var groups;
-    if (colorRegex.test(text)) {
-        groups = colorRegex.exec(text);
-        while (groups) {
-            // ignore bg for now (groups[2])
+    // Replace all mIRC formatting characters.
+    // The color character can have arguments.
+    const colorRegex = /[\x02\x1d\x1f\x0f\x16]|\x03(\d{0,2})(?:,(\d{1,2}))?/g;
 
-            // this text includes the reset code so the code can be applied for
-            // each formatting code. We'll strip it later on.
-            var coloredText = groups[3];
-            var fontColor = colorCodesToHtmlNames[groups[1]];
-            if (fontColor) {
-                text = text.replace(
-                    groups[0],
-                    function() { // eslint-disable-line no-loop-func
-                        return '<font color="' + fontColor + '">' +
-                        coloredText +
-                        '</font>'
-                    }
-                );
-            }
-            else {
-                // unknown font colour
-                text = text.replace(groups[0], coloredText);
-            }
-            groups = colorRegex.exec(text);
-        }
-    }
-
-    // force there to always be a RESET code at the end of the text to make sure
-    // we close up all open style tags at the end.
-    if (text.length > 0 && text[text.length - 1] !== RESET_CODE) {
-        text = text + RESET_CODE;
-    }
-
-    // Convert styles to bold/italics/underline
-    //
     // Maintain a small state machine of which tags are open so we can close the right
     // ones on RESET codes and toggle appropriately if they do the same code again.
-    let boldOpen = false;
-    let italicsOpen = false;
-    let underlineOpen = false;
-    for (let i = 0; i < text.length; i++) {
-        let char = text[i];
-        let charsToInsert = "";
-        switch (char) {
-            case STYLE_BOLD:
-                boldOpen = !boldOpen;
-                charsToInsert = boldOpen ? "<b>" : "</b>";
-                break;
-            case STYLE_ITALICS:
-                italicsOpen = !italicsOpen;
-                charsToInsert = italicsOpen ? "<i>" : "</i>";
-                break;
-            case STYLE_UNDERLINE:
-                underlineOpen = !underlineOpen;
-                charsToInsert = underlineOpen ? "<u>" : "</u>";
-                break;
-            case RESET_CODE:
-                if (boldOpen) {
-                    charsToInsert += "</b>";
-                }
-                if (italicsOpen) {
-                    charsToInsert += "</i>";
-                }
-                if (underlineOpen) {
-                    charsToInsert += "</u>";
-                }
-                boldOpen = false;
-                italicsOpen = false;
-                underlineOpen = false;
-                break;
-            default:
-                break;
-        }
-        if (charsToInsert.length > 0) {
-            // Insert the text into this location and remove the style code (the +1 in i+1)
-            // Increment i by the number of *additional* chars (which is the length-1)
-            text = text.slice(0, i) + charsToInsert + text.slice(i+1);
-            i += charsToInsert.length - 1;
-        }
-    }
+    let state = Object.assign({}, STYLE_DEFAULT_STATE);
 
-    // The text NOW needs the reset code(s) stripped out from it, since we've
-    // finished applying all the formatting.
-    text = text.replace(/\u000f/g, "");
-    return text;
+    // Return message with codes replaced
+    return text.replace(colorRegex, function(match, fg, bg) {
+        let tags = '';
+
+        // Modify state with the current match
+        switch (match) {
+            case STYLE_BOLD:
+                return htmlTag(state, 'b');
+
+            case STYLE_ITALICS:
+                return htmlTag(state, 'i');
+
+            case STYLE_UNDERLINE:
+                return htmlTag(state, 'u');
+
+            case REVERSE_CODE:
+                state.color = [state.bcolor, state.bcolor = state.color][0];
+                return htmlTag(state, 'font', false) + htmlTag(state, 'font', true);
+
+            case RESET_CODE:
+                // Close tags
+                tags = htmlTag(state, 'all', false);
+                // Reset state
+                state = Object.assign({}, STYLE_DEFAULT_STATE);
+                return tags;
+
+            default:
+                // Close font tag
+                if (state.color || state.bcolor) {
+                    tags += htmlTag(state, 'font', false);
+                }
+                // Foreground colour
+                if (fg) {
+                    state.color = colorCodesToHtmlNames[fg];
+                }
+                // Background colour
+                if (bg) {
+                    state.bcolor = colorCodesToHtmlNames[bg];
+                }
+                // Neither
+                if (!fg && !bg) {
+                    state.color = state.bcolor = null;
+                }
+                // Create font with style
+                if (state.color || state.bcolor) {
+                    tags += htmlTag(state, 'font', true);
+                }
+                return tags;
+        }
+    });
 };
 
 module.exports.toIrcLowerCase = function(str, caseMapping) {

--- a/lib/irc/formatting.js
+++ b/lib/irc/formatting.js
@@ -2,22 +2,22 @@
 
 var sanitizeHtml = require('sanitize-html');
 var htmlNamesToColorCodes = {
-    white:     ['\u000300', '\u00030'],
-    black:     ['\u000301', '\u00031'],
-    navy:      ['\u000302', '\u00032'],
-    green:     ['\u000303', '\u00033'],
-    red:       ['\u000304', '\u00034'],
-    maroon:    ['\u000305', '\u00035'],
-    purple:    ['\u000306', '\u00036'],
-    orange:    ['\u000307', '\u00037'],
-    yellow:    ['\u000308', '\u00038'],
-    lime:      ['\u000309', '\u00039'],
-    teal:      ['\u000310'],
-    aqua:      ['\u000311'],
-    blue:      ['\u000312'],
-    fuchsia:   ['\u000313'],
-    gray:      ['\u000314'],
-    lightgrey: ['\u000315']
+    white:     ['00', '0'],
+    black:     ['01', '1'],
+    navy:      ['02', '2'],
+    green:     ['03', '3'],
+    red:       ['04', '4'],
+    maroon:    ['05', '5'],
+    purple:    ['06', '6'],
+    orange:    ['07', '7'],
+    yellow:    ['08', '8'],
+    lime:      ['09', '9'],
+    teal:      ['10'],
+    aqua:      ['11'],
+    blue:      ['12'],
+    fuchsia:   ['13'],
+    gray:      ['14'],
+    lightgrey: ['15']
 };
 
 // These map the CSS color names to mIRC hex colors
@@ -44,8 +44,8 @@ var htmlNamesToHex = {
 var colorCodesToHtmlNames = {};
 var htmlNames = Object.keys(htmlNamesToColorCodes);
 htmlNames.forEach(function(htmlName) {
-    htmlNamesToColorCodes[htmlName].forEach(function(colorCode) {
-        colorCodesToHtmlNames[colorCode.substr(1)] = htmlNamesToHex[htmlName];
+    htmlNamesToColorCodes[htmlName].forEach(function(colorNum) {
+        colorCodesToHtmlNames[colorNum] = htmlNamesToHex[htmlName];
     });
 });
 
@@ -174,7 +174,7 @@ module.exports.htmlToIrc = function(html) {
     Object.keys(htmlNamesToColorCodes).forEach(function(htmlColor) {
         replacements.push([
             new RegExp('<font color="' + htmlColor + '">', 'g'),
-            htmlNamesToColorCodes[htmlColor][0]
+            STYLE_COLOR + htmlNamesToColorCodes[htmlColor][0]
         ]);
     });
     for (var i = 0; i < replacements.length; i++) {

--- a/lib/irc/formatting.js
+++ b/lib/irc/formatting.js
@@ -49,16 +49,26 @@ htmlNames.forEach(function(htmlName) {
     });
 });
 
+const STYLE_COLOR = '\u0003';
 const STYLE_BOLD = '\u0002';
 const STYLE_ITALICS = '\u001d';
 const STYLE_UNDERLINE = '\u001f';
 const STYLE_CODES = [STYLE_BOLD, STYLE_ITALICS, STYLE_UNDERLINE];
 const RESET_CODE = '\u000f';
 const REVERSE_CODE = '\u0016';
+
+/**
+ * This is used as the default state for irc to html conversion.
+ * The color attributes (color and bcolor) can be:
+ *  - null for no colour, or
+ *  - a string with an HTML/CSS colour.
+ *
+ * @type {{color: (null|string), bcolor: (null|string), history: Array}}
+ */
 const STYLE_DEFAULT_STATE = {
-    "color": null,
-    "bcolor": null,
-    "history": []
+    "color": null,  // The foreground colour.
+    "bcolor": null, // The background colour.
+    "history": []   // The history of opened tags. See the htmlTag function.
 };
 
 function escapeHtmlChars(text) {
@@ -70,6 +80,23 @@ function escapeHtmlChars(text) {
          .replace(/'/g, "&#39;"); // to work on HTML4 (&apos; is HTML5 only)
 }
 
+/**
+ * Given the state of the message, open or close an HTML tag with the
+ * appropriate attributes.
+ *
+ * Tags are stored in an array, which is used as a stack.
+ * Opening a tag is always pushed to the end. This can happen multiple times
+ * for nested tags of the same type.
+ * Closing a tag closes all tags up to the most recent corresponding tag in
+ * the history, and re-opens the ones opened after. Nothing happens if the tag
+ * doesn't exist.
+ *
+ * @param {Object} state Current state of a message
+ * @param {string} name Name of the HTML tag.
+ * @param {boolean} open Open or close the tag (optional) .
+ *                       Detected automatically when omitted.
+ * @returns {string} Text containing the relevant open/closing tags.
+ */
 function htmlTag(state, name, open) {
     let text = '';
 
@@ -215,10 +242,16 @@ module.exports.htmlToIrc = function(html) {
 
 module.exports.ircToHtml = function(text) {
     // Escape HTML characters and add reset character to close all tags at the end.
-    text = escapeHtmlChars(text) + '\x0f';
+    text = escapeHtmlChars(text) + RESET_CODE;
 
     // Replace all mIRC formatting characters.
     // The color character can have arguments.
+    // The regex matches:
+    // - Any single 'simple' formatting character: \x02, \x1d, \x1f, \x0f and
+    //   \x16 for bold, italics, underline, reset and reverse respectively.
+    // - The colour formatting character (\x03) followed by 0 to 2 digits for
+    //   the foreground colour and (optionally) a comma and 1-2 digits for the
+    //   background colour.
     const colorRegex = /[\x02\x1d\x1f\x0f\x16]|\x03(\d{0,2})(?:,(\d{1,2}))?/g;
 
     // Maintain a small state machine of which tags are open so we can close the right
@@ -229,8 +262,8 @@ module.exports.ircToHtml = function(text) {
     return text.replace(colorRegex, function(match, fg, bg) {
         let tags = '';
 
-        // Modify state with the current match
-        switch (match) {
+        // Modify state with the current matched formatting character
+        switch (match[0]) {
             case STYLE_BOLD:
                 return htmlTag(state, 'b');
 
@@ -241,7 +274,11 @@ module.exports.ircToHtml = function(text) {
                 return htmlTag(state, 'u');
 
             case REVERSE_CODE:
-                state.color = [state.bcolor, state.bcolor = state.color][0];
+                // Swap the foreground and background colours.
+                let temp = state.color;
+                state.color = state.bcolor;
+                state.bcolor = temp;
+                // Close and re-open the font tag.
                 return htmlTag(state, 'font', false) + htmlTag(state, 'font', true);
 
             case RESET_CODE:
@@ -251,7 +288,7 @@ module.exports.ircToHtml = function(text) {
                 state = Object.assign({}, STYLE_DEFAULT_STATE);
                 return tags;
 
-            default:
+            case STYLE_COLOR:
                 // Close font tag
                 if (state.color || state.bcolor) {
                     tags += htmlTag(state, 'font', false);
@@ -272,6 +309,10 @@ module.exports.ircToHtml = function(text) {
                 if (state.color || state.bcolor) {
                     tags += htmlTag(state, 'font', true);
                 }
+                return tags;
+
+            // Unknown or ignored character
+            default:
                 return tags;
         }
     });

--- a/spec/integ/irc-to-matrix.spec.js
+++ b/spec/integ/irc-to-matrix.spec.js
@@ -215,7 +215,7 @@ describe("IRC-to-Matrix message bridging", function() {
     it("should bridge badly formatted IRC text as Matrix's org.matrix.custom.html",
     function(done) {
         var tIrcFormattedText = "\u0002hello \u001d world\u0002 ! \u001d";
-        var tHtmlMain = "<b>hello <i> world</b> ! </i>";
+        var tHtmlMain = "<b>hello <i> world</i></b><i> ! </i>";
         var tFallback = "hello  world ! ";
         sdk.sendEvent.and.callFake(function(roomId, type, content) {
             expect(roomId).toEqual(roomMapping.roomId);


### PR DESCRIPTION
Rewrite the parsing to support more features:

- Background colours
- Reverse colours
- Valid HTML (tags are closed/opened correctly)

The biggest changes are the addition of a function that ensures valid HTML (by keeping a history of open tags) and a new regular expression that only matches the control characters. The latter also simplifies the replace.