### PR TITLE
Disable !join when dynamic channels are off

### DIFF
--- a/lib/bridge/MatrixHandler.js
+++ b/lib/bridge/MatrixHandler.js
@@ -357,7 +357,7 @@ MatrixHandler.prototype._onAdminMessage = Promise.coroutine(function*(req, event
         if (!ircChannel || ircChannel.indexOf("#") !== 0) {
             errText = "Format: '!join irc.example.com #channel [key]'";
         }
-        else if (ircServer.hasInviteRooms() && !ircServer.isInWhitelist(event.user_id)) {
+        else if (!ircServer.canJoinRooms(event.user_id)) {
             errText = "You are not authorised to join channels on this server.";
         }
 

--- a/lib/irc/IrcServer.js
+++ b/lib/irc/IrcServer.js
@@ -221,10 +221,14 @@ IrcServer.prototype.isExcludedChannel = function(channel) {
     return this.config.dynamicChannels.exclude.indexOf(channel) !== -1;
 };
 
-IrcServer.prototype.hasInviteRooms = function() {
-    return (
-        this.config.dynamicChannels.enabled && this.getJoinRule() === "invite"
-    );
+IrcServer.prototype.canJoinRooms = function(userId) {
+    if (!this.config.dynamicChannels.enabled) {
+        return false;
+    }
+    if (this.getJoinRule() === "public") {
+        return true;
+    }
+    return this.isInWhitelist(userId);
 };
 
 // check if this server dynamically create rooms with aliases.


### PR DESCRIPTION
AFAICT this can lead to private, statically configured channels getting
exposed to the public.