### PR TITLE
Remove unused dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "crc": "^3.2.1",
     "extend": "^2.0.0",
     "irc": "matrix-org/node-irc#b1614bc784200c65247784d7b9e9ab867140412d",
-    "jayschema": "^0.3.1",
     "js-yaml": "^3.2.7",
     "matrix-appservice-bridge": "1.4.0a",
     "nedb": "^1.1.2",


### PR DESCRIPTION
jayschema is declared in package.json as a dependency, but is never used.