### PR TITLE
Kick user regardless of his type on kick from irc

### DIFF
--- a/lib/bridge/IrcHandler.js
+++ b/lib/bridge/IrcHandler.js
@@ -534,72 +534,39 @@ IrcHandler.prototype.onKick = Promise.coroutine(function*(req, server,
 
     /*
     We know this is an IRC client kicking someone.
-    There are 2 scenarios to consider here:
-     - IRC on IRC kicking
-     - IRC on Matrix kicking
-
-    IRC-IRC
-    =======
-      __USER A____            ____USER B___
-     |            |          |             |
-    IRC       vMatrix1       IRC      vMatrix2 |     Effect
-    -----------------------------------------------------------------------
-    Kicker                 Kickee              |  vMatrix2 leaves room.
-                                                  This avoid potential permission issues
-                                                  in case vMatrix1 cannot kick vMatrix2
-                                                  on Matrix.
-
-    IRC-Matrix
-    ==========
-      __USER A____            ____USER B___
-     |            |          |             |
-    Matrix      vIRC        IRC       vMatrix  |     Effect
-    -----------------------------------------------------------------------
-               Kickee      Kicker              |  Bot tries to kick Matrix user via /kick.
+    Bot tries to kick user via /kick.
     */
 
+    let matrixRooms = yield this.ircBridge.getStore().getMatrixRoomsForChannel(server, chan);
+    if (matrixRooms.length === 0) {
+        req.log.info("No mapped matrix rooms for IRC channel %s", chan);
+        return;
+    }
+
+    let userId;
     if (kickee.isVirtual) {
-        // A real IRC user is kicking one of us - this is IRC on Matrix kicking.
-        let matrixRooms = yield this.ircBridge.getStore().getMatrixRoomsForChannel(server, chan);
-        if (matrixRooms.length === 0) {
-            req.log.info("No mapped matrix rooms for IRC channel %s", chan);
-            return;
-        }
         let bridgedIrcClient = this.ircBridge.getClientPool().getBridgedClientByNick(
             server, kickee.nick
         );
         if (!bridgedIrcClient || bridgedIrcClient.isBot) {
             return; // unexpected given isVirtual == true, but meh, bail.
         }
-        let promises = matrixRooms.map((room) => {
-            req.log.info("Kicking %s from room %s", bridgedIrcClient.userId, room.getId());
-            return this.ircBridge.getAppServiceBridge().getIntent().kick(
-                room.getId(), bridgedIrcClient.userId,
-                `${kicker.nick} has kicked ${bridgedIrcClient.userId} from ${chan} (${reason})`
-            );
-        });
-        yield Promise.all(promises);
+        userId = bridgedIrcClient.userId;
     }
     else {
-        // the kickee is just some random IRC user, but we still need to bridge this as IRC
-        // will NOT send a PART command. We equally cannot make a fake PART command and
-        // reuse the same code path as we want to force this to go through, regardless of
-        // whether incremental join/leave syncing is turned on.
         let matrixUser = yield this.ircBridge.getMatrixUser(kickee);
         req.log.info("Mapped kickee nick %s to %s", kickee.nick, JSON.stringify(matrixUser));
-        let matrixRooms = yield this.ircBridge.getStore().getMatrixRoomsForChannel(server, chan);
-        if (matrixRooms.length === 0) {
-            req.log.info("No mapped matrix rooms for IRC channel %s", chan);
-            return;
-        }
-        let promises = matrixRooms.map((room) => {
-            req.log.info("Leaving (due to kick) room %s", room.getId());
-            return this.ircBridge.getAppServiceBridge().getIntent(
-                matrixUser.getId()
-            ).leave(room.getId());
-        });
-        yield Promise.all(promises);
+        userId = matrixUser.getId();
     }
+
+    let promises = matrixRooms.map((room) => {
+        req.log.info("Kicking %s from room %s", userId, room.getId());
+        return this.ircBridge.getAppServiceBridge().getIntent().kick(
+            room.getId(), userId,
+            `${kicker.nick} has kicked ${userId} from ${chan} (${reason})`
+        );
+    });
+    yield Promise.all(promises);
 });
 
 /**

--- a/lib/bridge/IrcHandler.js
+++ b/lib/bridge/IrcHandler.js
@@ -534,7 +534,8 @@ IrcHandler.prototype.onKick = Promise.coroutine(function*(req, server,
 
     /*
     We know this is an IRC client kicking someone.
-    Bot tries to kick user via /kick.
+    Bot tries to kick user via /kick. If the kickee is an IRC user, we also make
+    it leave the room, to be sure the member list is sync even if the kick failed.
     */
 
     let matrixRooms = yield this.ircBridge.getStore().getMatrixRoomsForChannel(server, chan);
@@ -567,6 +568,17 @@ IrcHandler.prototype.onKick = Promise.coroutine(function*(req, server,
         );
     });
     yield Promise.all(promises);
+
+    if (!kickee.isVirtual) {
+        // security measure, the kick may have failed, so we make the user leave the room
+        let promisesLeave = matrixRooms.map((room) => {
+            req.log.info("Leaving (due to kick) room %s", room.getId());
+            return this.ircBridge.getAppServiceBridge().getIntent(userId).leave(
+                room.getId()
+            );
+        });
+        yield Promise.all(promisesLeave);
+    }
 });
 
 /**


### PR DESCRIPTION
With this modification, when a kick occurs from an IRC user, the bot always kick the kickee, regardless if it's an IRC user or a Matrix user. This makes kick much more cleaner, and no more "user leaving but actually it's a kick".