### PR TITLE
Don't rejoin users we know are in the room on a NAMES request.

### DIFF
--- a/lib/bridge/IrcHandler.js
+++ b/lib/bridge/IrcHandler.js
@@ -513,7 +513,7 @@ IrcHandler.prototype.onJoin = Promise.coroutine(function*(req, server, joiningUs
         /** If this is a "NAMES" query, we can make use of the joinedMembers call we made
          * to check if the user already exists in the room. This should save oodles of time.
          */
-        if (kind === "names" && 
+        if (kind === "names" &&
             this.ircBridge.memberListSyncers[server.domain].isRemoteJoinedToRoom(
                 room.getId(),
                 matrixUser.getId()

--- a/lib/bridge/IrcHandler.js
+++ b/lib/bridge/IrcHandler.js
@@ -510,6 +510,17 @@ IrcHandler.prototype.onJoin = Promise.coroutine(function*(req, server, joiningUs
         matrixUser.getId()
     );
     let promises = matrixRooms.map((room) => {
+        /** If this is a "NAMES" query, we can make use of the joinedMembers call we made
+         * to check if the user already exists in the room. This should save oodles of time.
+         */
+        if (kind === "names" && 
+            this.ircBridge.memberListSyncers[server.domain].isRemoteJoinedToRoom(
+                room.getId(),
+                matrixUser.getId(),
+            )) {
+            req.log.debug("Not joining to %s, already joined.", room.getId());
+            return;
+        }
         req.log.info("Joining room %s and setting presence to online", room.getId());
         const joinRetry = (attempts) => {
             req.log.debug(`Joining room (attempts:${attempts})`);

--- a/lib/bridge/IrcHandler.js
+++ b/lib/bridge/IrcHandler.js
@@ -516,7 +516,7 @@ IrcHandler.prototype.onJoin = Promise.coroutine(function*(req, server, joiningUs
         if (kind === "names" && 
             this.ircBridge.memberListSyncers[server.domain].isRemoteJoinedToRoom(
                 room.getId(),
-                matrixUser.getId(),
+                matrixUser.getId()
             )) {
             req.log.debug("Not joining to %s, already joined.", room.getId());
             return;

--- a/lib/bridge/MemberListSyncer.js
+++ b/lib/bridge/MemberListSyncer.js
@@ -43,6 +43,14 @@ function MemberListSyncer(ircBridge, appServiceBot, server, appServiceUserId, in
     this._leaveQueuePool = new QueuePool(3, this._leaveUsersInRoom.bind(this));
 }
 
+MemberListSyncer.prototype.isRemoteJoinedToRoom = Promise.coroutine(function*(roomId, userId) {
+    const room = this._memberLists.matrix[roomId];
+    if (room !== undefined) {
+        return room.remoteJoinedUsers.includes(userId);
+    }
+    return false;
+});
+
 MemberListSyncer.prototype.sync = Promise.coroutine(function*() {
     let server = this.server;
     if (!server.isMembershipListsEnabled()) {

--- a/lib/bridge/MemberListSyncer.js
+++ b/lib/bridge/MemberListSyncer.js
@@ -43,13 +43,13 @@ function MemberListSyncer(ircBridge, appServiceBot, server, appServiceUserId, in
     this._leaveQueuePool = new QueuePool(3, this._leaveUsersInRoom.bind(this));
 }
 
-MemberListSyncer.prototype.isRemoteJoinedToRoom = Promise.coroutine(function*(roomId, userId) {
+MemberListSyncer.prototype.isRemoteJoinedToRoom = function (roomId, userId) {
     const room = this._memberLists.matrix[roomId];
     if (room !== undefined) {
         return room.remoteJoinedUsers.includes(userId);
     }
     return false;
-});
+};
 
 MemberListSyncer.prototype.sync = Promise.coroutine(function*() {
     let server = this.server;


### PR DESCRIPTION
This is a dumb lookup of the list of ``/joinedMembers`` for rooms to determine if we have this person joined. If so, we just carry on. This doesn't affect ``join`` only ``names``, so any massive flash of joins will still need to be worked through but this at least counters the issue on restart of bridges. 

Flaws:
* We sync matrix membership once on start, but if we encounter more *NAMES* calls then we do not try to resync membership so the information becomes out of date over the bridges lifetime. 