### PR TITLE
Limit concurrent reconnects

### DIFF
--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -295,6 +295,14 @@ ircService:
         # a FIFO queue.
         # Default: 5000 (5 seconds)
         reconnectIntervalMs: 5000
+        # The number of concurrent reconnects if a user has been disconnected unexpectedly
+        # (e.g. a netsplit). You should set this to a reasonably high number so that
+        # bridges are not waiting an eternity to reconnect all it's users if 
+        # we see a massive number of disconnect. This is unrelated to the reconnectIntervalMs
+        # setting above which is for connecting on restart of the bridge. Set to 0 to 
+        # immediately try to reconnect all users.
+        # Default: 50
+        concurrentReconnectLimit: 50
         # The number of lines to allow being sent by the IRC client that has received
         # a large block of text to send from matrix. If the number of lines that would
         # be sent is > lineLimit, the text will instead be uploaded to matrix and the

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -297,7 +297,7 @@ ircService:
         reconnectIntervalMs: 5000
         # The number of concurrent reconnects if a user has been disconnected unexpectedly
         # (e.g. a netsplit). You should set this to a reasonably high number so that
-        # bridges are not waiting an eternity to reconnect all it's users if 
+        # bridges are not waiting an eternity to reconnect all its clients if 
         # we see a massive number of disconnect. This is unrelated to the reconnectIntervalMs
         # setting above which is for connecting on restart of the bridge. Set to 0 to 
         # immediately try to reconnect all users.

