### PR TITLE
Correct validation of nicks

### DIFF
--- a/lib/irc/BridgedClient.js
+++ b/lib/irc/BridgedClient.js
@@ -495,8 +495,8 @@ BridgedClient.prototype._getValidNick = function(nick, throwOnInvalid) {
         throw new Error(`Nick '${nick}' contains illegal characters.`);
     }
 
-    // nicks must start with a letter
-    if (!/^[A-Za-z]/.test(n)) {
+    // nicks must start with a letter or special character
+    if (!/^[A-Za-z\]\[\^\\\{\}\-`_\|]/.test(n)) {
         if (throwOnInvalid) {
             throw new Error(`Nick '${nick}' must start with a letter.`);
         }

--- a/lib/irc/BridgedClient.js
+++ b/lib/irc/BridgedClient.js
@@ -505,19 +505,17 @@ BridgedClient.prototype._getValidNick = function(nick, throwOnInvalid) {
         n = "M" + n;
     }
 
-    if (this.unsafeClient) {
-        // nicks can't be too long
-        let maxNickLen = 9; // RFC 1459 default
-        if (this.unsafeClient.supported &&
-                typeof this.unsafeClient.supported.nicklength == "number") {
-            maxNickLen = this.unsafeClient.supported.nicklength;
+    // nicks can't be too long
+    let maxNickLen = 9; // RFC 1459 default
+    if (this.unsafeClient && this.unsafeClient.supported &&
+            typeof this.unsafeClient.supported.nicklength == "number") {
+        maxNickLen = this.unsafeClient.supported.nicklength;
+    }
+    if (n.length > maxNickLen) {
+        if (throwOnInvalid) {
+            throw new Error(`Nick '${nick}' is too long. (Max: ${maxNickLen})`);
         }
-        if (n.length > maxNickLen) {
-            if (throwOnInvalid) {
-                throw new Error(`Nick '${nick}' is too long. (Max: ${maxNickLen})`);
-            }
-            n = n.substr(0, maxNickLen);
-        }
+        n = n.substr(0, maxNickLen);
     }
 
     return n;

--- a/lib/irc/BridgedClient.js
+++ b/lib/irc/BridgedClient.js
@@ -498,7 +498,8 @@ BridgedClient.prototype._getValidNick = function(nick, throwOnInvalid) {
     // nicks must start with a letter or special character
     if (!/^[A-Za-z\]\[\^\\\{\}`_\|]/.test(n)) {
         if (throwOnInvalid) {
-            throw new Error(`Nick '${nick}' must start with a letter or special character (but not dash).`);
+            throw new Error(
+              `Nick '${nick}' must start with a letter or special character (but not dash).`);
         }
         // Add arbitrary letter prefix. This is important for guest user
         // IDs which are all numbers.

--- a/lib/irc/BridgedClient.js
+++ b/lib/irc/BridgedClient.js
@@ -496,9 +496,9 @@ BridgedClient.prototype._getValidNick = function(nick, throwOnInvalid) {
     }
 
     // nicks must start with a letter or special character
-    if (!/^[A-Za-z\]\[\^\\\{\}\-`_\|]/.test(n)) {
+    if (!/^[A-Za-z\]\[\^\\\{\}`_\|]/.test(n)) {
         if (throwOnInvalid) {
-            throw new Error(`Nick '${nick}' must start with a letter.`);
+            throw new Error(`Nick '${nick}' must start with a letter or special character (but not dash).`);
         }
         // Add arbitrary letter prefix. This is important for guest user
         // IDs which are all numbers.

--- a/lib/irc/BridgedClient.js
+++ b/lib/irc/BridgedClient.js
@@ -505,17 +505,19 @@ BridgedClient.prototype._getValidNick = function(nick, throwOnInvalid) {
         n = "M" + n;
     }
 
-    // nicks can't be too long
-    let maxNickLen = 9; // RFC 1459 default
-    if (this.unsafeClient && this.unsafeClient.supported &&
-            typeof this.unsafeClient.supported.nicklength == "number") {
-        maxNickLen = this.unsafeClient.supported.nicklength;
-    }
-    if (n.length > maxNickLen) {
-        if (throwOnInvalid) {
-            throw new Error(`Nick '${nick}' is too long. (Max: ${maxNickLen})`);
+    if (this.unsafeClient) {
+        // nicks can't be too long
+        let maxNickLen = 9; // RFC 1459 default
+        if (this.unsafeClient.supported &&
+                typeof this.unsafeClient.supported.nicklength == "number") {
+            maxNickLen = this.unsafeClient.supported.nicklength;
         }
-        n = n.substr(0, maxNickLen);
+        if (n.length > maxNickLen) {
+            if (throwOnInvalid) {
+                throw new Error(`Nick '${nick}' is too long. (Max: ${maxNickLen})`);
+            }
+            n = n.substr(0, maxNickLen);
+        }
     }
 
     return n;

--- a/spec/unit/BridgedClient.spec.js
+++ b/spec/unit/BridgedClient.spec.js
@@ -86,12 +86,12 @@ describe("BridgedClient._getValidNick", () => {
 
   it("fails if the nick starts with a dash", () => {
     expect(() => {client._getValidNick("-Bob", true)}).
-      toThrowError("Nick '-Bob' contains illegal characters.")
+      toThrowError("Nick '-Bob' must start with a letter or special character (but not dash).")
   })
 
   it("fails if the nick starts with a number", () => {
     expect(() => {client._getValidNick("2Bob", true)}).
-      toThrowError("Nick '2Bob' must start with a letter.")
+      toThrowError("Nick '2Bob' must start with a letter or special character (but not dash).")
   })
 
   it("fails if the nick is longer than nine characters", () => {

--- a/spec/unit/BridgedClient.spec.js
+++ b/spec/unit/BridgedClient.spec.js
@@ -19,7 +19,10 @@ describe("BridgedClient._getValidNick", () => {
       }
     }
 
+    let unsafeClientMock = {}
+
     client = new BridgedClient(serverMock, ircClientConfigMock)
+    client.unsafeClient = unsafeClientMock
   })
 
   it("fails if the nick contains illegal characters", () => {

--- a/spec/unit/BridgedClient.spec.js
+++ b/spec/unit/BridgedClient.spec.js
@@ -1,0 +1,106 @@
+"use strict";
+const BridgedClient = require("../../lib/irc/BridgedClient.js");
+
+describe("BridgedClient._getValidNick", () => {
+  let client;
+
+  beforeEach(() => {
+    const serverMock = {
+      domain: "example.net"
+    }
+
+    const ircClientConfigMock = {
+      getDesiredNick: () => {
+        return "a_nick";
+      },
+
+      getPassword: () => {
+        return "p@$$w0rd";
+      }
+    }
+
+    client = new BridgedClient(serverMock, ircClientConfigMock)
+  })
+
+  it("fails if the nick contains illegal characters", () => {
+    expect(() => {client._getValidNick("S@l", true)}).
+      toThrowError("Nick 'S@l' contains illegal characters.")
+
+    expect(() => {client._getValidNick("B!ll", true)}).
+      toThrowError("Nick 'B!ll' contains illegal characters.")
+
+    expect(() => {client._getValidNick("Sa#", true)}).
+      toThrowError("Nick 'Sa#' contains illegal characters.")
+
+    expect(() => {client._getValidNick("Ca$h", true)}).
+      toThrowError("Nick 'Ca$h' contains illegal characters.")
+
+    expect(() => {client._getValidNick("two%", true)}).
+      toThrowError("Nick 'two%' contains illegal characters.")
+
+    expect(() => {client._getValidNick("b&", true)}).
+      toThrowError("Nick 'b&' contains illegal characters.")
+
+    expect(() => {client._getValidNick("A*", true)}).
+      toThrowError("Nick 'A*' contains illegal characters.")
+
+    expect(() => {client._getValidNick("main()", true)}).
+      toThrowError("Nick 'main()' contains illegal characters.")
+
+    expect(() => {client._getValidNick("quote\"", true)}).
+      toThrowError("Nick 'quote\"' contains illegal characters.")
+
+    expect(() => {client._getValidNick("f'", true)}).
+      toThrowError("Nick 'f'' contains illegal characters.")
+
+    expect(() => {client._getValidNick("sla/sh", true)}).
+      toThrowError("Nick 'sla/sh' contains illegal characters.")
+
+    expect(() => {client._getValidNick("dot.org", true)}).
+      toThrowError("Nick 'dot.org' contains illegal characters.")
+
+    expect(() => {client._getValidNick("C,S,V", true)}).
+      toThrowError("Nick 'C,S,V' contains illegal characters.")
+
+    expect(() => {client._getValidNick("one+one", true)}).
+      toThrowError("Nick 'one+one' contains illegal characters.")
+
+    expect(() => {client._getValidNick("soup_o<tag>", true)}).
+      toThrowError("Nick 'soup_o<tag>' contains illegal characters.")
+
+    expect(() => {client._getValidNick("wavey~", true)}).
+      toThrowError("Nick 'wavey~' contains illegal characters.")
+
+    expect(() => {client._getValidNick("y;", true)}).
+      toThrowError("Nick 'y;' contains illegal characters.")
+
+    expect(() => {client._getValidNick("x:y", true)}).
+      toThrowError("Nick 'x:y' contains illegal characters.")
+
+    expect(() => {client._getValidNick("what?", true)}).
+      toThrowError("Nick 'what?' contains illegal characters.")
+
+    expect(() => {client._getValidNick("hey!", true)}).
+      toThrowError("Nick 'hey!' contains illegal characters.")
+  })
+
+  it("fails if the nick starts with a dash", () => {
+    expect(() => {client._getValidNick("-Bob", true)}).
+      toThrowError("Nick '-Bob' contains illegal characters.")
+  })
+
+  it("fails if the nick starts with a number", () => {
+    expect(() => {client._getValidNick("2Bob", true)}).
+      toThrowError("Nick '2Bob' must start with a letter.")
+  })
+
+  it("fails if the nick is longer than nine characters", () => {
+    expect(() => {client._getValidNick("_123456789", true)}).
+      toThrowError("Nick '_123456789' is too long. (Max: 9)")
+  })
+
+  it("returns the input nick if valid", () => {
+    let uglyNick = "l33thax0r";
+    expect(client._getValidNick(uglyNick, true)).toBe(uglyNick)
+  })
+})


### PR DESCRIPTION
Correct the regular expression for validating the starting character of a nick
to conform to RFC 2812 § 2.3.1.  It was considering only letters to be valid
starting characters, whereas the standard allows letters or special characters.

Fixes matrix-org/matrix-appservice-irc#467