### PR TITLE
Retry joins

### DIFF
--- a/lib/bridge/IrcHandler.js
+++ b/lib/bridge/IrcHandler.js
@@ -508,13 +508,22 @@ IrcHandler.prototype.onJoin = Promise.coroutine(function*(req, server, joiningUs
     let matrixRooms = yield this.ircBridge.getStore().getMatrixRoomsForChannel(server, chan);
     let promises = matrixRooms.map((room) => {
         req.log.info("Joining room %s and setting presence to online", room.getId());
+        const joinRetry = (attempts) => {
+            return intent.join(room.getId()).catch((err) => {
+                if (err.httpStatus <= 500) {
+                    req.log.error(`Not retrying join for ${room.getId()}.`);
+                    return Promise.reject(err);
+                }
+                attempts++;
+                req.log.warn(`Failed to join ${room.getId()} (attempts:${attempts}) - ${err}.`);
+                req.log.debug(`Failed with: ${err.errcode} ${err.message}`);
+                return joinRetry(attempts);
+            });
+        };
+        this.virtualIdRoomIdMapping.add(mxUserRoom);
         return Promise.all([
-            this.ircBridge.getAppServiceBridge().getIntent(
-                matrixUser.getId()
-            ).join(room.getId()),
-            this.ircBridge.getAppServiceBridge().getIntent(
-                matrixUser.getId()
-            ).client.setPresence("online")
+            joinRetry(0),
+            intent.client.setPresence("online")
         ]);
     });
     if (matrixRooms.length === 0) {

--- a/lib/bridge/IrcHandler.js
+++ b/lib/bridge/IrcHandler.js
@@ -506,6 +506,9 @@ IrcHandler.prototype.onJoin = Promise.coroutine(function*(req, server, joiningUs
     // get virtual matrix user
     let matrixUser = yield this.ircBridge.getMatrixUser(joiningUser);
     let matrixRooms = yield this.ircBridge.getStore().getMatrixRoomsForChannel(server, chan);
+    const intent = this.ircBridge.getAppServiceBridge().getIntent(
+        matrixUser.getId()
+    );
     let promises = matrixRooms.map((room) => {
         req.log.info("Joining room %s and setting presence to online", room.getId());
         const joinRetry = (attempts) => {

--- a/lib/bridge/IrcHandler.js
+++ b/lib/bridge/IrcHandler.js
@@ -512,6 +512,7 @@ IrcHandler.prototype.onJoin = Promise.coroutine(function*(req, server, joiningUs
     let promises = matrixRooms.map((room) => {
         req.log.info("Joining room %s and setting presence to online", room.getId());
         const joinRetry = (attempts) => {
+            req.log.debug(`Joining room (attempts:${attempts})`);
             return intent.join(room.getId()).catch((err) => {
                 if (err.httpStatus <= 500) {
                     req.log.error(`Not retrying join for ${room.getId()}.`);
@@ -523,7 +524,6 @@ IrcHandler.prototype.onJoin = Promise.coroutine(function*(req, server, joiningUs
                 return joinRetry(attempts);
             });
         };
-        this.virtualIdRoomIdMapping.add(mxUserRoom);
         return Promise.all([
             joinRetry(0),
             intent.client.setPresence("online")


### PR DESCRIPTION
Fixes #603

We only retry requests which have failed with a 5XX which means that we shouldn't spend our time spinning on requests that will never succeed.