### PR TITLE
Show a preview of long messages on IRC

### DIFF
--- a/lib/bridge/MatrixHandler.js
+++ b/lib/bridge/MatrixHandler.js
@@ -12,6 +12,7 @@ var MatrixUser = require("matrix-appservice-bridge").MatrixUser;
 var BridgeRequest = require("../models/BridgeRequest");
 var toIrcLowerCase = require("../irc/formatting").toIrcLowerCase;
 var StateLookup = require('matrix-appservice-bridge').StateLookup;
+var ContentRepo = require('matrix-appservice-bridge').ContentRepo;
 
 function MatrixHandler(ircBridge) {
     this.ircBridge = ircBridge;
@@ -1242,21 +1243,22 @@ MatrixHandler.prototype._sendIrcAction = Promise.coroutine(
 
     // This is true if the upload was a success
     if (result.content_uri) {
-        // Alter event object so that it is treated as if a file has been uploaded
-        event.content.url = result.content_uri;
-        event.content.msgtype = "m.file";
-        event.content.body = "sent a long message: ";
+        // Show a one-line preview with a link to the full message
+        let httpUri = ContentRepo.getHttpUriForMxc(mediaUrl, result.content_uri);
+        let truncatedMsg = " (truncated, full message at " + httpUri + ")";
+        let maxMessageLength = ircClient.unsafeClient.maxLineLength - ircRoom.channel.length
+                                - truncatedMsg.length - 3; // account for ellipsis
 
-        // Create a file event to reflect the recent upload
-        let cli = this.ircBridge.getAppServiceBridge().getClientFactory().getClientAs();
-        let mAction = MatrixAction.fromEvent(cli, event, mediaUrl);
-        let bigFileIrcAction = IrcAction.fromMatrixAction(mAction);
+        // Add ellipsis if we need to get rid of part of the first line
+        let messagePreview = potentialMessages[0].substr(0, maxMessageLength);
+        if (messagePreview != potentialMessages[0]) {
+            messagePreview += '...';
+        }
 
-        // Replace "Posted a File with..."
-        bigFileIrcAction.text = mAction.text;
-
-        // Notify the IRC side of the uploaded text file
-        yield this.ircBridge.sendIrcAction(ircRoom, ircClient, bigFileIrcAction);
+        event.content = {
+            msgtype: "m.text",
+            body:    messagePreview + truncatedMsg
+        };
     }
     else {
         req.log.warn("Sending truncated message");
@@ -1269,18 +1271,18 @@ MatrixHandler.prototype._sendIrcAction = Promise.coroutine(
             msgtype : "m.text",
             body : potentialMessages.splice(0, lineLimit - 1).join('\n') + msg
         };
-
-        // Recreate action from modified event
-        let truncatedIrcAction = IrcAction.fromMatrixAction(
-            MatrixAction.fromEvent(
-                this.ircBridge.getAppServiceBridge().getClientFactory().getClientAs(),
-                event,
-                mediaUrl
-            )
-        );
-
-        yield this.ircBridge.sendIrcAction(ircRoom, ircClient, truncatedIrcAction);
     }
+
+    // Recreate action from modified event
+    let truncatedIrcAction = IrcAction.fromMatrixAction(
+        MatrixAction.fromEvent(
+            this.ircBridge.getAppServiceBridge().getClientFactory().getClientAs(),
+            event,
+            mediaUrl
+        )
+    );
+
+    yield this.ircBridge.sendIrcAction(ircRoom, ircClient, truncatedIrcAction);
 });
 
 /**

--- a/lib/bridge/MatrixHandler.js
+++ b/lib/bridge/MatrixHandler.js
@@ -1245,7 +1245,7 @@ MatrixHandler.prototype._sendIrcAction = Promise.coroutine(
     if (result.content_uri) {
         // Show a one-line preview with a link to the full message
         let httpUri = ContentRepo.getHttpUriForMxc(mediaUrl, result.content_uri);
-        let truncatedMsg = " (truncated, full message at " + httpUri + ")";
+        let truncatedMsg = ` (truncated, full message at ${httpUri})`;
         let maxMessageLength = ircClient.unsafeClient.maxLineLength - ircRoom.channel.length
                                 - truncatedMsg.length - 3; // account for ellipsis
 
@@ -1255,10 +1255,19 @@ MatrixHandler.prototype._sendIrcAction = Promise.coroutine(
             messagePreview += '...';
         }
 
-        event.content = {
-            msgtype: "m.text",
-            body:    messagePreview + truncatedMsg
-        };
+        let match = /^```(\w+)?/.exec(messagePreview);
+        if (match !== null) {
+            let type = match[1] ? ` ${match[1]}` : '';
+            event.content = {
+                msgtype: "m.emote",
+                body:    `sent a${type} code block: ${httpUri}`
+            };
+        } else {
+            event.content = {
+                msgtype: "m.text",
+                body: messagePreview + truncatedMsg
+            };
+        }
     }
     else {
         req.log.warn("Sending truncated message");

--- a/spec/integ/matrix-to-irc.spec.js
+++ b/spec/integ/matrix-to-irc.spec.js
@@ -380,7 +380,7 @@ describe("Matrix-to-IRC message bridging", function() {
                 expect(client.addr).toEqual(roomMapping.server);
                 expect(channel).toEqual(roomMapping.channel);
                 // don't be too brittle when checking this, but I expect to see the
-                // code type (body) and the http url.
+                // code type and the http url.
                 expect(text.indexOf("javascript")).not.toEqual(-1);
                 expect(text.indexOf(tHsUrl)).not.toEqual(-1);
                 done();


### PR DESCRIPTION
This gives users on the IRC side an idea what the long message is about, without flooding the channel with text. This solves an issue some people have where IRC users [aren't willing to click to content they can't see](https://matrix.to/#/!SudviOJlimDvrGdFCY:matrix.org/$1512407915217926ULUZv:matrix.org), and is more [in line with other services](https://matrix.to/#/!SudviOJlimDvrGdFCY:matrix.org/$1512409886253094NDwNA:matrix.org).