### PR TITLE
Propagate display name changes to nick changes

### DIFF
--- a/lib/bridge/IrcBridge.js
+++ b/lib/bridge/IrcBridge.js
@@ -843,7 +843,7 @@ IrcBridge.prototype.getBridgedClient = Promise.coroutine(function*(server, userI
     // check the database for stored config information for this irc client
     // including username, custom nick, nickserv password, etc.
     let ircClientConfig = IrcClientConfig.newConfig(
-        mxUser, server.domain, server.getNick(userId, displayName)
+        mxUser, server.domain, null
     );
     let storedConfig = yield this.getStore().getIrcClientConfig(userId, server.domain);
     if (storedConfig) {

--- a/lib/bridge/MatrixHandler.js
+++ b/lib/bridge/MatrixHandler.js
@@ -321,7 +321,7 @@ MatrixHandler.prototype._onAdminMessage = Promise.coroutine(function*(req, event
         // change the nick
         let bridgedClient = yield this.ircBridge.getBridgedClient(ircServer, event.user_id);
         try {
-            let response = yield bridgedClient.changeNick(nick);
+            let response = yield bridgedClient.changeNick(nick, true);
             let noticeRes = new MatrixAction("notice", response);
             yield this.ircBridge.sendMatrixAction(adminRoom, botUser, noticeRes, req);
             // persist this desired nick
@@ -837,7 +837,6 @@ MatrixHandler.prototype._onJoin = Promise.coroutine(function*(req, event, user) 
             // Check for a displayname change and update nick accordingly.
             if (event.content.displayname !== bridgedClient.displayName) {
                 bridgedClient.displayName = event.content.displayname;
-
                 // Changing the nick requires that:
                 // - the server allows nick changes
                 // - the nick is not custom
@@ -845,7 +844,8 @@ MatrixHandler.prototype._onJoin = Promise.coroutine(function*(req, event, user) 
                     bridgedClient.getClientConfig().getDesiredNick() === null
                 ) {
                     bridgedClient.changeNick(
-                        room.server.getNick(bridgedClient.userId, event.content.displayname));
+                        room.server.getNick(bridgedClient.userId, event.content.displayname),
+                        false);
                 }
             }
 

--- a/lib/bridge/MatrixHandler.js
+++ b/lib/bridge/MatrixHandler.js
@@ -840,8 +840,11 @@ MatrixHandler.prototype._onJoin = Promise.coroutine(function*(req, event, user) 
                 // Changing the nick requires that:
                 // - the server allows nick changes
                 // - the nick is not custom
+                let config = yield self.ircBridge.getStore().getIrcClientConfig(
+                    bridgedClient.userId, room.server.domain
+                );
                 if (room.server.allowsNickChanges() &&
-                    bridgedClient.getClientConfig().getDesiredNick() === null
+                    config.getDesiredNick() === null
                 ) {
                     bridgedClient.changeNick(
                         room.server.getNick(bridgedClient.userId, event.content.displayname),

--- a/lib/bridge/MatrixHandler.js
+++ b/lib/bridge/MatrixHandler.js
@@ -833,6 +833,22 @@ MatrixHandler.prototype._onJoin = Promise.coroutine(function*(req, event, user) 
             let bridgedClient = yield self.ircBridge.getBridgedClient(
                 room.server, user.getId(), (event.content || {}).displayname
             );
+
+            // Check for a displayname change and update nick accordingly.
+            if (event.content.displayname !== bridgedClient.displayName) {
+                bridgedClient.displayName = event.content.displayname;
+
+                // Changing the nick requires that:
+                // - the server allows nick changes
+                // - the nick is not custom
+                if (room.server.allowsNickChanges() &&
+                    bridgedClient.getClientConfig().getDesiredNick() === null
+                ) {
+                    bridgedClient.changeNick(
+                        room.server.getNick(bridgedClient.userId, event.content.displayname));
+                }
+            }
+
             yield bridgedClient.joinChannel(room.channel); // join each channel
         })());
     });

--- a/lib/irc/BridgedClient.js
+++ b/lib/irc/BridgedClient.js
@@ -202,13 +202,15 @@ BridgedClient.prototype.disconnect = function(reason) {
 
 /**
  * Change this user's nick.
- * @param {string} newNick : The new nick for the user.
+ * @param {string} newNick The new nick for the user.
+ * @param {boolean} throwOnInvalid True to throw an error on invalid nicks
+ * instead of coercing them.
  * @return {Promise<String>} Which resolves to a message to be sent to the user.
  */
-BridgedClient.prototype.changeNick = function(newNick) {
+BridgedClient.prototype.changeNick = function(newNick, throwOnInvalid) {
     let validNick = newNick;
     try {
-        validNick = this._getValidNick(newNick, true);
+        validNick = this._getValidNick(newNick, throwOnInvalid);
         if (validNick === this.nick) {
             return Promise.resolve(`Your nick is already '${validNick}'.`);
         }

--- a/lib/irc/BridgedClient.js
+++ b/lib/irc/BridgedClient.js
@@ -33,11 +33,14 @@ function BridgedClient(server, ircClientConfig, matrixUser, isBot, eventBroker, 
     this._clientConfig = ircClientConfig;
     this.matrixUser = matrixUser;
     this.server = server;
-    this.nick = this._getValidNick(ircClientConfig.getDesiredNick(), false);
+    this.userId = matrixUser ? this.matrixUser.getId() : null;
+    this.displayName = matrixUser ? this.matrixUser.getDisplayName() : null;
+    this.nick = this._getValidNick(
+        ircClientConfig.getDesiredNick() || server.getNick(this.userId, this.displayName),
+        false);
     this.password = (
         ircClientConfig.getPassword() ? ircClientConfig.getPassword() : server.config.password
     );
-    this.userId = matrixUser ? this.matrixUser.getId() : null;
 
     this.isBot = Boolean(isBot);
     this.lastActionTs = Date.now();

--- a/lib/models/IrcClientConfig.js
+++ b/lib/models/IrcClientConfig.js
@@ -16,10 +16,6 @@ class IrcClientConfig {
         this.userId = userId;
         this.domain = domain;
         this._config = configObj || {};
-
-        if (!this.getDesiredNick()) {
-            throw new Error("Client config must specify a nick");
-        }
     }
 
     getDomain() {

--- a/spec/integ/admin-rooms.spec.js
+++ b/spec/integ/admin-rooms.spec.js
@@ -65,6 +65,12 @@ describe("Admin rooms", function() {
     beforeEach(test.coroutine(function*() {
         yield test.beforeEach(env);
 
+        // enable syncing
+        config.ircService.servers[config._server].membershipLists.enabled = true;
+        config.ircService.servers[
+            config._server
+        ].membershipLists.global.matrixToIrc.incremental = true;
+
         // enable nick changes
         config.ircService.servers[roomMapping.server].ircClients.allowNickChanges = true;
         // enable private dynamic channels with the user ID in a whitelist
@@ -332,6 +338,92 @@ describe("Admin rooms", function() {
         // make sure everything was called
         expect(sentNickCommand).toBe(true, "Client did not send nick IRC command");
         expect(sentSay).toBe(true, "Client did not send message as new nick");
+    }));
+
+    it("should be able to change their nick using !nick and have it persist " +
+        "when changing the display name",
+        test.coroutine(function*() {
+            var newNick = "Blurple";
+            var displayName = "Durple";
+
+            // make sure that the nick command is sent
+            var sentNickCommand = false;
+            env.ircMock._whenClient(roomMapping.server, userIdNick, "send",
+                function(client, command, arg) {
+                    expect(client.nick).toEqual(userIdNick, "use the old nick on /nick");
+                    expect(client.addr).toEqual(roomMapping.server);
+                    expect(command).toEqual("NICK");
+                    expect(arg).toEqual(newNick);
+                    client._changeNick(userIdNick, newNick);
+                    sentNickCommand = true;
+                });
+
+            // make sure that a display name change is not propagated
+            var sentNick = false;
+            env.ircMock._whenClient(roomMapping.server, newNick, "send",
+                function(client, channel, text) {
+                    sentNick = true;
+                });
+
+            // trigger the request to change the nick
+            yield env.mockAppService._trigger("type:m.room.message", {
+                content: {
+                    body: "!nick " + roomMapping.server + " " + newNick,
+                    msgtype: "m.text"
+                },
+                user_id: userId,
+                room_id: adminRoomId,
+                type: "m.room.message"
+            });
+
+            // trigger a display name change
+            yield env.mockAppService._trigger("type:m.room.member", {
+                content: {
+                    membership: "join",
+                    avatar_url: null,
+                    displayname: displayName
+                },
+                state_key: userId,
+                user_id: userId,
+                room_id: roomMapping.roomId,
+                type: "m.room.member",
+            });
+
+            // make sure everything was called
+            expect(sentNickCommand).toBe(true, "sent nick IRC command");
+            expect(sentNick).toBe(false, "sent nick IRC command on displayname change");
+        }));
+
+    it("should propagate a display name change as a nick change when no custom nick is set",
+    test.coroutine(function*() {
+        var newNick = "Blurple";
+
+        // make sure that the nick command is sent
+        var sentNickCommand = false;
+        env.ircMock._whenClient(roomMapping.server, userIdNick, "send",
+            function(client, command, arg) {
+                expect(client.nick).toEqual(userIdNick, "use the old nick on /nick");
+                expect(client.addr).toEqual(roomMapping.server);
+                expect(command).toEqual("NICK");
+                expect(arg).toEqual('M-' + newNick);
+                sentNickCommand = true;
+            });
+
+        // trigger a display name change
+        yield env.mockAppService._trigger("type:m.room.member", {
+            content: {
+                membership: "join",
+                avatar_url: null,
+                displayname: newNick
+            },
+            state_key: userId,
+            user_id: userId,
+            room_id: roomMapping.roomId,
+            type: "m.room.member",
+        });
+
+        // make sure everything was called
+        expect(sentNickCommand).toBe(true, "sent nick IRC command");
     }));
 
     it("should reject !nick changes for IRC errors",

--- a/spec/integ/admin-rooms.spec.js
+++ b/spec/integ/admin-rooms.spec.js
@@ -562,6 +562,12 @@ describe("Admin rooms", function() {
             }
         });
 
+        // let the user join the IRC channel because of membership syncing
+        env.ircMock._whenClient(roomMapping.server, userIdNick, "join",
+        function(client, chan, cb) {
+            if (chan === newChannel && cb) { cb(); }
+        });
+
         // make sure the AS creates a new PRIVATE matrix room.
         var createdMatrixRoom = false;
         var sdk = env.clientMock._client(botUserId);
@@ -588,7 +594,7 @@ describe("Admin rooms", function() {
             user_id: userId,
             room_id: adminRoomId,
             type: "m.room.message"
-        })
+        });
 
         // make sure everything was called
         expect(createdMatrixRoom).toBe(true, "Did not create matrix room");


### PR DESCRIPTION
Any join event now changes the nickname (if different).
This is not done for configured nicknames (stored in the database).
Generated nicknames are now stored as null.

~This is a work in progress as tests are required for the following situations:~

- ~A user without custom nick changes their display name.~
- ~A user with a configured nick changes their display name.~
- ~A user without custom nick sets a nick and then changes their display name.~

Feedback would be appreciated!

Resolves #218 