### PR TITLE
Set custom power_levels on room creation

### DIFF
--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -97,6 +97,16 @@ ircService:
       modePowerMap:
         o: 50
 
+      # A map of levels needed to do some action on the Matrix room. Those levels will be set
+      # on the room on creation. With corresponding modePowerMap, this allows Matrix users who
+      # are ops on the IRC side to edit the room settings.
+      powerLevels:
+        avatar: 50
+        name: 50
+        canonicalAlias: 50
+        historyVisibility: 50
+        redact: 50
+
       botConfig:
         # Enable the presence of the bot in IRC channels. The bot serves as the entity
         # which maps from IRC -> Matrix. You can disable the bot entirely which

--- a/lib/bridge/IrcHandler.js
+++ b/lib/bridge/IrcHandler.js
@@ -278,9 +278,10 @@ IrcHandler.prototype.onInvite = Promise.coroutine(function*(req, server, fromUse
 
     if (matrixRooms.length === 0) {
         let ircRoom = yield this.ircBridge.trackChannel(server, channel, null);
-        let response = yield this.ircBridge.getAppServiceBridge().getIntent(
+        let userIntent = this.ircBridge.getAppServiceBridge().getIntent(
             virtualMatrixUser.getId()
-        ).createRoom({
+        );
+        let response = yield userIntent.createRoom({
             options: {
                 room_alias_name: roomAlias.split(":")[0].substring(1), // localpart
                 name: channel,
@@ -303,6 +304,11 @@ IrcHandler.prototype.onInvite = Promise.coroutine(function*(req, server, fromUse
                         content: {
                             history_visibility: "joined"
                         }
+                    },
+                    {
+                        type: "m.room.power_levels",
+                        state_key: "",
+                        content: ircServer.getPowerLevels(userIntent.getClient().credentials.userId)
                     }
                 ]
             }

--- a/lib/bridge/MatrixHandler.js
+++ b/lib/bridge/MatrixHandler.js
@@ -392,9 +392,8 @@ MatrixHandler.prototype._onAdminMessage = Promise.coroutine(function*(req, event
             // track the channel then invite them.
             // TODO: Dupes onAliasQuery a lot
             let ircRoom = yield this.ircBridge.trackChannel(ircServer, ircChannel, key);
-            let response = yield this.ircBridge.getAppServiceBridge().getIntent(
-                event.user_id
-            ).createRoom({
+            let userIntent = this.ircBridge.getAppServiceBridge().getIntent(event.user_id);
+            let response = yield userIntent.createRoom({
                 options: {
                     name: ircChannel,
                     visibility: "private",
@@ -416,6 +415,13 @@ MatrixHandler.prototype._onAdminMessage = Promise.coroutine(function*(req, event
                             content: {
                                 history_visibility: "joined"
                             }
+                        },
+                        {
+                            type: "m.room.power_levels",
+                            state_key: "",
+                            content: ircServer.getPowerLevels(
+                                userIntent.getClient().credentials.userId
+                            )
                         }
                     ]
                 }
@@ -1353,6 +1359,13 @@ MatrixHandler.prototype._onAliasQuery = Promise.coroutine(function*(req, roomAli
                             content: {
                                 history_visibility: "joined"
                             }
+                        },
+                        {
+                            type: "m.room.power_levels",
+                            state_key: "",
+                            content: channelInfo.server.getPowerLevels(
+                                botIntent.getClient().credentials.userIdl
+                            )
                         }
                     ]
                 }

--- a/lib/config/schema.yml
+++ b/lib/config/schema.yml
@@ -127,6 +127,19 @@ properties:
                                 "^[a-zA-Z]$":
                                     type: number
                                     minimum: 0
+                        powerLevels:
+                            type: "object"
+                            properties:
+                                avatar:
+                                    type: "number"
+                                name:
+                                    type: "number"
+                                canonical_alias:
+                                    type: "number"
+                                history_visibility:
+                                    type: "number"
+                                redact:
+                                    type: "number"
                         botConfig:
                             type: "object"
                             properties:

--- a/lib/irc/IrcServer.js
+++ b/lib/irc/IrcServer.js
@@ -119,6 +119,30 @@ IrcServer.prototype.getModePowerMap = function() {
     return this.config.modePowerMap || {};
 }
 
+/**
+ * Get a map of power levels to set.
+ * @param {string} userId : The room creator user ID.
+ * @return {Object}
+ */
+IrcServer.prototype.getPowerLevels = function(userId) {
+    var powerLevels = this.config.powerLevels || {};
+    var content = {
+        redact: powerLevels.redact || 50,
+        events_default: 0,
+        state_default: 50,
+        events: {
+            "m.room.avatar": powerLevels.avatar || 50,
+            "m.room.name": powerLevels.name || 50,
+            "m.room.canonical_alias": powerLevels.canonicalAlias || 50,
+            "m.room.history_visibility": powerLevels.historyVisibility || 100,
+            "m.room.power_levels": 100
+        },
+        users: {}
+    }
+    content["users"][userId] = 100;
+    return content;
+}
+
 IrcServer.prototype.getHardCodedRoomIds = function() {
     var roomIds = new Set();
     var channels = Object.keys(this.config.mappings);


### PR DESCRIPTION
An user can already set custom level for IRC modes. The idea of this PR is to allow to set also custom privilege levels needed to configure the room (Matrix side).

My first need was to be able to let the matrix users who are op on IRC set the history visibility, but I added some other parameters (avatar, name, canonical alias, ...).


Edit: currently this PR only set power levels on room creation, but I would like to set them on reconnection, to support config changes. Any advices on how to do this?