### PR TITLE
Additional metrics

### DIFF
--- a/lib/bridge/IrcBridge.js
+++ b/lib/bridge/IrcBridge.js
@@ -165,6 +165,10 @@ IrcBridge.prototype._initialiseMetrics = function() {
         help: "Number of leave requests queued up for virtual users on the bridge.",
         labels: ["server"]
     });
+
+    const memberListJoinQueue = metrics.addGauge({
+        name: "user_join_queue",
+        help: "Number of join requests queued up for virtual users on the bridge.",
         labels: ["server"]
     });
 
@@ -184,6 +188,10 @@ IrcBridge.prototype._initialiseMetrics = function() {
             memberListLeaveQueue.set(
                 {server},
                 this.memberListSyncers[server].getUsersWaitingToLeave()
+            );
+            memberListJoinQueue.set(
+                {server},
+                this.memberListSyncers[server].getUsersWaitingToJoin()
             );
         });
 

--- a/lib/bridge/IrcBridge.js
+++ b/lib/bridge/IrcBridge.js
@@ -116,9 +116,9 @@ function IrcBridge(config, registration) {
 }
 
 IrcBridge.prototype._initialiseMetrics = function() {
-    var zeroAge = new AgeCounters();
+    const zeroAge = new AgeCounters();
 
-    var metrics = this._bridge.getPrometheusMetrics();
+    const metrics = this._bridge.getPrometheusMetrics();
 
     this._bridge.registerBridgeGauges(() => {
         return {
@@ -140,7 +140,7 @@ IrcBridge.prototype._initialiseMetrics = function() {
         };
     });
 
-    var timers = this._timers = {};
+    const timers = this._timers = {};
 
     timers.matrix_request_seconds = metrics.addTimer({
         name: "matrix_request_seconds",

--- a/lib/bridge/IrcBridge.js
+++ b/lib/bridge/IrcBridge.js
@@ -165,17 +165,30 @@ IrcBridge.prototype._initialiseMetrics = function() {
         help: "Number of leaves queued up for virtual users from initial sync",
         labels: ["server"]
     });
+
+    const ircHandlerCalls = metrics.addCounter({
+        name: "irchandler_calls",
+        help: "Track calls made to the IRC Handler",
+        labels: ["method"]
+    });
     metrics.addCollector(() => {
         this.ircServers.forEach((server) => {
             reconnQueue.set({server: server.domain},
                 this._clientPool.totalReconnectsWaiting(server.domain)
             );
         });
+
         Object.keys(this.memberListSyncers).forEach((server) => {
             memberListLeaveQueue.set(
                 {server},
                 this.memberListSyncers[server].getUsersWaitingToLeave()
             );
+        });
+
+        const ircMetrics = this.ircHandler.getMetrics();
+        Object.keys(ircMetrics).forEach((method) => {
+            const value = ircMetrics[method];
+            ircHandlerCalls.inc({method}, value);
         });
     });
 };

--- a/lib/bridge/IrcBridge.js
+++ b/lib/bridge/IrcBridge.js
@@ -159,10 +159,22 @@ IrcBridge.prototype._initialiseMetrics = function() {
         help: "Number of irc connections waiting to reconnect",
         labels: ["server"]
     });
+
+    const memberListLeaveQueue = metrics.addGauge({
+        name: "memberlistsync_leave_queue",
+        help: "Number of leaves queued up for virtual users from initial sync",
+        labels: ["server"]
+    });
     metrics.addCollector(() => {
         this.ircServers.forEach((server) => {
             reconnQueue.set({server: server.domain},
                 this._clientPool.totalReconnectsWaiting(server.domain)
+            );
+        });
+        Object.keys(this.memberListSyncers).forEach((server) => {
+            memberListLeaveQueue.set(
+                {server},
+                this.memberListSyncers[server].getUsersWaitingToLeave()
             );
         });
     });

--- a/lib/bridge/IrcBridge.js
+++ b/lib/bridge/IrcBridge.js
@@ -152,6 +152,20 @@ IrcBridge.prototype._initialiseMetrics = function() {
         help: "Histogram of processing durations of received remote messages",
         labels: ["outcome"],
     });
