### PR TITLE
[Part 2] Drop support for Node 4, add support for 6-10.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ you use this method, the bridge can be run via `node app.js`.
 
 
 ### Requirements
- - Node.js v4.5 or above.
+ - Node.js **v6.9** or above.
  - A Matrix homeserver you control running Synapse v0.18.5-rc3 or above.
 
 ## 2. Configuration

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "app.js",
   "bin": "./bin/matrix-appservice-irc",
   "engines": {
-    "node": ">=4.5"
+    "node": ">=6.9"
   },
   "scripts": {
     "test": "BLUEBIRD_DEBUG=1 jasmine --stop-on-failure=true",


### PR DESCRIPTION
Forgot to bump the node version in the README.md and package.json