### PR TITLE
Configurable join retry

### DIFF
--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -258,6 +258,10 @@ ircService:
         # insert the IRC domain.
         # Optional. Default: "$NICK (IRC)". Example: "Alice (IRC)"
         displayName: "$NICK (IRC)"
+        # Number of tries a client can attempt to join a room before the request
+        # is discarded. Set to 0 to never retry.
+        # Optional. Default: 0
+        joinAttempts: 5
 
       # Configuration for virtual IRC users. The following variables are exposed:
       # $LOCALPART => The user ID localpart ("alice" in @alice:localhost)

--- a/lib/bridge/IrcHandler.js
+++ b/lib/bridge/IrcHandler.js
@@ -12,7 +12,6 @@ var MatrixAction = require("../models/MatrixAction");
 var Queue = require("../util/Queue.js");
 var QuitDebouncer = require("./QuitDebouncer.js");
 
-const MAX_JOIN_ATTEMPTS = 1000;
 const JOIN_DELAY_MS = 250;
 
 function IrcHandler(ircBridge) {
@@ -522,6 +521,7 @@ IrcHandler.prototype.onJoin = Promise.coroutine(function*(req, server, joiningUs
     const intent = this.ircBridge.getAppServiceBridge().getIntent(
         matrixUser.getId()
     );
+    const MAX_JOIN_ATTEMPTS = server.getJoinAttempts();
     let promises = matrixRooms.map((room) => {
         /** If this is a "NAMES" query, we can make use of the joinedMembers call we made
          * to check if the user already exists in the room. This should save oodles of time.

--- a/lib/bridge/IrcHandler.js
+++ b/lib/bridge/IrcHandler.js
@@ -538,7 +538,7 @@ IrcHandler.prototype.onJoin = Promise.coroutine(function*(req, server, joiningUs
         const joinRetry = (attempts) => {
             req.log.debug(`Joining room (attempts:${attempts})`);
             return intent.join(room.getId()).catch((err) => {
-                if (attempts > MAX_JOIN_ATTEMPTS || err.httpStatus === undefined || err.httpStatus <= 500) {
+                if (attempts > MAX_JOIN_ATTEMPTS) {
                     req.log.error(`Not retrying join for ${room.getId()}.`);
                     return Promise.reject(err);
                 }

--- a/lib/bridge/IrcHandler.js
+++ b/lib/bridge/IrcHandler.js
@@ -543,8 +543,8 @@ IrcHandler.prototype.onJoin = Promise.coroutine(function*(req, server, joiningUs
                     return Promise.reject(err);
                 }
                 attempts++;
-                const delay = JOIN_DELAY_MS*attempts;
-                req.log.warn(`Failed to join ${room.getId()} attempts:${attempts} ${err}.delaying for ${delay}ms`);
+                const delay = (JOIN_DELAY_MS * attempts) + (Math.random() * 500);
+                req.log.warn(`Failed to join ${room.getId()}, delaying for ${delay}ms`);
                 req.log.debug(`Failed with: ${err.errcode} ${err.message}`);
                 return Promise.delay(delay).then(() => {
                     return joinRetry(attempts);

--- a/lib/config/schema.yml
+++ b/lib/config/schema.yml
@@ -256,6 +256,9 @@ properties:
                                 displayName:
                                     type: "string"
                                     pattern: "\\$NICK"
+                                joinAttempts:
+                                    type: "integer"
+                                    minimum: 0
                         ircClients:
                             type: "object"
                             properties:

--- a/lib/irc/IrcServer.js
+++ b/lib/irc/IrcServer.js
@@ -248,6 +248,10 @@ IrcServer.prototype.getLineLimit = function() {
     return this.config.ircClients.lineLimit;
 };
 
+IrcServer.prototype.getJoinAttempts = function() {
+    return this.config.matrixClients.joinAttempts;
+};
+
 IrcServer.prototype.isExcludedChannel = function(channel) {
     return this.config.dynamicChannels.exclude.indexOf(channel) !== -1;
 };


### PR DESCRIPTION
New "joinAttempts" config option which allows admins to configure how many attempts a join can take before giving up in``IrcHandler``. Setting to 0 switches the feature off.