### PR TITLE
Set rawResponse=true in line with current default behaviour of matrix-js-sdk

### DIFF
--- a/lib/bridge/IrcBridge.js
+++ b/lib/bridge/IrcBridge.js
@@ -463,6 +463,7 @@ IrcBridge.prototype.uploadTextFile = function(fileName, plaintext, req) {
         stream: new Buffer(plaintext),
         name: fileName,
         type: "text/plain; charset=utf-8",
+        rawResponse: true,
     });
 };
 


### PR DESCRIPTION
```
Returning the raw JSON from uploadContent(). Future versions of the js-sdk will change this default, to return the parsed object. Set opts.rawResponse=false to change this behaviour now.
```
Currently the logs are full of this error.

Setting rawResponse=true is smallest change that will remove the warning, which reduces noise in the logs.

This was changed in the matrix-js-sdk nearly two years ago: https://github.com/matrix-org/matrix-js-sdk/pull/230