### PR TITLE
WIP: A prometheus metric of reconnecting clients

### DIFF
--- a/lib/bridge/IrcBridge.js
+++ b/lib/bridge/IrcBridge.js
@@ -126,6 +126,7 @@ IrcBridge.prototype._initialiseMetrics = function() {
             matrixRoomConfigs: 0,
             remoteRoomConfigs: 0,
 
+            remotePendingReconnectionGhosts: this._clientPool.countTotalPendingReconnections(),
             remoteGhosts: this._clientPool.countTotalConnections(),
             // matrixGhosts is provided automatically by the bridge
 

--- a/lib/irc/ClientPool.js
+++ b/lib/irc/ClientPool.js
@@ -241,6 +241,17 @@ ClientPool.prototype.countTotalConnections = function() {
     return count;
 };
 
+ClientPool.prototype.countTotalPendingReconnections = function() {
+    var count = 0;
+
+    Object.keys(this._virtualClients).forEach((domain) => {
+        let q = this._reconnectQueues[domain];
+        count += q.waitingClients);
+    });
+
+    return count;
+};
+
 ClientPool.prototype._sendConnectionMetric = function(server) {
     stats.ircClients(server.domain, this._getNumberOfConnections(server));
 };


### PR DESCRIPTION
#604 removed logging for pending reconnect users. Something like this would give visibility to the size of that reconnection queue in prometheus, which would be a better place for it than the log files.

I'm not sure if this is the right way to provide this sort of metric so happy for it to exist in another way.

I'm not even quite sure if we want to look at the number who are waiting to reconnect or the total of waiting to connect + currently reconnecting.