--- a/lib/irc/BridgedClient.js
+++ b/lib/irc/BridgedClient.js
@@ -142,7 +142,6 @@ BridgedClient.prototype.connect = Promise.coroutine(function*() {
 
         this.inst = connInst;
         this.unsafeClient = connInst.client;
-        this.log.debug("connected!");
         this.emit("client-connected", this);
         // we may have been assigned a different nick, so update it from source
         this.nick = connInst.client.nick;

--- a/lib/irc/ClientPool.js
+++ b/lib/irc/ClientPool.js
@@ -4,11 +4,12 @@
  * and may be closed for a variety of reasons.
  */
 "use strict";
-var stats = require("../config/stats");
-var log = require("../logging").get("ClientPool");
-var Promise = require("bluebird");
+const stats = require("../config/stats");
+const log = require("../logging").get("ClientPool");
+const Promise = require("bluebird");
+const QueuePool = require("../util/QueuePool");
 
-const RECONNECT_TIME_MS = 1000;
+const RECONNECT_CLIENT_QUEUE_SIZE = 20;
 
 function ClientPool(ircBridge) {
     this._ircBridge = ircBridge;
@@ -35,6 +36,13 @@ function ClientPool(ircBridge) {
     this._virtualClientCounts = {
         // server_domain: number
     };
+    this._reconnectQueue = new QueuePool( 
+        RECONNECT_CLIENT_QUEUE_SIZE,
+        (item) => {
+            log.info(`Reconnecting client. ${this._reconnectQueue.waitingItems} left.`);
+            return this._reconnectClient(item);
+        }
+    );
 }
 
 ClientPool.prototype.killAllClients = function() {
@@ -276,25 +284,27 @@ ClientPool.prototype._onClientDisconnected = function(bridgedClient) {
     // remove ref to the disconnected client so it can be GC'd. If we don't do this,
     // the timeout below holds it in a closure, preventing it from being GC'd.
     bridgedClient = undefined;
-    setTimeout(function() {
-        cli.connect().then(function() {
-            log.info(
-                "<%s> Reconnected %s@%s", cli._id, cli.nick, cli.server.domain
-            );
-            if (chanList.length > 0) {
-                log.info("<%s> Rejoining %s channels", cli._id, chanList.length);
-                chanList.forEach(function(c) {
-                    cli.joinChannel(c);
-                });
-            }
-            self._sendConnectionMetric(cli.server);
-        }, function(e) {
-            log.error(
-                "<%s> Failed to reconnect %s@%s", cli._id, cli.nick, cli.server.domain
-            );
-        });
-    }, RECONNECT_TIME_MS);
+    this._reconnectQueue.enqueue(cli._id, {cli, chanList});
 };
+
+ClientPool.prototype._reconnectClient = function({cli, chanList}) {
+    return cli.connect().then(() => {
+        log.info(
+            "<%s> Reconnected %s@%s", cli._id, cli.nick, cli.server.domain
+        );
+        if (chanList.length > 0) {
+            log.info("<%s> Rejoining %s channels", cli._id, chanList.length);
+            chanList.forEach(function(c) {
+                cli.joinChannel(c);
+            });
+        }
+        this._sendConnectionMetric(cli.server);
+    }, function(e) {
+        log.error(
+            "<%s> Failed to reconnect %s@%s", cli._id, cli.nick, cli.server.domain
+        );
+    });
+}
 
 ClientPool.prototype._onNickChange = function(bridgedClient, oldNick, newNick) {
     this._virtualClients[bridgedClient.server.domain].nicks[oldNick] = undefined;

--- a/lib/irc/ClientPool.js
+++ b/lib/irc/ClientPool.js
@@ -77,7 +77,7 @@ ClientPool.prototype.getOrCreateReconnQueue = function(server) {
         q = this._reconnectQueues[server.domain] = new QueuePool(
             server.getConcurrentReconnectLimit(),
             (item) => {
-                log.info(`Reconnecting client. ${this._reconnectQueue.waitingItems} left.`);
+                log.info(`Reconnecting client. ${q.waitingItems} left.`);
                 return this._reconnectClient(item);
             }
         );
@@ -308,7 +308,6 @@ ClientPool.prototype._onClientDisconnected = function(bridgedClient) {
         });
         return;
     }
-
     queue.enqueue(cli._id, {
         cli: cli,
         chanList: chanList,

--- a/lib/irc/ClientPool.js
+++ b/lib/irc/ClientPool.js
@@ -68,7 +68,7 @@ ClientPool.prototype.killAllClients = function() {
     );
 }
 
-ClientPool.prototype.getOrCreateReconnQueue = function(server) {
+ClientPool.prototype.getOrCreateReconnectQueue = function(server) {
     if (server.getConcurrentReconnectLimit() === 0) {
         return null;
     }
@@ -300,7 +300,7 @@ ClientPool.prototype._onClientDisconnected = function(bridgedClient) {
         log.info(`Dropping ${cli._id} ${cli.nick} because they are not joined to any channels`);
         return;
     }
-    let queue = this.getOrCreateReconnQueue(cli.server);
+    let queue = this.getOrCreateReconnectQueue(cli.server);
     if (queue === null) {
         this._reconnectClient({
             cli: cli,

--- a/lib/irc/ClientPool.js
+++ b/lib/irc/ClientPool.js
@@ -284,7 +284,7 @@ ClientPool.prototype._onClientDisconnected = function(bridgedClient) {
     // the timeout below holds it in a closure, preventing it from being GC'd.
     bridgedClient = undefined;
 
-    if(chanList.length === 0) {
+    if (chanList.length === 0) {
         log.info(`Dropping ${cli._id} ${cli.nick} because they are not joined to any channels`);
         return;
     }

--- a/lib/irc/ClientPool.js
+++ b/lib/irc/ClientPool.js
@@ -9,7 +9,7 @@ const log = require("../logging").get("ClientPool");
 const Promise = require("bluebird");
 const QueuePool = require("../util/QueuePool");
 
-const RECONNECT_CLIENT_QUEUE_SIZE = 50;
+const CONCURRENT_RECONNECT_LIMIT = 50;
 
 function ClientPool(ircBridge) {
     this._ircBridge = ircBridge;
@@ -37,7 +37,7 @@ function ClientPool(ircBridge) {
         // server_domain: number
     };
     this._reconnectQueue = new QueuePool(
-        RECONNECT_CLIENT_QUEUE_SIZE,
+        CONCURRENT_RECONNECT_LIMIT,
         (item) => {
             log.info(`Reconnecting client. ${this._reconnectQueue.waitingItems} left.`);
             return this._reconnectClient(item);

--- a/lib/irc/ClientPool.js
+++ b/lib/irc/ClientPool.js
@@ -9,8 +9,6 @@ const log = require("../logging").get("ClientPool");
 const Promise = require("bluebird");
 const QueuePool = require("../util/QueuePool");
 
-const CONCURRENT_RECONNECT_LIMIT = 50;
-
 function ClientPool(ircBridge) {
     this._ircBridge = ircBridge;
     // The list of bot clients on servers (not specific users)
@@ -36,13 +34,10 @@ function ClientPool(ircBridge) {
     this._virtualClientCounts = {
         // server_domain: number
     };
-    this._reconnectQueue = new QueuePool(
-        CONCURRENT_RECONNECT_LIMIT,
-        (item) => {
-            log.info(`Reconnecting client. ${this._reconnectQueue.waitingItems} left.`);
-            return this._reconnectClient(item);
-        }
-    );
+    
+    this._reconnectQueues = {
+        // server_domain: QueuePool
+    };
 }
 
 ClientPool.prototype.killAllClients = function() {
@@ -72,6 +67,23 @@ ClientPool.prototype.killAllClients = function() {
         )
     );
 }
+
+ClientPool.prototype.getOrCreateReconnQueue = function(server) {
+    if (server.getConcurrentReconnectLimit() === 0) {
+        return null;
+    }
+    let q = this._reconnectQueues[server.domain];
+    if (q === undefined) {
+        q = this._reconnectQueues[server.domain] = new QueuePool(
+            server.getConcurrentReconnectLimit(),
+            (item) => {
+                log.info(`Reconnecting client. ${this._reconnectQueue.waitingItems} left.`);
+                return this._reconnectClient(item);
+            }
+        );
+    }
+    return q;
+};
 
 ClientPool.prototype.setBot = function(server, client) {
     this._botClients[server.domain] = client;
@@ -288,8 +300,16 @@ ClientPool.prototype._onClientDisconnected = function(bridgedClient) {
         log.info(`Dropping ${cli._id} ${cli.nick} because they are not joined to any channels`);
         return;
     }
-
-    this._reconnectQueue.enqueue(cli._id, {
+    let queue = this.getOrCreateReconnQueue(bridgedClient.server);
+    if (queue === null) {
+        this._reconnectClient({
+            cli: cli,
+            chanList: chanList,
+        });
+        return;
+    }
+    
+    queue.enqueue(cli._id, {
         cli: cli,
         chanList: chanList,
     });

--- a/lib/irc/ClientPool.js
+++ b/lib/irc/ClientPool.js
@@ -9,7 +9,7 @@ const log = require("../logging").get("ClientPool");
 const Promise = require("bluebird");
 const QueuePool = require("../util/QueuePool");
 
-const RECONNECT_CLIENT_QUEUE_SIZE = 20;
+const RECONNECT_CLIENT_QUEUE_SIZE = 50;
 
 function ClientPool(ircBridge) {
     this._ircBridge = ircBridge;

--- a/lib/irc/ClientPool.js
+++ b/lib/irc/ClientPool.js
@@ -261,10 +261,6 @@ ClientPool.prototype._onClientDisconnected = function(bridgedClient) {
         return;
     }
     // Reconnect this user
-    log.debug(
-        "onClientDisconnected: <%s> Reconnecting %s@%s in %sms",
-        bridgedClient._id, bridgedClient.nick, bridgedClient.server.domain, RECONNECT_TIME_MS
-    );
     // change the client config to use the current nick rather than the desired nick. This
     // makes sure that the client attempts to reconnect with the *SAME* nick, and also draws
     // from the latest !nick change, as the client config here may be very very old.

--- a/lib/irc/ClientPool.js
+++ b/lib/irc/ClientPool.js
@@ -326,7 +326,7 @@ ClientPool.prototype._reconnectClient = function(cliChan) {
             cli.joinChannel(c);
         });
         this._sendConnectionMetric(cli.server);
-    }, function(e) {
+    }, (e) => {
         log.error(
             "<%s> Failed to reconnect %s@%s", cli._id, cli.nick, cli.server.domain
         );

--- a/lib/irc/ClientPool.js
+++ b/lib/irc/ClientPool.js
@@ -300,7 +300,7 @@ ClientPool.prototype._onClientDisconnected = function(bridgedClient) {
         log.info(`Dropping ${cli._id} ${cli.nick} because they are not joined to any channels`);
         return;
     }
-    let queue = this.getOrCreateReconnQueue(bridgedClient.server);
+    let queue = this.getOrCreateReconnQueue(cli.server);
     if (queue === null) {
         this._reconnectClient({
             cli: cli,

--- a/lib/irc/ClientPool.js
+++ b/lib/irc/ClientPool.js
@@ -283,6 +283,12 @@ ClientPool.prototype._onClientDisconnected = function(bridgedClient) {
     // remove ref to the disconnected client so it can be GC'd. If we don't do this,
     // the timeout below holds it in a closure, preventing it from being GC'd.
     bridgedClient = undefined;
+
+    if(chanList.length === 0) {
+        log.info(`Dropping ${cli._id} ${cli.nick} because they are not joined to any channels`);
+        return;
+    }
+
     this._reconnectQueue.enqueue(cli._id, {
         cli: cli,
         chanList: chanList,
@@ -296,12 +302,10 @@ ClientPool.prototype._reconnectClient = function(cliChan) {
         log.info(
             "<%s> Reconnected %s@%s", cli._id, cli.nick, cli.server.domain
         );
-        if (chanList.length > 0) {
-            log.info("<%s> Rejoining %s channels", cli._id, chanList.length);
-            chanList.forEach(function(c) {
-                cli.joinChannel(c);
-            });
-        }
+        log.info("<%s> Rejoining %s channels", cli._id, chanList.length);
+        chanList.forEach(function(c) {
+            cli.joinChannel(c);
+        });
         this._sendConnectionMetric(cli.server);
     }, function(e) {
         log.error(

--- a/lib/irc/ClientPool.js
+++ b/lib/irc/ClientPool.js
@@ -34,7 +34,7 @@ function ClientPool(ircBridge) {
     this._virtualClientCounts = {
         // server_domain: number
     };
-    
+
     this._reconnectQueues = {
         // server_domain: QueuePool
     };
@@ -308,7 +308,7 @@ ClientPool.prototype._onClientDisconnected = function(bridgedClient) {
         });
         return;
     }
-    
+
     queue.enqueue(cli._id, {
         cli: cli,
         chanList: chanList,

--- a/lib/irc/ClientPool.js
+++ b/lib/irc/ClientPool.js
@@ -36,7 +36,7 @@ function ClientPool(ircBridge) {
     this._virtualClientCounts = {
         // server_domain: number
     };
-    this._reconnectQueue = new QueuePool( 
+    this._reconnectQueue = new QueuePool(
         RECONNECT_CLIENT_QUEUE_SIZE,
         (item) => {
             log.info(`Reconnecting client. ${this._reconnectQueue.waitingItems} left.`);
@@ -280,14 +280,18 @@ ClientPool.prototype._onClientDisconnected = function(bridgedClient) {
         cliConfig, bridgedClient.matrixUser, bridgedClient.isBot
     );
     var chanList = bridgedClient.chanList;
-    var self = this;
     // remove ref to the disconnected client so it can be GC'd. If we don't do this,
     // the timeout below holds it in a closure, preventing it from being GC'd.
     bridgedClient = undefined;
-    this._reconnectQueue.enqueue(cli._id, {cli, chanList});
+    this._reconnectQueue.enqueue(cli._id, {
+        cli: cli,
+        chanList: chanList,
+    });
 };
 
-ClientPool.prototype._reconnectClient = function({cli, chanList}) {
+ClientPool.prototype._reconnectClient = function(cliChan) {
+    const cli = cliChan.cli;
+    const chanList = cliChan.chanList;
     return cli.connect().then(() => {
         log.info(
             "<%s> Reconnected %s@%s", cli._id, cli.nick, cli.server.domain

--- a/lib/irc/ConnectionInstance.js
+++ b/lib/irc/ConnectionInstance.js
@@ -19,7 +19,9 @@ const PING_TIMEOUT_MS = 1000 * 60 * 10;
 const THROTTLE_WAIT_MS = 20 * 1000;
 
 // The minimum time to wait between connection attempts if the kernel has given us
-// a net_error.
+// a net_error. Usually these come about due to a network being unavaliable or resource
+// starvation. Unlike throttling which is ircd based, we should retry sooner to see if
+// the kernel is happy now.
 const NET_ERROR_WAIT_MS = 5 * 1000;
 
 const BANNED_TIME_MS = 6 * 60 * 60 * 1000; // once every 6 hours

--- a/lib/irc/ConnectionInstance.js
+++ b/lib/irc/ConnectionInstance.js
@@ -18,6 +18,10 @@ const PING_TIMEOUT_MS = 1000 * 60 * 10;
 // due to throttling.
 const THROTTLE_WAIT_MS = 20 * 1000;
 
+// The minimum time to wait between connection attempts if the kernel has given us
+// a net_error.
+const NET_ERROR_WAIT_MS = 5 * 1000;
+
 const BANNED_TIME_MS = 6 * 60 * 60 * 1000; // once every 6 hours
 
 // The rate at which to send pings to the IRCd if the client is being quiet for a while.
@@ -358,7 +362,7 @@ ConnectionInstance.create = Promise.coroutine(function*(server, opts, onCreatedC
 
             if (err.message === "net_error") {
                 // This is the kernel complaining, we should back off.
-                retryTimeMs += THROTTLE_WAIT_MS;
+                retryTimeMs += NET_ERROR_WAIT_MS;
             }
 
             if (err.message === "throttled") {

--- a/lib/irc/ConnectionInstance.js
+++ b/lib/irc/ConnectionInstance.js
@@ -355,7 +355,7 @@ ConnectionInstance.create = Promise.coroutine(function*(server, opts, onCreatedC
             log.error(
                 `ConnectionInstance.connect failed after ${connAttempts} attempts (${err.message})`
             );
-            
+
             if (err.message === "throttled") {
                 retryTimeMs += THROTTLE_WAIT_MS;
             }

--- a/lib/irc/ConnectionInstance.js
+++ b/lib/irc/ConnectionInstance.js
@@ -355,9 +355,16 @@ ConnectionInstance.create = Promise.coroutine(function*(server, opts, onCreatedC
             log.error(
                 `ConnectionInstance.connect failed after ${connAttempts} attempts (${err.message})`
             );
+
+            if (err.message === "net_error") {
+                // This is the kernel complaining, we should back off.
+                retryTimeMs += THROTTLE_WAIT_MS;
+            }
+
             if (err.message === "throttled") {
                 retryTimeMs += THROTTLE_WAIT_MS;
             }
+            
             if (err.message === "banned") {
                 log.error(
                     `${opts.nick} is banned from ${server.domain}, ` +

--- a/lib/irc/ConnectionInstance.js
+++ b/lib/irc/ConnectionInstance.js
@@ -18,12 +18,6 @@ const PING_TIMEOUT_MS = 1000 * 60 * 10;
 // due to throttling.
 const THROTTLE_WAIT_MS = 20 * 1000;
 
-// The minimum time to wait between connection attempts if the kernel has given us
-// a net_error. Usually these come about due to a network being unavaliable or resource
-// starvation. Unlike throttling which is ircd based, we should retry sooner to see if
-// the kernel is happy now.
-const NET_ERROR_WAIT_MS = 5 * 1000;
-
 const BANNED_TIME_MS = 6 * 60 * 60 * 1000; // once every 6 hours
 
 // The rate at which to send pings to the IRCd if the client is being quiet for a while.
@@ -361,12 +355,7 @@ ConnectionInstance.create = Promise.coroutine(function*(server, opts, onCreatedC
             log.error(
                 `ConnectionInstance.connect failed after ${connAttempts} attempts (${err.message})`
             );
-
-            if (err.message === "net_error") {
-                // This is the kernel complaining, we should back off.
-                retryTimeMs += NET_ERROR_WAIT_MS;
-            }
-
+            
             if (err.message === "throttled") {
                 retryTimeMs += THROTTLE_WAIT_MS;
             }

--- a/lib/irc/ConnectionInstance.js
+++ b/lib/irc/ConnectionInstance.js
@@ -368,7 +368,7 @@ ConnectionInstance.create = Promise.coroutine(function*(server, opts, onCreatedC
             if (err.message === "throttled") {
                 retryTimeMs += THROTTLE_WAIT_MS;
             }
-            
+
             if (err.message === "banned") {
                 log.error(
                     `${opts.nick} is banned from ${server.domain}, ` +

--- a/lib/irc/IrcServer.js
+++ b/lib/irc/IrcServer.js
@@ -506,6 +506,7 @@ IrcServer.DEFAULT_CONFIG = {
         maxClients: 30,
         idleTimeout: 172800,
         reconnectIntervalMs: 5000,
+        concurrentReconnectLimit: 50,
         allowNickChanges: false,
         ipv6: {only: false},
         lineLimit: 3

--- a/lib/irc/IrcServer.js
+++ b/lib/irc/IrcServer.js
@@ -186,6 +186,10 @@ IrcServer.prototype.getReconnectIntervalMs = function() {
     return this.config.ircClients.reconnectIntervalMs;
 };
 
+IrcServer.prototype.getConcurrentReconnectLimit = function() {
+    return this.config.ircClients.concurrentReconnectLimit;
+};
+
 IrcServer.prototype.getMaxClients = function() {
     return this.config.ircClients.maxClients;
 };

--- a/lib/util/QueuePool.js
+++ b/lib/util/QueuePool.js
@@ -27,9 +27,9 @@ class QueuePool {
         this._overflowCount = 0;
     }
 
+    // Get number of items waiting to be inserted into a queue.
     get waitingItems() { return this._overflowCount; };
     
-
     // Add an item to the queue. ID and item are passed directly to the Queue.
     // Index is optional and should be between 0 ~ poolSize-1. It determines
     // which queue to put the item into, which will bypass the overflow queue.

--- a/lib/util/QueuePool.js
+++ b/lib/util/QueuePool.js
@@ -54,6 +54,7 @@ class QueuePool {
         // onto the queue pool. We want to return a promise which resolves
         // after the item has finished executing on the queue pool, hence
         // the promise chain here.
+        this._overflowCount++;
         return this.overflow.enqueue(id, {
             id: id,
             item: item,
@@ -72,7 +73,6 @@ class QueuePool {
                 p: queue.enqueue(req.id, req.item)
             });
         }
-        this._overflowCount++;
         // wait for any queue to become available
         let promises = this.queues.map((q) => {
             return q.onceFree();

--- a/lib/util/QueuePool.js
+++ b/lib/util/QueuePool.js
@@ -24,7 +24,11 @@ class QueuePool {
             this.queues.push(new Queue(fn));
         }
         this.overflow = new Queue(this._overflow.bind(this));
+        this._overflowCount = 0;
     }
+
+    get waitingItems() { return this._overflowCount; };
+    
 
     // Add an item to the queue. ID and item are passed directly to the Queue.
     // Index is optional and should be between 0 ~ poolSize-1. It determines
@@ -68,11 +72,13 @@ class QueuePool {
                 p: queue.enqueue(req.id, req.item)
             });
         }
+        this._overflowCount++;
         // wait for any queue to become available
         let promises = this.queues.map((q) => {
             return q.onceFree();
         });
         return Promise.any(promises).then((q) => {
+            this._overflowCount--;
             if (q.size() !== 0) {
                 throw new Error(`QueuePool overflow: starvation. No free queues.`);
             }

--- a/lib/util/QueuePool.js
+++ b/lib/util/QueuePool.js
@@ -28,8 +28,8 @@ class QueuePool {
     }
 
     // Get number of items waiting to be inserted into a queue.
-    get waitingItems() { return this._overflowCount; };
-    
+    get waitingItems() { return this._overflowCount; }
+
     // Add an item to the queue. ID and item are passed directly to the Queue.
     // Index is optional and should be between 0 ~ poolSize-1. It determines
     // which queue to put the item into, which will bypass the overflow queue.


### PR DESCRIPTION
This is designed so that we do not try to reconnect all clients at once in the case of a catastrophic connection loss. There are a few issues with this implementation as it stands but I want to see what people think of this first:

- We are now limiting reconnects, which means recovery will take longer (though potentially less crashy)
- ~~If we receive a "net_error" i.e. a socket issue, we throttle for **20s** which may be unacceptably long.~~
- The limit is currently 50 connections a second (which is now configurable), so if every connection takes one second, and we are dealing with a mass disconnect from freenode: 22000 connections / 20 = 1100s = 18m

Given this could very well make or break some of the matrix.org hosted networks, I'd like to get reviews from a few folks :)