### PR TITLE
Unbridge API

### DIFF
--- a/lib/DebugApi.js
+++ b/lib/DebugApi.js
@@ -209,14 +209,19 @@ DebugApi.prototype.run = function() {
 DebugApi.prototype.killPortal = Promise.coroutine(function*(req, response) {
     const result = {error: [], stages: []};
     const body = yield this._wrapJsonReq(req, response);
+
     // Room room_id to lookup and delete the alias from.
     const roomId = body["room_id"];
+
     // IRC server domain
     const domain = body["domain"];
+
     // IRC channel
     const channel = body["channel"];
+
     // Should we tell the room about the deletion. Defaults to true.
     const notice = !(body["leave_notice"] === false);
+
     // Should we remove the alias from the room. Defaults to true.
     const remove_alias = !(body["remove_alias"] === false);
 

--- a/lib/DebugApi.js
+++ b/lib/DebugApi.js
@@ -207,7 +207,11 @@ DebugApi.prototype.run = function() {
 }
 
 DebugApi.prototype.killPortal = Promise.coroutine(function*(req, response) {
-    const result = {error: [], stages: []};
+    const result = {
+        error: [], // string|[string] containing a fatal error or minor errors.
+        stages: [] // stages completed for removing the room. It's possible it might only
+                   // half complete, and we should make that obvious.
+    };
     const body = yield this._wrapJsonReq(req, response);
 
     // Room room_id to lookup and delete the alias from.
@@ -225,6 +229,7 @@ DebugApi.prototype.killPortal = Promise.coroutine(function*(req, response) {
     // Should we remove the alias from the room. Defaults to true.
     const remove_alias = !(body["remove_alias"] === false);
 
+    // These keys are required.
     ["room_id", "channel", "domain"].forEach((key) => {
         if (typeof(body[key]) !== "string") {
             result.error.push(`'${key}' is missing from body or not a string`);
@@ -296,8 +301,9 @@ Remove Alias: ${remove_alias}`);
         }
     }
 
-
-    // Drop clients from room. We are being naughty and using the provisioners method for this.
+    // Drop clients from room.
+    // The provisioner will only drop clients who are not in other rooms.
+    // It will also leave the MatrixBot.
     try {
         yield this.ircBridge.getProvisioner()._leaveIfUnprovisioned(
             { log: log },

--- a/lib/DebugApi.js
+++ b/lib/DebugApi.js
@@ -204,10 +204,10 @@ DebugApi.prototype.run = function() {
     }).listen(this.port);
 }
 
-DebugApi.prototype.killPortal = async function(req, response) {
+DebugApi.prototype.killPortal = Promise.coroutine(function*(req, response) {
     const result = {error: [], stages: []};
 
-    const body = await this._wrapJsonReq(req, response);
+    const body = yield this._wrapJsonReq(req, response);
     // Room room_id to lookup and delete the alias from.
     const roomId = body["room_id"];
     // IRC server domain
@@ -237,7 +237,7 @@ Leave Notice: ${notice}
 Remove Alias: ${remove_alias}`);
 
     // Find room
-    let room = await this.ircBridge.getStore().getRoom(
+    let room = yield this.ircBridge.getStore().getRoom(
         roomId,
         domain,
         channel,
@@ -267,7 +267,7 @@ Remove Alias: ${remove_alias}`);
     
     if (notice) {
         try {
-            await this.ircBridge.getAppServiceBridge().getIntent().sendEvent(roomId, "notice",
+            yield this.ircBridge.getAppServiceBridge().getIntent().sendEvent(roomId, "notice",
             {
                 body: `This room has been unbridged from ${channel} (${server.getReadableName()})`
             });
@@ -281,7 +281,7 @@ Remove Alias: ${remove_alias}`);
         const roomAlias = server.getAliasFromChannel(channel);
         console.log("Alias", roomAlias);
         try {
-            await this.ircBridge.getAppServiceBridge().getIntent().client.deleteAlias(roomAlias);
+            yield this.ircBridge.getAppServiceBridge().getIntent().client.deleteAlias(roomAlias);
             result.stages.push("Deleted alias for room.");
         } catch (e) {
             result.error.push("Failed to remove alias");
@@ -291,7 +291,7 @@ Remove Alias: ${remove_alias}`);
 
     // Drop clients from room. We are being naughty and using the provisioners method for this.
     try {
-        await this.ircBridge.getProvisioner()._leaveIfUnprovisioned({
+        yield this.ircBridge.getProvisioner()._leaveIfUnprovisioned({
             log: log
         },
             roomId, 
@@ -307,7 +307,7 @@ Remove Alias: ${remove_alias}`);
 
     result.stages.push("Parted clients where applicable.");
     this._wrapJsonResponse(result, true, response);
-}
+});
 
 DebugApi.prototype._wrapJsonReq = function(req, response) {
     let body = "";

--- a/lib/DebugApi.js
+++ b/lib/DebugApi.js
@@ -240,7 +240,7 @@ DebugApi.prototype.killPortal = Promise.coroutine(function*(req, response) {
         return;
     }
 
-    log.info(
+    log.warn(
 `Requested deletion of portal room alias ${roomId} through debug API
 Domain: ${domain}
 Channel: ${channel}

--- a/lib/DebugApi.js
+++ b/lib/DebugApi.js
@@ -201,4 +201,36 @@ DebugApi.prototype.run = function() {
     }).listen(this.port);
 }
 
+DebugApi.prototype._wrapJsonReq = function(req, response) {
+    let body = "";
+    req.on("data", function(chunk) {
+        body += chunk;
+    });
+    return new Promise((resolve, reject) => {
+        req.on("error", (err) => {
+            reject(err);
+        });
+        req.on("end", () => {
+            if( body === "") {
+                reject({"error": "Body missing"});
+            }
+            try {
+                body = JSON.parse(body);
+                resolve(
+                    body
+                );
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    });
+}
+
+DebugApi.prototype._wrapJsonResponse = function(json, isOk, response) {
+    response.writeHead(isOk === true ? 200 : 500, {"Content-Type": "application/json"});
+    response.write(JSON.stringify(json));
+    response.end();
+}
+
 module.exports = DebugApi;

--- a/lib/DebugApi.js
+++ b/lib/DebugApi.js
@@ -1,3 +1,4 @@
+/*eslint no-invalid-this: 0*/ // eslint doesn't understand Promise.coroutine wrapping
 "use strict";
 var querystring = require("querystring");
 var Promise = require("bluebird");
@@ -126,7 +127,8 @@ DebugApi.prototype.run = function() {
                     });
                 });
                 return;
-            } else if (req.method === "POST" && path == "/killPortal") {
+            }
+            else if (req.method === "POST" && path == "/killPortal") {
                 this.killPortal(req, response);
                 return;
             }
@@ -206,7 +208,6 @@ DebugApi.prototype.run = function() {
 
 DebugApi.prototype.killPortal = Promise.coroutine(function*(req, response) {
     const result = {error: [], stages: []};
-
     const body = yield this._wrapJsonReq(req, response);
     // Room room_id to lookup and delete the alias from.
     const roomId = body["room_id"];
@@ -224,7 +225,7 @@ DebugApi.prototype.killPortal = Promise.coroutine(function*(req, response) {
             result.error.push(`'${key}' is missing from body or not a string`);
         }
     });
-    if (result.error.length > 0) { 
+    if (result.error.length > 0) {
         this._wrapJsonResponse(result.error, false, response);
         return;
     }
@@ -250,7 +251,7 @@ Remove Alias: ${remove_alias}`);
     }
 
     const server = this.servers.find((srv) => srv.domain === domain);
-    if (server == null) {
+    if (server === null) {
         result.error = "Server not found!";
         this._wrapJsonResponse(result, false, response);
         return;
@@ -264,7 +265,7 @@ Remove Alias: ${remove_alias}`);
         "alias"
     );
     result.stages.push("Removed room from store");
-    
+
     if (notice) {
         try {
             yield this.ircBridge.getAppServiceBridge().getIntent().sendEvent(roomId, "notice",
@@ -272,7 +273,8 @@ Remove Alias: ${remove_alias}`);
                 body: `This room has been unbridged from ${channel} (${server.getReadableName()})`
             });
             result.stages.push("Left notice in room.");
-        } catch (e) {
+        }
+        catch (e) {
             result.error.push("Failed to send a leave notice");
         }
     }
@@ -283,7 +285,8 @@ Remove Alias: ${remove_alias}`);
         try {
             yield this.ircBridge.getAppServiceBridge().getIntent().client.deleteAlias(roomAlias);
             result.stages.push("Deleted alias for room.");
-        } catch (e) {
+        }
+        catch (e) {
             result.error.push("Failed to remove alias");
         }
     }
@@ -294,11 +297,12 @@ Remove Alias: ${remove_alias}`);
         yield this.ircBridge.getProvisioner()._leaveIfUnprovisioned({
             log: log
         },
-            roomId, 
+            roomId,
             server,
             channel
         );
-    } catch (e) {
+    }
+    catch (e) {
         result.error.push("Failed to leave users from room");
         result.error.push(e);
         this._wrapJsonResponse(result, false, response);
@@ -319,7 +323,7 @@ DebugApi.prototype._wrapJsonReq = function(req, response) {
             reject(err);
         });
         req.on("end", () => {
-            if( body === "") {
+            if (body === "") {
                 reject({"error": "Body missing"});
             }
             try {

--- a/lib/DebugApi.js
+++ b/lib/DebugApi.js
@@ -294,9 +294,8 @@ Remove Alias: ${remove_alias}`);
 
     // Drop clients from room. We are being naughty and using the provisioners method for this.
     try {
-        yield this.ircBridge.getProvisioner()._leaveIfUnprovisioned({
-            log: log
-        },
+        yield this.ircBridge.getProvisioner()._leaveIfUnprovisioned(
+            { log: log },
             roomId,
             server,
             channel
@@ -328,9 +327,7 @@ DebugApi.prototype._wrapJsonReq = function(req, response) {
             }
             try {
                 body = JSON.parse(body);
-                resolve(
-                    body
-                );
+                resolve(body);
             }
             catch (err) {
                 reject(err);

--- a/lib/DebugApi.js
+++ b/lib/DebugApi.js
@@ -126,6 +126,9 @@ DebugApi.prototype.run = function() {
                     });
                 });
                 return;
+            } else if (req.method === "POST" && path == "/killPortal") {
+                this.killPortal(req, response);
+                return;
             }
 
             // Looks like /irc/$domain/user/$user_id
@@ -199,6 +202,111 @@ DebugApi.prototype.run = function() {
             log.error(err.stack);
         }
     }).listen(this.port);
+}
+
+DebugApi.prototype.killPortal = async function(req, response) {
+    const result = {error: [], stages: []};
+
+    const body = await this._wrapJsonReq(req, response);
+    // Room room_id to lookup and delete the alias from.
+    const roomId = body["room_id"];
+    // IRC server domain
+    const domain = body["domain"];
+    // IRC channel
+    const channel = body["channel"];
+    // Should we tell the room about the deletion. Defaults to true.
+    const notice = !(body["leave_notice"] === false);
+    // Should we remove the alias from the room. Defaults to true.
+    const remove_alias = !(body["remove_alias"] === false);
+
+    ["room_id", "channel", "domain"].forEach((key) => {
+        if (typeof(body[key]) !== "string") {
+            result.error.push(`'${key}' is missing from body or not a string`);
+        }
+    });
+    if (result.error.length > 0) { 
+        this._wrapJsonResponse(result.error, false, response);
+        return;
+    }
+
+    log.info(
+`Requested deletion of portal room alias ${roomId} through debug API
+Domain: ${domain}
+Channel: ${channel}
+Leave Notice: ${notice}
+Remove Alias: ${remove_alias}`);
+
+    // Find room
+    let room = await this.ircBridge.getStore().getRoom(
+        roomId,
+        domain,
+        channel,
+        "alias"
+    );
+    if (room === null) {
+        result.error = "Room not found";
+        this._wrapJsonResponse(result, false, response);
+        return;
+    }
+
+    const server = this.servers.find((srv) => srv.domain === domain);
+    if (server == null) {
+        result.error = "Server not found!";
+        this._wrapJsonResponse(result, false, response);
+        return;
+    }
+
+    // Drop room from room store.
+    this.ircBridge.getStore().removeRoom(
+        roomId,
+        domain,
+        channel,
+        "alias"
+    );
+    result.stages.push("Removed room from store");
+    
+    if (notice) {
+        try {
+            await this.ircBridge.getAppServiceBridge().getIntent().sendEvent(roomId, "notice",
+            {
+                body: `This room has been unbridged from ${channel} (${server.getReadableName()})`
+            });
+            result.stages.push("Left notice in room.");
+        } catch (e) {
+            result.error.push("Failed to send a leave notice");
+        }
+    }
+
+    if (remove_alias) {
+        const roomAlias = server.getAliasFromChannel(channel);
+        console.log("Alias", roomAlias);
+        try {
+            await this.ircBridge.getAppServiceBridge().getIntent().client.deleteAlias(roomAlias);
+            result.stages.push("Deleted alias for room.");
+        } catch (e) {
+            result.error.push("Failed to remove alias");
+        }
+    }
+
+
+    // Drop clients from room. We are being naughty and using the provisioners method for this.
+    try {
+        await this.ircBridge.getProvisioner()._leaveIfUnprovisioned({
+            log: log
+        },
+            roomId, 
+            server,
+            channel
+        );
+    } catch (e) {
+        result.error.push("Failed to leave users from room");
+        result.error.push(e);
+        this._wrapJsonResponse(result, false, response);
+        return;
+    }
+
+    result.stages.push("Parted clients where applicable.");
+    this._wrapJsonResponse(result, true, response);
 }
 
 DebugApi.prototype._wrapJsonReq = function(req, response) {

--- a/lib/DebugApi.js
+++ b/lib/DebugApi.js
@@ -282,7 +282,7 @@ Remove Alias: ${remove_alias}`);
             {
                 body: `This room has been unbridged from ${channel} (${server.getReadableName()})`
             });
-            result.stages.push("Left notice in room.");
+            result.stages.push("Left notice in room");
         }
         catch (e) {
             result.error.push("Failed to send a leave notice");
@@ -294,7 +294,7 @@ Remove Alias: ${remove_alias}`);
         console.log("Alias", roomAlias);
         try {
             yield this.ircBridge.getAppServiceBridge().getIntent().client.deleteAlias(roomAlias);
-            result.stages.push("Deleted alias for room.");
+            result.stages.push("Deleted alias for room");
         }
         catch (e) {
             result.error.push("Failed to remove alias");


### PR DESCRIPTION
An endpoint on the DebugAPI to unbridge a portal room (alias). You can call ``/killPortal`` with the body:
```
{
    room_id: // room_id to kill
    domain // Domain of the irc server
    channel: // Channel of the irc chan
    leave_notice: true // Do you want to put a notice in the room. Def true.
    remove_alias: true // Remove the alias of the room assigned by the bridge. Def true.
}
```

Kill was chosen so to be similar to `/killClient` but I might change that one.