### PR TITLE
Bump Node version to current LTS release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "4"
+  - "8"
 install: npm install
 script:  let "n = 0";npm run lint; let "n = n + $?";npm run ci-test; let "n = n + $?";(exit $n)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,15 +40,7 @@ This project follows "git flow" semantics. In practice, this means:
  - Create a pull request. If this PR fixes an issue, link to it by referring to its number.
 
 ## Coding notes
-The IRC bridge is compatible on Node.js v4+. It does not use a transpiler like Babel. As such,
-only a subset of ES6 features are natively supported. Some of the common ones which are supported
-are listed below (see http://node.green/ for the full list):
- - Generators
- - \`template ${strings}\`
- - ES6 `class`es
- - `let`, `const`
- - `Map`, `Set`
- - `(arrow) => { } // functions`
+The IRC bridge is compatible on Node.js v8+.
  
 Tests are written in Jasmine. Depending on the pull request, you may be asked to write tests for
 new code.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "app.js",
   "bin": "./bin/matrix-appservice-irc",
   "engines": {
-    "node": ">=4.5"
+    "node": ">=8.9"
   },
   "scripts": {
     "test": "BLUEBIRD_DEBUG=1 jasmine --stop-on-failure=true",


### PR DESCRIPTION
Node 4 was two LTS releases ago now, and there's little value in supporting the previous LTS for this project.  (It's unlikely to be used in environments that are tied to very old versions of Node, and supporting more versions will demand more effort from an already stretched project.)