### PR TITLE
Cache mode internally

### DIFF
--- a/lib/DataStore.js
+++ b/lib/DataStore.js
@@ -325,23 +325,22 @@ DataStore.prototype.getModesForChannel = function (server, channel) {
     });
 };
 
-DataStore.prototype.setModeForRoom = Promise.coroutine(function*(roomId, mode, remove=False) {
-    log.info("setModeForRoom (mode=%s, roomId=%s, remove=%s)",
-        mode, roomId, remove
+DataStore.prototype.setModeForRoom = Promise.coroutine(function*(roomId, mode, enabled=True) {
+    log.info("setModeForRoom (mode=%s, roomId=%s, enabled=%s)",
+        mode, roomId, enabled
     );
     this._roomStore.getEntriesByMatrixId(roomId).then((entries) => {
         entries.forEach((entry) => {
             const modes = entry.remote.get("modes") || [];
             const hasMode = modes.includes(mode);
 
-            if ((!hasMode && remove) || (hasMode && !remove)) {
+            if ((!hasMode && !enabled) || (hasMode && enabled)) {
                 return;
             }
-
-            if (remove) {
-                modes.splice(modes.indexOf(mode), 1);
-            } else {
+            if (enabled) {
                 modes.push(mode);
+            } else {
+                modes.splice(modes.indexOf(mode), 1);
             }
 
             entry.remote.set("modes", modes);

--- a/lib/DataStore.js
+++ b/lib/DataStore.js
@@ -311,6 +311,46 @@ DataStore.prototype.getMappingsForChannelByOrigin = function(server, channel, or
     });
 };
 
+DataStore.prototype.getModesForChannel = function (server, channel) {
+    log.info("getModesForChannel (server=%s, channel=%s)",
+        server.domain, channel
+    );
+    let remoteId = IrcRoom.createId(server, channel);
+    return this._roomStore.getEntriesByRemoteId(remoteId).then((entries) => {
+        const mapping = {};
+        entries.forEach((entry) => {
+            mapping[entry.matrix.getId()] = entry.remote.get("modes") || [];
+        });
+        return mapping;
+    });
+};
+
+DataStore.prototype.setModeForRoom = Promise.coroutine(function*(roomId, mode, remove=False) {
+    log.info("setModeForRoom (mode=%s, roomId=%s, remove=%s)",
+        mode, roomId, remove
+    );
+    this._roomStore.getEntriesByMatrixId(roomId).then((entries) => {
+        entries.forEach((entry) => {
+            const modes = entry.remote.get("modes") || [];
+            const hasMode = modes.includes(mode);
+
+            if ((!hasMode && remove) || (hasMode && !remove)) {
+                return;
+            }
+
+            if (remove) {
+                modes.splice(modes.indexOf(mode), 1);
+            } else {
+                modes.push(mode);
+            }
+
+            entry.remote.set("modes", modes);
+
+            return this._roomStore.upsertEntry(entry);
+        });
+    });
+});
+
 DataStore.prototype.setPmRoom = function(ircRoom, matrixRoom, userId, virtualUserId) {
     log.info("setPmRoom (id=%s, addr=%s chan=%s real=%s virt=%s)",
         matrixRoom.getId(), ircRoom.server.domain, ircRoom.channel, userId,

--- a/lib/DataStore.js
+++ b/lib/DataStore.js
@@ -329,8 +329,8 @@ DataStore.prototype.setModeForRoom = Promise.coroutine(function*(roomId, mode, e
     log.info("setModeForRoom (mode=%s, roomId=%s, enabled=%s)",
         mode, roomId, enabled
     );
-    this._roomStore.getEntriesByMatrixId(roomId).then((entries) => {
-        entries.forEach((entry) => {
+    return this._roomStore.getEntriesByMatrixId(roomId).then((entries) => {
+        entries.map((entry) => {
             const modes = entry.remote.get("modes") || [];
             const hasMode = modes.includes(mode);
 
@@ -339,13 +339,14 @@ DataStore.prototype.setModeForRoom = Promise.coroutine(function*(roomId, mode, e
             }
             if (enabled) {
                 modes.push(mode);
-            } else {
+            }
+            else {
                 modes.splice(modes.indexOf(mode), 1);
             }
 
             entry.remote.set("modes", modes);
 
-            return this._roomStore.upsertEntry(entry);
+            this._roomStore.upsertEntry(entry);
         });
     });
 });

--- a/lib/DataStore.js
+++ b/lib/DataStore.js
@@ -334,7 +334,7 @@ DataStore.prototype.setModeForRoom = Promise.coroutine(function*(roomId, mode, e
             const modes = entry.remote.get("modes") || [];
             const hasMode = modes.includes(mode);
 
-            if ((!hasMode && !enabled) || (hasMode && enabled)) {
+            if (hasMode === enabled) {
                 return;
             }
             if (enabled) {

--- a/lib/bridge/IrcHandler.js
+++ b/lib/bridge/IrcHandler.js
@@ -883,7 +883,6 @@ IrcHandler.prototype._onPrivateMode = Promise.coroutine(function*(req, server, c
                     "Reverting %s back to default join_rule"),
                     room.getId()
                 );
-                this.ircBridge.getStore().setModeForRoom(room.getId(), mode, enabled);
                 if (enabled) {
                     return this._setMatrixRoomAsInviteOnly(room, true);
                 }
@@ -898,7 +897,11 @@ IrcHandler.prototype._onPrivateMode = Promise.coroutine(function*(req, server, c
         }
     });
 
-    yield Promise.all(promises);
+    yield Promise.all(promises).then(() => {
+        matrixRooms.forEach((room) => {
+            this.ircBridge.getStore().setModeForRoom(room.getId(), mode, enabled);
+        });
+    });
 });
 
 /**

--- a/lib/bridge/IrcHandler.js
+++ b/lib/bridge/IrcHandler.js
@@ -14,6 +14,12 @@ var QuitDebouncer = require("./QuitDebouncer.js");
 
 const JOIN_DELAY_MS = 250;
 const JOIN_DELAY_CAP_MS = 30 * 60 * 1000; // 30 mins
+const MODES_TO_WATCH = [
+    "m", // We want to ensure we do not miss rooms that get unmoderated.
+    "k",
+    "i",
+    "s"
+];
 
 function IrcHandler(ircBridge) {
     this.ircBridge = ircBridge;

--- a/lib/bridge/IrcHandler.js
+++ b/lib/bridge/IrcHandler.js
@@ -830,7 +830,7 @@ IrcHandler.prototype._onModeratedChannelToggle = Promise.coroutine(function*(req
                 "onModeratedChannelToggle: (channel=%s,enabled=%s) power levels updated in room %s",
                 channel, enabled, roomId
             );
-            this.ircBridge.getStore().setModeForRoom(roomId, "m", !enabled);
+            this.ircBridge.getStore().setModeForRoom(roomId, "m", enabled);
         }
         catch (err) {
             req.log.error("Failed to alter power level in room %s : %s", roomId, err);

--- a/lib/bridge/IrcHandler.js
+++ b/lib/bridge/IrcHandler.js
@@ -882,7 +882,7 @@ IrcHandler.prototype._onPrivateMode = Promise.coroutine(function*(req, server, c
                 return this._setMatrixRoomAsInviteOnly(room, enabled);
             default:
                 // Not reachable, but warn anyway in case of future additions
-                log.warn(`onMode: Unhandled channel mode ${mode}`);
+                req.log.warn(`onMode: Unhandled channel mode ${mode}`);
                 return Promise.resolve();
         }
     });

--- a/lib/bridge/IrcHandler.js
+++ b/lib/bridge/IrcHandler.js
@@ -824,6 +824,7 @@ IrcHandler.prototype._onModeratedChannelToggle = Promise.coroutine(function*(req
                 "onModeratedChannelToggle: (channel=%s,enabled=%s) power levels updated in room %s",
                 channel, enabled, roomId
             );
+            this.ircBridge.getStore().setModeForRoom(roomId, "m", !enabled);
         }
         catch (err) {
             req.log.error("Failed to alter power level in room %s : %s", roomId, err);

--- a/lib/bridge/IrcHandler.js
+++ b/lib/bridge/IrcHandler.js
@@ -875,7 +875,9 @@ IrcHandler.prototype._onPrivateMode = Promise.coroutine(function*(req, server, c
         );
     } else {
         // "k" and "i"
-        this.ircBridge.getStore().setModeForRoom(room.getId(), mode, enabled);
+        matrixRooms.map((room) => {
+            this.ircBridge.getStore().setModeForRoom(room.getId(), mode, enabled);
+        });
     }
 
     var promises = matrixRooms.map((room) => {

--- a/lib/bridge/IrcHandler.js
+++ b/lib/bridge/IrcHandler.js
@@ -873,12 +873,11 @@ IrcHandler.prototype._onPrivateMode = Promise.coroutine(function*(req, server, c
         return this.ircBridge.publicitySyncer.updateVisibilityMap(
             true, key, enabled
         );
-    } else {
-        // "k" and "i"
-        matrixRooms.map((room) => {
-            this.ircBridge.getStore().setModeForRoom(room.getId(), mode, enabled);
-        });
     }
+    // "k" and "i"
+    matrixRooms.map((room) => {
+        this.ircBridge.getStore().setModeForRoom(room.getId(), mode, enabled);
+    });
 
     var promises = matrixRooms.map((room) => {
         switch (mode) {
@@ -929,8 +928,8 @@ IrcHandler.prototype.onModeIs = Promise.coroutine(function*(req, server, channel
     // We cache modes per room, so extract the set of modes for all these rooms.
     const roomModeMap = yield this.ircBridge.getStore().getModesForChannel(server, channel);
     const oldModes = new Set();
-    Object.values(roomModeMap).forEach((mode) => {
-        mode.forEach((m) => {oldModes.add(m)});
+    Object.values(roomModeMap).forEach((roomMode) => {
+        roomMode.forEach((m) => {oldModes.add(m)});
     });
     req.log.debug(`Got cached mode for ${channel} ${[...oldModes]}`);
 
@@ -939,7 +938,7 @@ IrcHandler.prototype.onModeIs = Promise.coroutine(function*(req, server, channel
         if (!MODES_TO_WATCH.includes(oldModeChar)) {
             return Promise.resolve();
         }
-        req.log.debug(`${server.domain} ${channel}: Checking if cached mode '${oldModeChar}' is still set.`);
+        req.log.debug(`${server.domain} ${channel}: Checking if '${oldModeChar}' is still set.`);
         if (!mode.includes(oldModeChar)) { // If the mode is no longer here.
             req.log.debug(`${oldModeChar} has been unset, disabling.`);
             return this.onMode(req, server, channel, 'onModeIs function', oldModeChar, false);

--- a/lib/bridge/IrcHandler.js
+++ b/lib/bridge/IrcHandler.js
@@ -911,10 +911,25 @@ IrcHandler.prototype.onModeIs = Promise.coroutine(function*(req, server, channel
         }
     );
 
-    // If the channel does not have 's' as part of its mode, trigger the equivalent of '-s'
-    if (mode.indexOf('s') === -1) {
-        promises.push(this.onMode(req, server, channel, 'onModeIs function', 's', false));
-    }
+    // We cache modes per room, so extract the set of modes for all these rooms.
+    const roomModeMap = yield this.ircBridge.getStore().getModesForChannel(server, channel);
+    const oldModes = new Set();
+    Object.values(roomModeMap).forEach((mode) => {
+        mode.forEach((m) => {oldModes.add(m)});
+    });
+    req.log.debug(`Got cached mode for ${channel} ${[...oldModes]}`);
+
+    // For each cached mode we have for the room, that is no longer set: emit a disabled mode.
+    promises.concat([...oldModes].map((oldModeChar) => {
+        if (!MODES_TO_WATCH.includes(oldModeChar)) {
+            return Promise.resolve();
+        }
+        req.log.debug(`${server.domain} ${channel}: Checking if cached mode '${oldModeChar}' is still set.`);
+        if (!mode.includes(oldModeChar)) { // If the mode is no longer here.
+            req.log.debug(`${oldModeChar} has been unset, disabling.`);
+            return this.onMode(req, server, channel, 'onModeIs function', oldModeChar, false);
+        }
+    }));
 
     yield Promise.all(promises);
 });

--- a/lib/bridge/IrcHandler.js
+++ b/lib/bridge/IrcHandler.js
@@ -873,6 +873,9 @@ IrcHandler.prototype._onPrivateMode = Promise.coroutine(function*(req, server, c
         return this.ircBridge.publicitySyncer.updateVisibilityMap(
             true, key, enabled
         );
+    } else {
+        // "k" and "i"
+        this.ircBridge.getStore().setModeForRoom(room.getId(), mode, enabled);
     }
 
     var promises = matrixRooms.map((room) => {
@@ -897,11 +900,7 @@ IrcHandler.prototype._onPrivateMode = Promise.coroutine(function*(req, server, c
         }
     });
 
-    yield Promise.all(promises).then(() => {
-        matrixRooms.forEach((room) => {
-            this.ircBridge.getStore().setModeForRoom(room.getId(), mode, enabled);
-        });
-    });
+    yield Promise.all(promises);
 });
 
 /**

--- a/lib/bridge/IrcHandler.js
+++ b/lib/bridge/IrcHandler.js
@@ -866,6 +866,9 @@ IrcHandler.prototype._onPrivateMode = Promise.coroutine(function*(req, server, c
         }
         const key = this.ircBridge.publicitySyncer.getIRCVisMapKey(server.getNetworkId(), channel);
 
+        matrixRooms.map((room) => {
+            this.ircBridge.getStore().setModeForRoom(room.getId(), "s", enabled);
+        });
         // Update the visibility for all rooms connected to this channel
         return this.ircBridge.publicitySyncer.updateVisibilityMap(
             true, key, enabled
@@ -880,6 +883,7 @@ IrcHandler.prototype._onPrivateMode = Promise.coroutine(function*(req, server, c
                     "Reverting %s back to default join_rule"),
                     room.getId()
                 );
+                this.ircBridge.getStore().setModeForRoom(room.getId(), mode, enabled);
                 if (enabled) {
                     return this._setMatrixRoomAsInviteOnly(room, true);
                 }


### PR DESCRIPTION
This PR adds mode caching to rooms (which are actually the channels modes, but we set them per room anyway). The modes that will be stored are ``m,i,k and s``.

This will currently only help with tracking modes across restarts, but will help us work out why a room has become desynced when it happens.