### PR TITLE
Drop support for Node 4, add support for 6-10.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: node_js
 node_js:
-  - "4"
+  - "6"
+  - "8"
+  - "10"
 install: npm install
 script:  let "n = 0";npm run lint; let "n = n + $?";npm run ci-test; let "n = n + $?";(exit $n)
 


### PR DESCRIPTION
Fixes #586 

This simply makes Travis test against the newer versions of node. If things break, there will be more changes on this PR.