### PR TITLE
Improve !help message

### DIFF
--- a/lib/bridge/MatrixHandler.js
+++ b/lib/bridge/MatrixHandler.js
@@ -203,33 +203,33 @@ MatrixHandler.prototype._onAdminMessage = Promise.coroutine(function*(req, event
     if (cmd === "!help") {
         let helpCommands = {
             "!join": {
-                example: `!join irc.example.com #channel [key]`,
+                example: `!join [irc.example.net] #channel [key]`,
                 summary: `Join a channel (with optional channel key)`,
             },
             "!nick": {
-                example: `!nick irc.example.com DesiredNick`,
+                example: `!nick [irc.example.net] DesiredNick`,
                 summary: "Change your nick. If no arguments are supplied, " +
                          "your current nick is shown.",
             },
             "!whois": {
-                example: `!whois NickName|@alice:matrix.org`,
+                example: `!whois [irc.example.net] NickName|@alice:matrix.org`,
                 summary: "Do a /whois lookup. If a Matrix User ID is supplied, " +
                          "return information about that user's IRC connection.",
             },
             "!storepass": {
-                example: `!storepass [irc.example.com] passw0rd`,
+                example: `!storepass [irc.example.net] passw0rd`,
                 summary: `Store a NickServ password (server password)`,
             },
             "!removepass": {
-                example: `!removepass [irc.example.com]`,
+                example: `!removepass [irc.example.net]`,
                 summary: `Remove a previously stored NickServ password`,
             },
             "!quit": {
                 example: `!quit`,
-                summary: `Leave all bridged channels and remove your connection to IRC`,
+                summary: `Leave all bridged channels, on all networks, and remove your connections to all networks.`,
             },
             "!cmd": {
-                example: `!cmd [irc.server] COMMAND [arg0 [arg1 [...]]]`,
+                example: `!cmd [irc.example.net] COMMAND [arg0 [arg1 [...]]]`,
                 summary: `Issue a raw IRC command. These will not produce a reply.`,
             },
         };

--- a/lib/bridge/MatrixHandler.js
+++ b/lib/bridge/MatrixHandler.js
@@ -231,7 +231,8 @@ MatrixHandler.prototype._onAdminMessage = Promise.coroutine(function*(req, event
             },
             "!cmd": {
                 example: `!cmd [irc.example.net] COMMAND [arg0 [arg1 [...]]]`,
-                summary: `Issue a raw IRC command. These will not produce a reply.`,
+                summary: "Issue a raw IRC command. These will not produce a reply." +
+                         "(Note that the command must be all uppercase.)",
             },
         };
 

--- a/lib/bridge/MatrixHandler.js
+++ b/lib/bridge/MatrixHandler.js
@@ -226,7 +226,8 @@ MatrixHandler.prototype._onAdminMessage = Promise.coroutine(function*(req, event
             },
             "!quit": {
                 example: `!quit`,
-                summary: `Leave all bridged channels, on all networks, and remove your connections to all networks.`,
+                summary: "Leave all bridged channels, on all networks, and remove your " +
+                         "connections to all networks.",
             },
             "!cmd": {
                 example: `!cmd [irc.example.net] COMMAND [arg0 [arg1 [...]]]`,


### PR DESCRIPTION
Add the missing server argument to the help message for !whois, and make this argument consistent across all command help messages.

(Related: #547)