+
+    // Custom IRC metrics
+    const reconnQueue = metrics.addGauge({
+        name: "clientpool_reconnect_queue",
+        help: "Number of irc connections waiting to reconnect",
+        labels: ["server"]
+    });
+    metrics.addCollector(() => {
+        this.ircServers.forEach((server) => {
+            reconnQueue.set({server: server.domain},
+                this._clientPool.totalReconnectsWaiting(server.domain)
+            );
+        });
+    });
 };
 
 IrcBridge.prototype.getAppServiceUserId = function() {

--- a/lib/bridge/IrcBridge.js
+++ b/lib/bridge/IrcBridge.js
@@ -156,13 +156,15 @@ IrcBridge.prototype._initialiseMetrics = function() {
     // Custom IRC metrics
     const reconnQueue = metrics.addGauge({
         name: "clientpool_reconnect_queue",
-        help: "Number of irc connections waiting to reconnect",
+        help: "Number of disconnected irc connections waiting to reconnect.",
         labels: ["server"]
     });
 
     const memberListLeaveQueue = metrics.addGauge({
-        name: "memberlistsync_leave_queue",
-        help: "Number of leaves queued up for virtual users from initial sync",
+        name: "user_leave_queue",
+        help: "Number of leave requests queued up for virtual users on the bridge.",
+        labels: ["server"]
+    });
         labels: ["server"]
     });
 

