### PR TITLE
Check we are joined on mapped rooms before trying to join

### DIFF
--- a/lib/bridge/IrcBridge.js
+++ b/lib/bridge/IrcBridge.js
@@ -807,7 +807,7 @@ IrcBridge.prototype._loginToServer = Promise.coroutine(function*(server) {
             });
         }, 500 * num);
         num += 1;
-    });yield
+    });
 });
 
 IrcBridge.prototype.checkNickExists = function(server, nick) {
@@ -905,8 +905,13 @@ IrcBridge.prototype.getBotClient = function(server) {
         return this._clientPool.getBot(server);
     });
 }
-
 IrcBridge.prototype._fetchJoinedRooms = Promise.coroutine(function*() {
+    /** Fetching joined rooms is quicker on larger homeservers than trying to
+     * /join each room in the mappings list. To ensure we start quicker,
+     * the bridge will block on this call rather than blocking on all join calls.
+     * On the most overloaded servers even this call may take several attempts,
+     * so it will block indefinitely.
+     */
     const bot = this._bridge.getBot();
     if (bot.getJoinedRooms == undefined) {
         return;
@@ -914,19 +919,16 @@ IrcBridge.prototype._fetchJoinedRooms = Promise.coroutine(function*() {
     let gotRooms = false;
     while (!gotRooms) {
         try {
-            const roomids = yield bot.getJoinedRooms();
+            const roomIds = yield bot.getJoinedRooms();
             gotRooms = true;
-            this.joinedRoomList = roomids;
-            log.info(`ASBot is in ${roomids.length} rooms!`);
+            this.joinedRoomList = roomIds;
+            log.info(`ASBot is in ${roomIds.length} rooms!`);
         }
         catch (ex) {
-            // We should retry this, because it's still quicker than rejoining everything.
             log.error(`Failed to fetch roomlist from joined_rooms: ${ex}. Retrying`);
-            yield Promise.delay(DELAY_FETCH_ROOM_LIST_MS); // wait a bit before retrying
+            yield Promise.delay(DELAY_FETCH_ROOM_LIST_MS);
         }
     }
-
-
 });
 
 IrcBridge.DEFAULT_LOCALPART = "appservice-irc";

--- a/lib/bridge/IrcBridge.js
+++ b/lib/bridge/IrcBridge.js
@@ -908,6 +908,9 @@ IrcBridge.prototype.getBotClient = function(server) {
 
 IrcBridge.prototype._fetchJoinedRooms = Promise.coroutine(function*() {
     const bot = this._bridge.getBot();
+    if (bot.getJoinedRooms == undefined) {
+        return;
+    }
     let gotRooms = false;
     while (!gotRooms) {
         try {

--- a/lib/bridge/IrcBridge.js
+++ b/lib/bridge/IrcBridge.js
@@ -908,7 +908,7 @@ IrcBridge.prototype.getBotClient = function(server) {
 
 IrcBridge.prototype._fetchJoinedRooms = Promise.coroutine(function*() {
     const bot = this._bridge.getBot();
-    const gotRooms = false;
+    let gotRooms = false;
     while (!gotRooms) {
         try {
             const roomids = yield bot.getJoinedRooms();

--- a/lib/bridge/IrcBridge.js
+++ b/lib/bridge/IrcBridge.js
@@ -271,6 +271,9 @@ IrcBridge.prototype.run = Promise.coroutine(function*(port) {
         );
     }
 
+    log.info("Fetching Matrix rooms that are already joined to...");
+    yield this._fetchJoinedRooms();
+
     // start things going
     log.info("Joining mapped Matrix rooms...");
     yield this._joinMappedMatrixRooms();
@@ -895,6 +898,19 @@ IrcBridge.prototype.getBotClient = function(server) {
     return this._loginToServer(server).then(() => {
         return this._clientPool.getBot(server);
     });
+}
+
+IrcBridge.prototype._fetchJoinedRooms = function*() {
+    const bot = this._bridge.getBot();
+    try {
+        const roomids = yield bot.getJoinedRooms();
+        console.log(roomids);
+    }
+    catch (ex) {
+        // We should retry this, because it's still quicker than rejoining everything.
+        console.log(ex);
+    }
+
 }
 
 IrcBridge.DEFAULT_LOCALPART = "appservice-irc";

--- a/lib/bridge/IrcBridge.js
+++ b/lib/bridge/IrcBridge.js
@@ -28,6 +28,7 @@ var Provisioner = require("../provisioning/Provisioner.js");
 var PublicitySyncer = require("./PublicitySyncer.js");
 
 const DELAY_TIME_MS = 10 * 1000;
+const DELAY_FETCH_ROOM_LIST_MS = 3 * 1000;
 const DEAD_TIME_MS = 5 * 60 * 1000;
 const ACTION_TYPE_TO_MSGTYPE = {
     message: "m.text",
@@ -44,6 +45,7 @@ function IrcBridge(config, registration) {
     this.memberListSyncers = {
     //  domain: MemberListSyncer
     };
+    this.joinedRoomList = [];
 
     // Dependency graph
     this.matrixHandler = new MatrixHandler(this);
@@ -431,6 +433,10 @@ IrcBridge.prototype.isStartedUp = function() {
 IrcBridge.prototype._joinMappedMatrixRooms = Promise.coroutine(function*() {
     let roomIds = yield this.getStore().getRoomIdsFromConfig();
     let promises = roomIds.map((roomId) => {
+        if (this.joinedRoomList.includes(roomId)) {
+            log.debug(`Not joining ${roomId} because we are marked as joined`);
+            return Promise.resolve();
+        }
         return this._bridge.getIntent().join(roomId);
     });
     yield promiseutil.allSettled(promises);
@@ -801,7 +807,7 @@ IrcBridge.prototype._loginToServer = Promise.coroutine(function*(server) {
             });
         }, 500 * num);
         num += 1;
-    });
+    });yield
 });
 
 IrcBridge.prototype.checkNickExists = function(server, nick) {
@@ -900,18 +906,25 @@ IrcBridge.prototype.getBotClient = function(server) {
     });
 }
 
-IrcBridge.prototype._fetchJoinedRooms = function*() {
+IrcBridge.prototype._fetchJoinedRooms = Promise.coroutine(function*() {
     const bot = this._bridge.getBot();
-    try {
-        const roomids = yield bot.getJoinedRooms();
-        console.log(roomids);
-    }
-    catch (ex) {
-        // We should retry this, because it's still quicker than rejoining everything.
-        console.log(ex);
+    const gotRooms = false;
+    while (!gotRooms) {
+        try {
+            const roomids = yield bot.getJoinedRooms();
+            gotRooms = true;
+            this.joinedRoomList = roomids;
+            log.info(`ASBot is in ${roomids.length} rooms!`);
+        }
+        catch (ex) {
+            // We should retry this, because it's still quicker than rejoining everything.
+            log.error(`Failed to fetch roomlist from joined_rooms: ${ex}. Retrying`);
+            yield Promise.delay(DELAY_FETCH_ROOM_LIST_MS); // wait a bit before retrying
+        }
     }
 
-}
+
+});
 
 IrcBridge.DEFAULT_LOCALPART = "appservice-irc";
 

--- a/spec/util/client-sdk-mock.js
+++ b/spec/util/client-sdk-mock.js
@@ -43,7 +43,6 @@ function MockClient(config) {
         if (endpoint === "/joined_rooms") {
             return Promise.resolve([]);
         }
-        console.log("BAAAAAAAAAAAAAAAAAAAAAAAA:",method);
         return Promise.resolve();
     });
 

--- a/spec/util/client-sdk-mock.js
+++ b/spec/util/client-sdk-mock.js
@@ -13,7 +13,7 @@ function MockClient(config) {
         userId: config.userId
     };
     this._http = { opts: {} };
-    this._http.authedRequestWithPrefix = jasmine.createSpy("sdk.authedRequestWithPrefix");
+    this._http.authedRequestWithPrefix = jasmine.createSpy("sdk.authedRequestWithPrefix()");
     this.register = jasmine.createSpy("sdk.register(username, password)");
     this.createRoom = jasmine.createSpy("sdk.createRoom(opts)");
     this.joinRoom = jasmine.createSpy("sdk.joinRoom(idOrAlias, opts)");
@@ -34,10 +34,17 @@ function MockClient(config) {
     this.setPresence = jasmine.createSpy("sdk.setPresence()");
 
     this.setPresence.and.returnValue(Promise.resolve({}));
-
     // mock up joinRoom immediately since it is called when joining mapped IRC<-->Matrix rooms
     this.joinRoom.and.callFake(function() {
         return Promise.resolve({});
+    });
+
+    this._http.authedRequestWithPrefix.and.callFake(function(a, method, endpoint) {
+        if (endpoint === "/joined_rooms") {
+            return Promise.resolve([]);
+        }
+        console.log("BAAAAAAAAAAAAAAAAAAAAAAAA:",method);
+        return Promise.resolve();
     });
 
     // mock up sendStateEvent


### PR DESCRIPTION
Because synapse will attempt to join regardless of the actual join state, and one call to  ``joined_rooms`` is faster than x number of ``join`` calls.

This fixes #593 