### PR TITLE
whois case-sensitivity fix

### DIFF
--- a/lib/irc/BridgedClient.js
+++ b/lib/irc/BridgedClient.js
@@ -357,7 +357,7 @@ BridgedClient.prototype.whois = function(nick) {
             resolve({
                 server: self.server,
                 nick: nick,
-                msg: `Whois info for '${nick}': ${info}`
+                msg: `Whois info for '${whois.nick}': ${info}`
             });
         });
     });


### PR DESCRIPTION
Since the whois command is case insensitive, display the nick string from the
server's reply, instead of the string given by the user, so that we display the
nick with correct casing.

Goes with PR matrix-org/node-irc#26

Addresses matrix-org/matrix-appservice-irc#496