--- a/lib/bridge/IrcHandler.js
+++ b/lib/bridge/IrcHandler.js
@@ -46,6 +46,7 @@ function IrcHandler(ircBridge) {
 
     // Map<string,bool> which contains nicks we know have been registered/has display name
     this._registeredNicks = Object.create(null);
+    this.getMetrics();
 }
 
 IrcHandler.prototype.onMatrixMemberEvent = function(event) {
@@ -156,6 +157,7 @@ IrcHandler.prototype._createPmRoom = Promise.coroutine(
  */
 IrcHandler.prototype.onPrivateMessage = Promise.coroutine(function*(req, server, fromUser,
                                                               toUser, action) {
+    this._callCountMetrics["pm"]++;
     if (fromUser.isVirtual) {
         return BridgeRequest.ERR_VIRTUAL_USER;
     }
@@ -253,6 +255,7 @@ IrcHandler.prototype.onPrivateMessage = Promise.coroutine(function*(req, server,
  */
 IrcHandler.prototype.onInvite = Promise.coroutine(function*(req, server, fromUser,
                                                               toUser, channel) {
+    this._callCountMetrics["invite"]++;
     if (fromUser.isVirtual) {
         return BridgeRequest.ERR_VIRTUAL_USER;
     }
@@ -404,6 +407,7 @@ IrcHandler.prototype._serviceTopicQueue = Promise.coroutine(function*(item) {
  */
 IrcHandler.prototype.onTopic = Promise.coroutine(function*(req, server, fromUser,
                                                     channel, action) {
+    this._callCountMetrics["topic"]++;
     req.log.info("onTopic: %s from=%s to=%s action=%s",
         server.domain, fromUser, channel, JSON.stringify(action).substring(0, 80)
     );
@@ -448,6 +452,7 @@ IrcHandler.prototype.onTopic = Promise.coroutine(function*(req, server, fromUser
  */
 IrcHandler.prototype.onMessage = Promise.coroutine(function*(req, server, fromUser,
                                                     channel, action) {
+    this._callCountMetrics["message"]++;
     if (fromUser.isVirtual) {
         return BridgeRequest.ERR_VIRTUAL_USER;
     }
@@ -501,6 +506,12 @@ IrcHandler.prototype.onMessage = Promise.coroutine(function*(req, server, fromUs
  * @return {Promise} which is resolved/rejected when the request finishes.
  */
 IrcHandler.prototype.onJoin = Promise.coroutine(function*(req, server, joiningUser, chan, kind) {
+    if(kind === "names") {
+        this._callCountMetrics["join.names"]++;
+    } else { // Let's avoid any surprises
+        this._callCountMetrics["join"]++;
+    }
+    
     let nick = joiningUser.nick;
     let syncType = kind === "names" ? "initial" : "incremental";
     if (!server.shouldSyncMembershipToMatrix(syncType, chan)) {
@@ -567,6 +578,7 @@ IrcHandler.prototype.onJoin = Promise.coroutine(function*(req, server, joiningUs
 
 IrcHandler.prototype.onKick = Promise.coroutine(function*(req, server,
                                                 kicker, kickee, chan, reason) {
+    this._callCountMetrics["kick"]++;
     req.log.info(
         "onKick(%s) %s is kicking %s from %s",
         server.domain, kicker.nick, kickee.nick, chan
@@ -652,6 +664,7 @@ IrcHandler.prototype.onKick = Promise.coroutine(function*(req, server,
  * @return {Promise} which is resolved/rejected when the request finishes.
  */
 IrcHandler.prototype.onPart = Promise.coroutine(function*(req, server, leavingUser, chan, kind) {
+    this._callCountMetrics["part"]++;
     // parts are always incremental (only NAMES are initial)
     if (!server.shouldSyncMembershipToMatrix("incremental", chan)) {
         req.log.info("Server doesn't mirror parts.");
@@ -696,6 +709,7 @@ IrcHandler.prototype.onPart = Promise.coroutine(function*(req, server, leavingUs
 
 IrcHandler.prototype.onMode = Promise.coroutine(function*(req, server, channel, by,
                                                 mode, enabled, arg) {
+    this._callCountMetrics["mode"]++;
     req.log.info(
         "onMode(%s) in %s by %s (arg=%s)",
         (enabled ? ("+" + mode) : ("-" + mode)),
@@ -952,5 +966,21 @@ IrcHandler.prototype._setMatrixRoomAsInviteOnly = function(room, isInviteOnly) {
         }, ""
     );
 };
+
+IrcHandler.prototype.getMetrics = function() {
+    const metrics = Object.assign({}, this._callCountMetrics);
+    this._callCountMetrics = {
+        "join.names": 0,
+        "join": 0,
+        "part": 0,
+        "pm": 0,
+        "invite": 0,
+        "topic": 0,
+        "message": 0,
+        "kick": 0,
+        "mode": 0,
+    };
+    return metrics;
+}
 
 module.exports = IrcHandler;

--- a/lib/bridge/IrcHandler.js
+++ b/lib/bridge/IrcHandler.js
@@ -550,16 +550,19 @@ IrcHandler.prototype.onJoin = Promise.coroutine(function*(req, server, joiningUs
         const joinRetry = (attempts) => {
             req.log.debug(`Joining room (attempts:${attempts})`);
             return intent.join(room.getId()).catch((err) => {
-                if (attempts > MAX_JOIN_ATTEMPTS
-                    ) {
+                // -1 to never retry, 0 to never give up
+                if (MAX_JOIN_ATTEMPTS !== 0 &&
+                    (attempts > MAX_JOIN_ATTEMPTS) ) {
                     req.log.error(`Not retrying join for ${room.getId()}.`);
                     return Promise.reject(err);
                 }
                 attempts++;
-                const delay = JOIN_DELAY_MS*attempts;
-                req.log.warn(
-                    `Failed to join ${room.getId()} attempts:${attempts} Delaying for ${delay}ms`
+                const delay = Math.min(
+                    (JOIN_DELAY_MS * attempts) + (Math.random() * 500),
+                    JOIN_DELAY_CAP_MS
                 );
+                req.log.warn(`Failed to join ${room.getId()}, delaying for ${delay}ms`);
+                req.log.debug(`Failed with: ${err.errcode} ${err.message}`);
                 return Promise.delay(delay).then(() => {
                     return joinRetry(attempts);
                 });

--- a/lib/bridge/IrcHandler.js
+++ b/lib/bridge/IrcHandler.js
@@ -506,12 +506,13 @@ IrcHandler.prototype.onMessage = Promise.coroutine(function*(req, server, fromUs
  * @return {Promise} which is resolved/rejected when the request finishes.
  */
 IrcHandler.prototype.onJoin = Promise.coroutine(function*(req, server, joiningUser, chan, kind) {
-    if(kind === "names") {
+    if (kind === "names") {
         this._callCountMetrics["join.names"]++;
-    } else { // Let's avoid any surprises
+    }
+    else { // Let's avoid any surprises
         this._callCountMetrics["join"]++;
     }
-    
+
     let nick = joiningUser.nick;
     let syncType = kind === "names" ? "initial" : "incremental";
     if (!server.shouldSyncMembershipToMatrix(syncType, chan)) {
@@ -549,13 +550,17 @@ IrcHandler.prototype.onJoin = Promise.coroutine(function*(req, server, joiningUs
         const joinRetry = (attempts) => {
             req.log.debug(`Joining room (attempts:${attempts})`);
             return intent.join(room.getId()).catch((err) => {
-                if (attempts > MAX_JOIN_ATTEMPTS || err.httpStatus === undefined || err.httpStatus <= 500) {
+                if (attempts > MAX_JOIN_ATTEMPTS ||
+                    err.httpStatus === undefined ||
+                    err.httpStatus <= 500) {
                     req.log.error(`Not retrying join for ${room.getId()}.`);
                     return Promise.reject(err);
                 }
                 attempts++;
                 const delay = JOIN_DELAY_MS*attempts;
-                req.log.warn(`Failed to join ${room.getId()} attempts:${attempts} ${err}.delaying for ${delay}ms`);
+                req.log.warn(
+                `Failed to join ${room.getId()} attempts:${attempts} ${err}.delaying for ${delay}ms`
+                );
                 req.log.debug(`Failed with: ${err.errcode} ${err.message}`);
                 return Promise.delay(delay).then(() => {
                     return joinRetry(attempts);

--- a/lib/bridge/IrcHandler.js
+++ b/lib/bridge/IrcHandler.js
@@ -550,18 +550,16 @@ IrcHandler.prototype.onJoin = Promise.coroutine(function*(req, server, joiningUs
         const joinRetry = (attempts) => {
             req.log.debug(`Joining room (attempts:${attempts})`);
             return intent.join(room.getId()).catch((err) => {
-                if (attempts > MAX_JOIN_ATTEMPTS ||
-                    err.httpStatus === undefined ||
-                    err.httpStatus <= 500) {
+                if (attempts > MAX_JOIN_ATTEMPTS
+                    ) {
                     req.log.error(`Not retrying join for ${room.getId()}.`);
                     return Promise.reject(err);
                 }
                 attempts++;
                 const delay = JOIN_DELAY_MS*attempts;
                 req.log.warn(
-                `Failed to join ${room.getId()} attempts:${attempts} ${err}.delaying for ${delay}ms`
+                `Failed to join ${room.getId()} attempts:${attempts} Delaying for ${delay}ms`
                 );
-                req.log.debug(`Failed with: ${err.errcode} ${err.message}`);
                 return Promise.delay(delay).then(() => {
                     return joinRetry(attempts);
                 });

--- a/lib/bridge/IrcHandler.js
+++ b/lib/bridge/IrcHandler.js
@@ -157,7 +157,7 @@ IrcHandler.prototype._createPmRoom = Promise.coroutine(
  */
 IrcHandler.prototype.onPrivateMessage = Promise.coroutine(function*(req, server, fromUser,
                                                               toUser, action) {
-    this._callCountMetrics["pm"]++;
+    this.incrementMetric("pm");
     if (fromUser.isVirtual) {
         return BridgeRequest.ERR_VIRTUAL_USER;
     }
@@ -255,7 +255,7 @@ IrcHandler.prototype.onPrivateMessage = Promise.coroutine(function*(req, server,
  */
 IrcHandler.prototype.onInvite = Promise.coroutine(function*(req, server, fromUser,
                                                               toUser, channel) {
-    this._callCountMetrics["invite"]++;
+    this.incrementMetric("invite");
     if (fromUser.isVirtual) {
         return BridgeRequest.ERR_VIRTUAL_USER;
     }
@@ -407,7 +407,7 @@ IrcHandler.prototype._serviceTopicQueue = Promise.coroutine(function*(item) {
  */
 IrcHandler.prototype.onTopic = Promise.coroutine(function*(req, server, fromUser,
                                                     channel, action) {
-    this._callCountMetrics["topic"]++;
+    this.incrementMetric("topic");
     req.log.info("onTopic: %s from=%s to=%s action=%s",
         server.domain, fromUser, channel, JSON.stringify(action).substring(0, 80)
     );
@@ -452,7 +452,7 @@ IrcHandler.prototype.onTopic = Promise.coroutine(function*(req, server, fromUser
  */
 IrcHandler.prototype.onMessage = Promise.coroutine(function*(req, server, fromUser,
                                                     channel, action) {
-    this._callCountMetrics["message"]++;
+    this.incrementMetric("message");
     if (fromUser.isVirtual) {
         return BridgeRequest.ERR_VIRTUAL_USER;
     }
@@ -507,10 +507,10 @@ IrcHandler.prototype.onMessage = Promise.coroutine(function*(req, server, fromUs
  */
 IrcHandler.prototype.onJoin = Promise.coroutine(function*(req, server, joiningUser, chan, kind) {
     if (kind === "names") {
-        this._callCountMetrics["join.names"]++;
+        this.incrementMetric("join.names");
     }
     else { // Let's avoid any surprises
-        this._callCountMetrics["join"]++;
+        this.incrementMetric("join");
     }
 
     let nick = joiningUser.nick;
@@ -558,7 +558,7 @@ IrcHandler.prototype.onJoin = Promise.coroutine(function*(req, server, joiningUs
                 attempts++;
                 const delay = JOIN_DELAY_MS*attempts;
                 req.log.warn(
-                `Failed to join ${room.getId()} attempts:${attempts} Delaying for ${delay}ms`
+                    `Failed to join ${room.getId()} attempts:${attempts} Delaying for ${delay}ms`
                 );
                 return Promise.delay(delay).then(() => {
                     return joinRetry(attempts);
@@ -581,7 +581,7 @@ IrcHandler.prototype.onJoin = Promise.coroutine(function*(req, server, joiningUs
 
 IrcHandler.prototype.onKick = Promise.coroutine(function*(req, server,
                                                 kicker, kickee, chan, reason) {
-    this._callCountMetrics["kick"]++;
+    this.incrementMetric("kick");
     req.log.info(
         "onKick(%s) %s is kicking %s from %s",
         server.domain, kicker.nick, kickee.nick, chan
@@ -667,7 +667,7 @@ IrcHandler.prototype.onKick = Promise.coroutine(function*(req, server,
  * @return {Promise} which is resolved/rejected when the request finishes.
  */
 IrcHandler.prototype.onPart = Promise.coroutine(function*(req, server, leavingUser, chan, kind) {
-    this._callCountMetrics["part"]++;
+    this.incrementMetric("part");
     // parts are always incremental (only NAMES are initial)
     if (!server.shouldSyncMembershipToMatrix("incremental", chan)) {
         req.log.info("Server doesn't mirror parts.");
@@ -712,7 +712,7 @@ IrcHandler.prototype.onPart = Promise.coroutine(function*(req, server, leavingUs
 
 IrcHandler.prototype.onMode = Promise.coroutine(function*(req, server, channel, by,
                                                 mode, enabled, arg) {
-    this._callCountMetrics["mode"]++;
+    this.incrementMetric("mode");
     req.log.info(
         "onMode(%s) in %s by %s (arg=%s)",
         (enabled ? ("+" + mode) : ("-" + mode)),
@@ -969,6 +969,13 @@ IrcHandler.prototype._setMatrixRoomAsInviteOnly = function(room, isInviteOnly) {
         }, ""
     );
 };
+
+IrcHandler.prototype.incrementMetric = function(metric) {
+    if (this._callCountMetrics[metric] === undefined) {
+        this._callCountMetrics[metric] = 0;
+    }
+    this._callCountMetrics[metric]++;
+}
 
 IrcHandler.prototype.getMetrics = function() {
     const metrics = Object.assign({}, this._callCountMetrics);

--- a/lib/bridge/MemberListSyncer.js
+++ b/lib/bridge/MemberListSyncer.js
@@ -347,7 +347,8 @@ MemberListSyncer.prototype._leaveUsersInRoom = Promise.coroutine(function*(item)
     // when this room is completely done.
     let self = this;
     let q = new Queue(Promise.coroutine(function*(userId) {
-        self._usersToLeave--; // Do this here, we might not manage to leave but we won't retry either.
+         // Do this here, we might not manage to leave but we won't retry.
+        self._usersToLeave--;
         yield self.ircBridge.getAppServiceBridge().getIntent(userId).leave(item.roomId);
         stats.membership(true, "part");
     }));
@@ -401,7 +402,7 @@ MemberListSyncer.prototype.updateIrcMemberList = Promise.coroutine(function*(cha
                 return ircUserIds.indexOf(userId) === -1;
             }
         );
-        
+
         this._usersToLeave += usersToLeave.length;
         // ID is the complete mapping of roomID/channel which will be unique
         promises.push(this._leaveQueuePool.enqueue(roomId + " " + channel, {

--- a/lib/bridge/MemberListSyncer.js
+++ b/lib/bridge/MemberListSyncer.js
@@ -31,6 +31,8 @@ function MemberListSyncer(ircBridge, appServiceBot, server, appServiceUserId, in
             //$channel : nick[]
         }
     };
+    // This is used for metrics
+    this._usersToLeave = 0;
 
     // A queue which controls the rate at which leaves are sent to Matrix. We need this queue
     // because Synapse is slow. Synapse locks based on the room ID, so there is no benefit to
@@ -345,6 +347,7 @@ MemberListSyncer.prototype._leaveUsersInRoom = Promise.coroutine(function*(item)
     // when this room is completely done.
     let self = this;
     let q = new Queue(Promise.coroutine(function*(userId) {
+        self._usersToLeave--; // Do this here, we might not manage to leave but we won't retry either.
         yield self.ircBridge.getAppServiceBridge().getIntent(userId).leave(item.roomId);
         stats.membership(true, "part");
     }));
@@ -398,6 +401,8 @@ MemberListSyncer.prototype.updateIrcMemberList = Promise.coroutine(function*(cha
                 return ircUserIds.indexOf(userId) === -1;
             }
         );
+        
+        this._usersToLeave += usersToLeave.length;
         // ID is the complete mapping of roomID/channel which will be unique
         promises.push(this._leaveQueuePool.enqueue(roomId + " " + channel, {
             roomId: roomId,
@@ -409,6 +414,10 @@ MemberListSyncer.prototype.updateIrcMemberList = Promise.coroutine(function*(cha
     );
     yield Promise.all(promises);
 });
+
+MemberListSyncer.prototype.getUsersWaitingToLeave = function() {
+    return this._usersToLeave;
+}
 
 function getRoomMemberData(server, roomId, stateEvents, appServiceUserId) {
     stateEvents = stateEvents || [];

--- a/lib/bridge/MemberListSyncer.js
+++ b/lib/bridge/MemberListSyncer.js
@@ -32,6 +32,7 @@ function MemberListSyncer(ircBridge, appServiceBot, server, appServiceUserId, in
         }
     };
     // This is used for metrics
+    this._usersToJoin = 0;
     this._usersToLeave = 0;
 
     // A queue which controls the rate at which leaves are sent to Matrix. We need this queue
@@ -70,7 +71,7 @@ MemberListSyncer.prototype.sync = Promise.coroutine(function*() {
     this.leaveIrcUsersFromRooms(rooms, server);
     start = Date.now();
     log.info("Joining Matrix users to IRC channels...");
-    yield joinMatrixUsersToChannels(rooms, server, this.injectJoinFn);
+    yield this._joinMatrixUsersToChannels(rooms, server, this.injectJoinFn);
     log.info("Joined Matrix users to IRC channels. (%sms)", Date.now() - start);
     // NB: We do not need to explicitly join IRC users to Matrix rooms
     // because we get all of the NAMEs/JOINs as events when we connect to
@@ -240,7 +241,7 @@ MemberListSyncer.prototype._getSyncableRooms = function() {
     return this._syncableRoomsPromise;
 };
 
-function joinMatrixUsersToChannels(rooms, server, injectJoinFn) {
+MemberListSyncer.prototype._joinMatrixUsersToChannels = function(rooms, server, injectJoinFn) {
     var d = promiseutil.defer();
 
     // filter out rooms listed in the rules
@@ -293,8 +294,9 @@ function joinMatrixUsersToChannels(rooms, server, injectJoinFn) {
     });
 
     log.debug("Got %s matrix join events to inject.", entries.length);
+    this._usersToJoin = entries.length;
     // take the first entry and inject a join event
-    function joinNextUser() {
+    const joinNextUser = () => {
         var entry = entries.shift();
         if (!entry) {
             d.resolve();
@@ -308,6 +310,7 @@ function joinMatrixUsersToChannels(rooms, server, injectJoinFn) {
             "Injecting join event for %s in %s (%s left) is_frontier=%s",
             entry.userId, entry.roomId, entries.length, entry.frontier
         );
+        this._usersToJoin--;
         injectJoinFn(entry.roomId, entry.userId, entry.displayName, entry.frontier).timeout(
             server.getMemberListFloodDelayMs()
         ).then(() => {
@@ -415,6 +418,10 @@ MemberListSyncer.prototype.updateIrcMemberList = Promise.coroutine(function*(cha
     );
     yield Promise.all(promises);
 });
+
+MemberListSyncer.prototype.getUsersWaitingToJoin = function() {
+    return this._usersToJoin;
+}
 
 MemberListSyncer.prototype.getUsersWaitingToLeave = function() {
     return this._usersToLeave;

--- a/lib/irc/ClientPool.js
+++ b/lib/irc/ClientPool.js
@@ -241,6 +241,14 @@ ClientPool.prototype.countTotalConnections = function() {
     return count;
 };
 
+ClientPool.prototype.totalReconnectsWaiting = function (serverDomain) {
+    if (this._reconnectQueues[serverDomain] !== undefined) {
+        return this._reconnectQueues[serverDomain].waitingItems;
+    } else {
+        return 0;
+    }
+}
+
 ClientPool.prototype._sendConnectionMetric = function(server) {
     stats.ircClients(server.domain, this._getNumberOfConnections(server));
 };

--- a/lib/irc/ClientPool.js
+++ b/lib/irc/ClientPool.js
@@ -244,9 +244,8 @@ ClientPool.prototype.countTotalConnections = function() {
 ClientPool.prototype.totalReconnectsWaiting = function (serverDomain) {
     if (this._reconnectQueues[serverDomain] !== undefined) {
         return this._reconnectQueues[serverDomain].waitingItems;
-    } else {
-        return 0;
     }
+    return 0;
 }
 
 ClientPool.prototype._sendConnectionMetric = function(server) {

--- a/spec/integ/irc-to-matrix.spec.js
+++ b/spec/integ/irc-to-matrix.spec.js
@@ -513,6 +513,7 @@ describe("IRC-to-Matrix name bridging", function() {
         config.ircService.servers[roomMapping.server].matrixClients.displayName = (
             "Test $NICK and $SERVER"
         );
+        config.ircService.servers[roomMapping.server].matrixClients.joinAttempts = 3;
         config.ircService.servers[roomMapping.server].membershipLists.enabled = true;
         config.ircService.servers[
             roomMapping.server

--- a/spec/integ/irc-to-matrix.spec.js
+++ b/spec/integ/irc-to-matrix.spec.js
@@ -616,7 +616,7 @@ describe("IRC-to-Matrix name bridging", function() {
         cli.joinRoom.and.callFake(function(r, opts) {
             if (count > 0) {
                 count--;
-                return Promise.reject({httpStatus: 504});
+                return Promise.reject({});
             }
             expect(r).toEqual(roomMapping.roomId);
             done();


### PR DESCRIPTION
This adds the following metrics: **EDITED**
- ``clientpool_reconnect_queue{serverdomain}``
  Number of IRC clients waiting to reconnect after losing connection.
- ``user_leave_queue{serverdomain}``
  Number of leaves queued I->M after receiving the /joined_users member set.
- ``user_join_queue{serverdomain}``
  Number of joins queued I->M after receiving the /joined_users member set.
- ``irchandler_calls{method}``
  Functions called in the IrcHandler. This includes things like ``onJoin`` which handles new IRC users appearing and onPart. Might be particularly useful in monitoring netsplits.

  