### PR TITLE
Delay part/kick mirroring until inflight messages are completed.

### DIFF
--- a/lib/bridge/IrcBridge.js
+++ b/lib/bridge/IrcBridge.js
@@ -191,7 +191,7 @@ IrcBridge.prototype._initialiseMetrics = function() {
         help: "Track membership changes which are delayed behind inflight messages",
         labels: []
     });
-    
+
     const matrixHandlerConnFailureKicks = metrics.addCounter({
         name: "matrixhandler_connection_failure_kicks",
         help: "Track IRC connection failures resulting in kicks",

--- a/lib/bridge/IrcBridge.js
+++ b/lib/bridge/IrcBridge.js
@@ -204,7 +204,7 @@ IrcBridge.prototype._initialiseMetrics = function() {
                 this._clientPool.totalReconnectsWaiting(server.domain)
             );
             let mxMetrics = this.matrixHandler.getMetrics(server.domain);
-            matrixHandlerConnFailureKicks.set(
+            matrixHandlerConnFailureKicks.inc(
                 {server: server.domain},
                 mxMetrics["connection_failure_kicks"] || 0
             );

--- a/lib/bridge/IrcBridge.js
+++ b/lib/bridge/IrcBridge.js
@@ -572,6 +572,13 @@ IrcBridge.prototype.userHasMessagesInFlight = function(room, virtualUser) {
     return val > 0;
 }
 
+IrcBridge.prototype.getUserMessagesInFlightCount = function(room, virtualUser) {
+    // Undefined == 0 here, thanks JavaScript.
+    const key = `${room.getId()}:${virtualUser.getId()}`;
+    const val = this._messagesInFlight[key];
+    return val || 0;
+}
+
 IrcBridge.prototype.uploadTextFile = function(fileName, plaintext, req) {
     return this._bridge.getIntent().getClient().uploadContent({
         stream: new Buffer(plaintext),

--- a/lib/bridge/IrcBridge.js
+++ b/lib/bridge/IrcBridge.js
@@ -185,6 +185,12 @@ IrcBridge.prototype._initialiseMetrics = function() {
         help: "Track calls made to the IRC Handler",
         labels: ["method"]
     });
+
+    const ircHandlerMembershipDelayed = metrics.addGauge({
+        name: "irchandler_delayed_membership",
+        help: "Track membership changes which are delayed behind inflight messages",
+        labels: []
+    });
     metrics.addCollector(() => {
         this.ircServers.forEach((server) => {
             reconnQueue.set({server: server.domain},
@@ -204,10 +210,11 @@ IrcBridge.prototype._initialiseMetrics = function() {
         });
 
         const ircMetrics = this.ircHandler.getMetrics();
-        Object.keys(ircMetrics).forEach((method) => {
+        Object.keys(ircMetrics.callCounters).forEach((method) => {
             const value = ircMetrics[method];
             ircHandlerCalls.inc({method}, value);
         });
+        ircHandlerMembershipDelayed.set(ircMetrics.delayedMembership);
     });
 };
 

--- a/lib/bridge/IrcBridge.js
+++ b/lib/bridge/IrcBridge.js
@@ -120,7 +120,7 @@ function IrcBridge(config, registration) {
 
     this._messagesInFlight = {
         //"roomId:userId" => number
-    }
+    };
 }
 
 IrcBridge.prototype._initialiseMetrics = function() {
@@ -501,24 +501,26 @@ IrcBridge.prototype.sendMatrixAction = function(room, from, action, req) {
     let msgtype = ACTION_TYPE_TO_MSGTYPE[action.type];
     let intent = this._bridge.getIntent(from.userId);
     if (msgtype) {
-        this._incrementMessageInFlight(room, from);
+        this._incrementMessagesInFlight(room, from);
+        let messageContent;
         if (action.htmlText) {
-            return intent.sendMessage(room.getId(), {
+            messageContent = {
                 msgtype: msgtype,
                 body: (
                     action.text || action.htmlText.replace(/(<([^>]+)>)/ig, "") // strip html tags
                 ),
                 format: "org.matrix.custom.html",
                 formatted_body: action.htmlText
-            }).finally(() => {
-                this._decrementMessageInFlight(room, from);
-            })
+            };
         }
-        return intent.sendMessage(room.getId(), {
-            msgtype: msgtype,
-            body: action.text
-        }).finally(() => {
-            this._decrementMessageInFlight(room, from);
+        else {
+            messageContent = {
+                msgtype: msgtype,
+                body: action.text
+            };
+        }
+        return intent.sendMessage(room.getId(), messageContent).finally(() => {
+            this._decrementMessagesInFlight(room, from);
         });
     }
     else if (action.type === "topic") {
@@ -527,9 +529,9 @@ IrcBridge.prototype.sendMatrixAction = function(room, from, action, req) {
     return Promise.reject(new Error("Unknown action: " + action.type));
 };
 
-IrcBridge.prototype._incrementMessageInFlight = function(room, virtualUser) {
+IrcBridge.prototype._incrementMessagesInFlight = function(room, virtualUser) {
     const key = `${room.getId()}:${virtualUser.getId()}`;
-    if (this._messagesInFlight[key] === undefined) {
+    if (!this._messagesInFlight[key]) {
         this._messagesInFlight[key] = 1;
     }
     else {
@@ -537,19 +539,17 @@ IrcBridge.prototype._incrementMessageInFlight = function(room, virtualUser) {
     }
 }
 
-IrcBridge.prototype._decrementMessageInFlight = function(room, virtualUser) {
+IrcBridge.prototype._decrementMessagesInFlight = function(room, virtualUser) {
     const key = `${room.getId()}:${virtualUser.getId()}`;
-    if (this._messagesInFlight[key] === undefined) {
-        this._messagesInFlight[key] = 0;
-    }
-    else {
+    if (this._messagesInFlight[key] > 0) {
         this._messagesInFlight[key]--;
     }
 }
 
 IrcBridge.prototype.userHasMessagesInFlight = function(room, virtualUser) {
     // Undefined == 0 here, thanks JavaScript.
-    const val = this._messagesInFlight[`${room.getId()}:${virtualUser.getId()}`];
+    const key = `${room.getId()}:${virtualUser.getId()}`;
+    const val = this._messagesInFlight[key];
     return val > 0;
 }
 

--- a/lib/bridge/IrcBridge.js
+++ b/lib/bridge/IrcBridge.js
@@ -117,6 +117,10 @@ function IrcBridge(config, registration) {
     this._provisioner = null;
 
     this.publicitySyncer = new PublicitySyncer(this);
+
+    this._messagesInFlight = {
+        //"roomId:userId" => number
+    }
 }
 
 IrcBridge.prototype._initialiseMetrics = function() {
@@ -497,6 +501,7 @@ IrcBridge.prototype.sendMatrixAction = function(room, from, action, req) {
     let msgtype = ACTION_TYPE_TO_MSGTYPE[action.type];
     let intent = this._bridge.getIntent(from.userId);
     if (msgtype) {
+        this._incrementMessageInFlight(room, from);
         if (action.htmlText) {
             return intent.sendMessage(room.getId(), {
                 msgtype: msgtype,
@@ -505,11 +510,15 @@ IrcBridge.prototype.sendMatrixAction = function(room, from, action, req) {
                 ),
                 format: "org.matrix.custom.html",
                 formatted_body: action.htmlText
-            });
+            }).finally(() => {
+                this._decrementMessageInFlight(room, from);
+            })
         }
         return intent.sendMessage(room.getId(), {
             msgtype: msgtype,
             body: action.text
+        }).finally(() => {
+            this._decrementMessageInFlight(room, from);
         });
     }
     else if (action.type === "topic") {
@@ -517,6 +526,30 @@ IrcBridge.prototype.sendMatrixAction = function(room, from, action, req) {
     }
     return Promise.reject(new Error("Unknown action: " + action.type));
 };
+
+IrcBridge.prototype._incrementMessageInFlight = function(room, virtualUser) {
+    const key = `${room.getId()}:${virtualUser.getId()}`;
+    if (this._messagesInFlight[key] === undefined) {
+        this._messagesInFlight[key] = 1;
+    } else {
+        this._messagesInFlight[key]++;
+    }
+}
+
+IrcBridge.prototype._decrementMessageInFlight = function(room, virtualUser) {
+    const key = `${room.getId()}:${virtualUser.getId()}`;
+    if (this._messagesInFlight[key] === undefined) {
+        this._messagesInFlight[key] = 0;
+    } else {
+        this._messagesInFlight[key]--;
+    }
+}
+
+IrcBridge.prototype.userHasMessagesInFlight = function(room, virtualUser) {
+    // Undefined == 0 here, thanks JavaScript.
+    const val = this._messagesInFlight[`${room.getId()}:${virtualUser.getId()}`];
+    return val > 0;
+}
 
 IrcBridge.prototype.uploadTextFile = function(fileName, plaintext, req) {
     return this._bridge.getIntent().getClient().uploadContent({
@@ -959,6 +992,7 @@ IrcBridge.prototype.getBotClient = function(server) {
         return this._clientPool.getBot(server);
     });
 }
+
 IrcBridge.prototype._fetchJoinedRooms = Promise.coroutine(function*() {
     /** Fetching joined rooms is quicker on larger homeservers than trying to
      * /join each room in the mappings list. To ensure we start quicker,

--- a/lib/bridge/IrcBridge.js
+++ b/lib/bridge/IrcBridge.js
@@ -531,7 +531,8 @@ IrcBridge.prototype._incrementMessageInFlight = function(room, virtualUser) {
     const key = `${room.getId()}:${virtualUser.getId()}`;
     if (this._messagesInFlight[key] === undefined) {
         this._messagesInFlight[key] = 1;
-    } else {
+    }
+    else {
         this._messagesInFlight[key]++;
     }
 }
@@ -540,7 +541,8 @@ IrcBridge.prototype._decrementMessageInFlight = function(room, virtualUser) {
     const key = `${room.getId()}:${virtualUser.getId()}`;
     if (this._messagesInFlight[key] === undefined) {
         this._messagesInFlight[key] = 0;
-    } else {
+    }
+    else {
         this._messagesInFlight[key]--;
     }
 }

--- a/lib/bridge/IrcHandler.js
+++ b/lib/bridge/IrcHandler.js
@@ -754,7 +754,7 @@ IrcHandler.prototype.onPart = Promise.coroutine(function*(req, server, leavingUs
         return this.delayMembershipWhileInFlight(
             room, matrixUser, "leave", intent
         ).then((delayed) => {
-            req.log.info(`Left room ${room.getId()} (delayed:${!!delayed})`);
+            req.log.info(`Left room ${room.getId()} (delayed:${delayed === true})`);
         });
     });
     stats.membership(true, "part");

--- a/lib/bridge/IrcHandler.js
+++ b/lib/bridge/IrcHandler.js
@@ -489,7 +489,9 @@ IrcHandler.prototype.onMessage = Promise.coroutine(function*(req, server, fromUs
         req.log.info(
             "Relaying in room %s", room.getId()
         );
-        return this.ircBridge.sendMatrixAction(room, virtualMatrixUser, mxAction, req).finally(() => {
+        return this.ircBridge.sendMatrixAction(
+            room, virtualMatrixUser, mxAction, req
+        ).finally(() => {
             return this.processDelayedMembership(room, virtualMatrixUser, req);
         });
     });
@@ -661,8 +663,12 @@ IrcHandler.prototype.onKick = Promise.coroutine(function*(req, server,
             const intent = this.ircBridge.getAppServiceBridge().getIntent(
                 matrixUser.getId()
             );
-            return this.delayMembershipWhileInFlight(room, matrixUser, "leave", intent).then((delayed) => {
-                req.log.info(`Left room (due to kick) ${room.getId()} (delayed:${Boolean(delayed)})`);
+            return this.delayMembershipWhileInFlight(
+                room, matrixUser, "leave", intent
+            ).then((delayed) => {
+                req.log.info(
+                    `Left room (due to kick) ${room.getId()} (delayed:${!!delayed})`
+                );
             });
         });
         yield Promise.all(promises);
@@ -716,28 +722,32 @@ IrcHandler.prototype.onPart = Promise.coroutine(function*(req, server, leavingUs
         const intent = this.ircBridge.getAppServiceBridge().getIntent(
             matrixUser.getId()
         );
-        return this.delayMembershipWhileInFlight(room, matrixUser, "leave", intent).then((delayed) => {
-            req.log.info(`Left room ${room.getId()} (delayed:${Boolean(delayed)})`);
+        return this.delayMembershipWhileInFlight(
+            room, matrixUser, "leave", intent
+        ).then((delayed) => {
+            req.log.info(`Left room ${room.getId()} (delayed:${!!delayed})`);
         });
     });
     stats.membership(true, "part");
     yield Promise.all(promises);
 });
 
-IrcHandler.prototype.delayMembershipWhileInFlight = function(room, matrixUser, operation, intent, reason=null) {
-    if (this.ircBridge.userHasMessagesInFlight(room, matrixUser)) {
-        /* This either sets or overwrites membership on purpose so we don't
-           have conflicting, and possibly racy operations for a user.
-
-           This comes at the cost of not fully replicating a leave and join on the
-           matrix side, but just the membership delta.
-           I.e a leave,join,leave will be sent as a single leave if lots of messages are in flight.*/
-        this.membershipWaiting[`${room.getId()}:${matrixUser.getId()}`] = {operation, reason, intent};
-        return Promise.resolve(true);
-    } else {
+IrcHandler.prototype.delayMembershipWhileInFlight = function(room, matrixUser, operation,
+                                                             intent, reason=null) {
+    if (!this.ircBridge.userHasMessagesInFlight(room, matrixUser)) {
         // We don't need to wait, just dooo it.
         return intent[operation](room.getId(), matrixUser.getId(), reason);
     }
+    /* This either sets or overwrites membership on purpose so we don't
+    have conflicting, and possibly racy operations for a user.
+
+    This comes at the cost of not fully replicating a leave and join on the
+    matrix side, but just the membership delta. A leave,join,leave will
+    be sent as a single leave if lots of messages are in flight. */
+    this.membershipWaiting[`${room.getId()}:${matrixUser.getId()}`] = {
+        operation, reason, intent
+    };
+    return Promise.resolve(true);
 }
 
 IrcHandler.prototype.processDelayedMembership = function(room, matrixUser, req) {
@@ -748,7 +758,8 @@ IrcHandler.prototype.processDelayedMembership = function(room, matrixUser, req) 
     }
     // Drop since we are now processing it.
     delete this.membershipWaiting[key];
-    req.log.info(`Sending delayed membership ${membership.operation} for ${matrixUser.getId()} in ${room.getId()}`);
+    req.log.info(`Sending delayed membership ${membership.operation} ` +
+                 `for ${matrixUser.getId()} in ${room.getId()}`);
     const intent = membership.intent;
     return intent[membership.operation](room.getId(), matrixUser.getId(), membership.reason);
 };

--- a/lib/bridge/IrcHandler.js
+++ b/lib/bridge/IrcHandler.js
@@ -778,7 +778,7 @@ IrcHandler.prototype.delayMembershipWhileInFlight = function(room, matrixUser, o
 
 IrcHandler.prototype.processDelayedMembership = function(room, matrixUser, req) {
     const key = `${room.getId()}:${matrixUser.getId()}`;
-    if ( this.membershipWaiting.has(key) ||
+    if ( !this.membershipWaiting.has(key) ||
          this.ircBridge.userHasMessagesInFlight(room, matrixUser)) {
         return;
     }

--- a/lib/bridge/IrcHandler.js
+++ b/lib/bridge/IrcHandler.js
@@ -16,7 +16,7 @@ const JOIN_DELAY_MS = 250;
 const JOIN_DELAY_CAP_MS = 30 * 60 * 1000; // 30 mins
 
 // Delay for when messages are inflight and we want to leave.
-const LEAVE_INFLIGHT_DELAY = 500;
+const LEAVE_INFLIGHT_DELAY_MS = 500;
 
 function IrcHandler(ircBridge) {
     this.ircBridge = ircBridge;
@@ -654,10 +654,12 @@ IrcHandler.prototype.onKick = Promise.coroutine(function*(req, server,
             return;
         }
         let promises = matrixRooms.map((room) => {
-            req.log.info("Leaving (due to kick) room %s", room.getId());
-            return this.ircBridge.getAppServiceBridge().getIntent(
-                matrixUser.getId()
-            ).leave(room.getId());
+            return this.delayWhileInflight(room, matrixUser).then(() => {
+                req.log.info("Leaving (due to kick) room %s", room.getId());
+                return this.ircBridge.getAppServiceBridge().getIntent(
+                    matrixUser.getId()
+                ).leave(room.getId());
+            });
         });
         yield Promise.all(promises);
     }
@@ -706,18 +708,8 @@ IrcHandler.prototype.onPart = Promise.coroutine(function*(req, server, leavingUs
         }
     }
 
-    const delayForInflight = (room) => {
-        if (this.ircBridge.userHasMessagesInFlight(room, matrixUser)) {
-            req.log.info(`User has messages inflight, delaying for ${LEAVE_INFLIGHT_DELAY}ms`);
-            return Promise.delay(LEAVE_INFLIGHT_DELAY).then(() => {
-                return delayForInflight(room);
-            });
-        }
-        return Promise.resolve();
-    };
-
     let promises = matrixRooms.map((room) => {
-        return delayForInflight(room).then(() => {
+        return this.delayWhileInflight(room, matrixUser).then(() => {
             req.log.info("Leaving room %s", room.getId());
             return this.ircBridge.getAppServiceBridge().getIntent(
                 matrixUser.getId()
@@ -727,6 +719,15 @@ IrcHandler.prototype.onPart = Promise.coroutine(function*(req, server, leavingUs
     stats.membership(true, "part");
     yield Promise.all(promises);
 });
+
+IrcHandler.prototype.delayWhileInflight = function(room, matrixUser) {
+    if (this.ircBridge.userHasMessagesInFlight(room, matrixUser)) {
+        return Promise.delay(LEAVE_INFLIGHT_DELAY_MS).then(() => {
+            return this.delayWhileInflight(room, matrixUser);
+        });
+    }
+    return Promise.resolve();
+}
 
 IrcHandler.prototype.onMode = Promise.coroutine(function*(req, server, channel, by,
                                                 mode, enabled, arg) {

--- a/lib/bridge/IrcHandler.js
+++ b/lib/bridge/IrcHandler.js
@@ -11,6 +11,7 @@ var MatrixAction = require("../models/MatrixAction");
 
 var Queue = require("../util/Queue.js");
 var QuitDebouncer = require("./QuitDebouncer.js");
+const IrcMemberStateBuffer = require("./IrcMemberStateBuffer");
 
 const JOIN_DELAY_MS = 250;
 const JOIN_DELAY_CAP_MS = 30 * 60 * 1000; // 30 mins
@@ -22,8 +23,6 @@ const MODES_TO_WATCH = [
 ];
 
 const NICK_USERID_CACHE_MAX = 512;
-const LAST_MESSAGE_WAIT_TIME_MS = 15 * 1000;
-const LAST_MESSAGE_CULL_TIME_MS = 60 * 1000;
 
 function IrcHandler(ircBridge) {
     this.ircBridge = ircBridge;
@@ -54,20 +53,9 @@ function IrcHandler(ircBridge) {
         //'$fromUserId $toUserId' : Promise
     };
 
-    this.membershipWaiting = new Map(); //roomId:userId => {
-    //    operation = intent function to call
-    //    reason = reason code if kicking
-    //    intent = intent that is doing the action }
-
-    // Used to determine how long ago someone spoke in a room.
-    this.lastMessageTime = new Map(); //roomId:userId => ts
-    setInterval(() => {
-        this.lastMessageTime.forEach((value, key) => {
-            if (value > LAST_MESSAGE_WAIT_TIME_MS) {
-                this.lastMessageTime.delete(key);
-            }
-        });
-    }, LAST_MESSAGE_CULL_TIME_MS);
+    this.memberStateBuffer = new IrcMemberStateBuffer(this.ircBridge, {
+        activeDuration: ircBridge.config.ircService.ircHandler.activeDuration,
+    });
 
     this.nickUserIdMapCache = new Map(); // server:channel => mapping
 
@@ -524,14 +512,14 @@ IrcHandler.prototype.onMessage = Promise.coroutine(function*(req, server, fromUs
 
     let matrixRooms = yield this.ircBridge.getStore().getMatrixRoomsForChannel(server, channel);
     let promises = matrixRooms.map((room) => {
-        this.lastMessageTime.set(`${room.getId()}:${virtualMatrixUser.getId()}`, Date.now());
+        this.memberStateBuffer.bumpMessageTime(room, virtualMatrixUser);
         req.log.info(
             "Relaying in room %s", room.getId()
         );
         return this.ircBridge.sendMatrixAction(
             room, virtualMatrixUser, mxAction, req
         ).finally(() => {
-            return this.processDelayedMembership(room, virtualMatrixUser, req);
+            return this.memberStateBuffer.processMembership(room, virtualMatrixUser, req);
         });
     });
     if (matrixRooms.length === 0) {
@@ -704,7 +692,7 @@ IrcHandler.prototype.onKick = Promise.coroutine(function*(req, server,
             const intent = this.ircBridge.getAppServiceBridge().getIntent(
                 matrixUser.getId()
             );
-            return this.delayMembershipWhileInFlight(
+            return this.memberStateBuffer.delayMembership(
                 room, matrixUser, "leave", intent
             ).then((delayed) => {
                 req.log.info(
@@ -764,7 +752,7 @@ IrcHandler.prototype.onPart = Promise.coroutine(function*(req, server, leavingUs
         const intent = this.ircBridge.getAppServiceBridge().getIntent(
             matrixUser.getId()
         );
-        return this.delayMembershipWhileInFlight(
+        return this.memberStateBuffer.delayMembership(
             room, matrixUser, "leave", intent
         ).then((delayed) => {
             req.log.info(
@@ -776,57 +764,6 @@ IrcHandler.prototype.onPart = Promise.coroutine(function*(req, server, leavingUs
     stats.membership(true, "part");
     yield Promise.all(promises);
 });
-
-IrcHandler.prototype.delayMembershipWhileInFlight = function(room, matrixUser, operation,
-                                                             intent, reason=null) {
-    if (!this.ircBridge.userHasMessagesInFlight(room, matrixUser)) {
-        // We don't need to wait, just dooo it.
-        return intent[operation](room.getId(), matrixUser.getId(), reason);
-    }
-    
-    /* This either sets or overwrites membership on purpose so we don't
-    have conflicting, and possibly racy operations for a user.
-
-    This comes at the cost of not fully replicating a leave and join on the
-    matrix side, but just the membership delta. A leave,join,leave will
-    be sent as a single leave if lots of messages are in flight. */
-    this.membershipWaiting.set(`${room.getId()}:${matrixUser.getId()}`,
-        { operation, reason, intent }
-    );
-    return Promise.resolve(true);
-}
-
-IrcHandler.prototype.processDelayedMembership = function(room, matrixUser, req) {
-    const key = `${room.getId()}:${matrixUser.getId()}`;
-    if ( !this.membershipWaiting.has(key) ||
-         this.ircBridge.userHasMessagesInFlight(room, matrixUser)
-        ) {
-        return;
-    }
-    const membership = this.membershipWaiting.get(key);
-    /* IRC has a tendency to push events out of order, it is *very good*
-       at sending parts before finishing sending messages, especially over
-       linked IRCds. The best solution here is to delay membership for a period
-       of time until we fairly certain they have stopped talking.
-    */
-    const lastMs = this.lastMessageTime.get(key) || 0;
-
-    const timeDelta = LAST_MESSAGE_WAIT_TIME_MS - (Date.now() - lastMs);
-    if (timeDelta > 0) {
-        req.log.info(
-            `User has sent a message in the last ${LAST_MESSAGE_WAIT_TIME_MS}ms`+
-            `, delaying ${membership.operation} for ${timeDelta}ms`);
-        return Promise.delay(timeDelta).then(() => {
-            this.processDelayedMembership(room, matrixUser, req);
-        });
-    }
-    // Drop since we are now processing it.
-    this.membershipWaiting.delete(key);
-    req.log.info(`Sending delayed membership ${membership.operation} ` +
-                 `for ${matrixUser.getId()} in ${room.getId()}`);
-    const intent = membership.intent;
-    return intent[membership.operation](room.getId(), matrixUser.getId(), membership.reason);
-};
 
 IrcHandler.prototype.onMode = Promise.coroutine(function*(req, server, channel, by,
                                                 mode, enabled, arg) {
@@ -1137,7 +1074,7 @@ IrcHandler.prototype.getMetrics = function() {
     };
     return {
         callCounters,
-        delayedMembership: this.membershipWaiting.size,
+        delayedMembership: this.memberStateBuffer.membershipWaiting,
     };
 }
 

--- a/lib/bridge/IrcHandler.js
+++ b/lib/bridge/IrcHandler.js
@@ -52,9 +52,8 @@ function IrcHandler(ircBridge) {
         //'$fromUserId $toUserId' : Promise
     };
 
-    this.membershipWaiting = {
-        //userId => join|leave|kick|ban
-    };
+    this.membershipWaiting = new Map(); //userId => join|leave|kick|ban
+
     this.nickUserIdMapCache = new Map(); // server:channel => mapping
 
     // Map<string,bool> which contains nicks we know have been registered/has display name
@@ -771,20 +770,20 @@ IrcHandler.prototype.delayMembershipWhileInFlight = function(room, matrixUser, o
     This comes at the cost of not fully replicating a leave and join on the
     matrix side, but just the membership delta. A leave,join,leave will
     be sent as a single leave if lots of messages are in flight. */
-    this.membershipWaiting[`${room.getId()}:${matrixUser.getId()}`] = {
-        operation, reason, intent
-    };
+    this.membershipWaiting.set(`${room.getId()}:${matrixUser.getId()}`,
+        { operation, reason, intent }
+    );
     return Promise.resolve(true);
 }
 
 IrcHandler.prototype.processDelayedMembership = function(room, matrixUser, req) {
     const key = `${room.getId()}:${matrixUser.getId()}`;
-    const membership = this.membershipWaiting[key];
-    if (!this.membershipWaiting[key] || this.ircBridge.userHasMessagesInFlight(room, matrixUser)) {
+    if (this.membershipWaiting.has(key) || this.ircBridge.userHasMessagesInFlight(room, matrixUser)) {
         return;
     }
+    const membership = this.membershipWaiting.get(key);
     // Drop since we are now processing it.
-    delete this.membershipWaiting[key];
+    this.membershipWaiting.delete(key);
     req.log.info(`Sending delayed membership ${membership.operation} ` +
                  `for ${matrixUser.getId()} in ${room.getId()}`);
     const intent = membership.intent;
@@ -1100,7 +1099,7 @@ IrcHandler.prototype.getMetrics = function() {
     };
     return {
         callCounters,
-        delayedMembership: this.membershipWaiting.length,
+        delayedMembership: this.membershipWaiting.size,
     };
 }
 

--- a/lib/bridge/IrcHandler.js
+++ b/lib/bridge/IrcHandler.js
@@ -484,8 +484,6 @@ IrcHandler.prototype.onMessage = Promise.coroutine(function*(req, server, fromUs
         return BridgeRequest.ERR_VIRTUAL_USER;
     }
 
-    this.lastMessageTime.set(`${room.getId()}:${matrixUser.getId()}`, Date.now());
-
     req.log.info("onMessage: %s from=%s to=%s action=%s",
         server.domain, fromUser, channel, JSON.stringify(action).substring(0, 80)
     );
@@ -526,6 +524,7 @@ IrcHandler.prototype.onMessage = Promise.coroutine(function*(req, server, fromUs
 
     let matrixRooms = yield this.ircBridge.getStore().getMatrixRoomsForChannel(server, channel);
     let promises = matrixRooms.map((room) => {
+        this.lastMessageTime.set(`${room.getId()}:${virtualMatrixUser.getId()}`, Date.now());
         req.log.info(
             "Relaying in room %s", room.getId()
         );

--- a/lib/bridge/IrcHandler.js
+++ b/lib/bridge/IrcHandler.js
@@ -22,6 +22,8 @@ const MODES_TO_WATCH = [
 ];
 
 const NICK_USERID_CACHE_MAX = 512;
+const LAST_MESSAGE_WAIT_TIME_MS = 15 * 1000;
+const LAST_MESSAGE_CULL_TIME_MS = 60 * 1000;
 
 function IrcHandler(ircBridge) {
     this.ircBridge = ircBridge;
@@ -52,10 +54,20 @@ function IrcHandler(ircBridge) {
         //'$fromUserId $toUserId' : Promise
     };
 
-    this.membershipWaiting = new Map(); //userId => {
+    this.membershipWaiting = new Map(); //roomId:userId => {
     //    operation = intent function to call
     //    reason = reason code if kicking
     //    intent = intent that is doing the action }
+
+    // Used to determine how long ago someone spoke in a room.
+    this.lastMessageTime = new Map(); //roomId:userId => ts
+    setInterval(() => {
+        this.lastMessageTime.forEach((value, key) => {
+            if (value > LAST_MESSAGE_WAIT_TIME_MS) {
+                this.lastMessageTime.delete(key);
+            }
+        });
+    }, LAST_MESSAGE_CULL_TIME_MS);
 
     this.nickUserIdMapCache = new Map(); // server:channel => mapping
 
@@ -472,6 +484,8 @@ IrcHandler.prototype.onMessage = Promise.coroutine(function*(req, server, fromUs
         return BridgeRequest.ERR_VIRTUAL_USER;
     }
 
+    this.lastMessageTime.set(`${room.getId()}:${matrixUser.getId()}`, Date.now());
+
     req.log.info("onMessage: %s from=%s to=%s action=%s",
         server.domain, fromUser, channel, JSON.stringify(action).substring(0, 80)
     );
@@ -786,10 +800,27 @@ IrcHandler.prototype.delayMembershipWhileInFlight = function(room, matrixUser, o
 IrcHandler.prototype.processDelayedMembership = function(room, matrixUser, req) {
     const key = `${room.getId()}:${matrixUser.getId()}`;
     if ( !this.membershipWaiting.has(key) ||
-         this.ircBridge.userHasMessagesInFlight(room, matrixUser)) {
+         this.ircBridge.userHasMessagesInFlight(room, matrixUser)
+        ) {
         return;
     }
     const membership = this.membershipWaiting.get(key);
+    /* IRC has a tendency to push events out of order, it is *very good*
+       at sending parts before finishing sending messages, especially over
+       linked IRCds. The best solution here is to delay membership for a period
+       of time until we fairly certain they have stopped talking.
+    */
+    const lastMs = this.lastMessageTime.get(key) || 0;
+
+    const timeDelta = LAST_MESSAGE_WAIT_TIME_MS - (Date.now() - lastMs);
+    if (timeDelta > 0) {
+        req.log.info(
+            `User has sent a message in the last ${LAST_MESSAGE_WAIT_TIME_MS}ms`+
+            `, delaying ${membership.operation} for ${timeDelta}ms`);
+        return Promise.delay(timeDelta).then(() => {
+            this.processDelayedMembership(room, matrixUser, req);
+        });
+    }
     // Drop since we are now processing it.
     this.membershipWaiting.delete(key);
     req.log.info(`Sending delayed membership ${membership.operation} ` +

--- a/lib/bridge/IrcHandler.js
+++ b/lib/bridge/IrcHandler.js
@@ -15,6 +15,9 @@ var QuitDebouncer = require("./QuitDebouncer.js");
 const JOIN_DELAY_MS = 250;
 const JOIN_DELAY_CAP_MS = 30 * 60 * 1000; // 30 mins
 
+// Delay for when messages are inflight and we want to leave.
+const LEAVE_INFLIGHT_DELAY = 500;
+
 function IrcHandler(ircBridge) {
     this.ircBridge = ircBridge;
     // maintain a map of which user ID is in which PM room, so we know if we
@@ -243,7 +246,6 @@ IrcHandler.prototype.onPrivateMessage = Promise.coroutine(function*(req, server,
     req.log.info("Relaying PM in room %s", pmRoom.getId());
     yield this.ircBridge.sendMatrixAction(pmRoom, virtualMatrixUser, mxAction, req);
 });
-
 /**
  * Called when the AS receives an IRC invite event.
  * @param {IrcServer} server : The sending IRC server.
@@ -704,11 +706,23 @@ IrcHandler.prototype.onPart = Promise.coroutine(function*(req, server, leavingUs
         }
     }
 
+    const delayForInflight = (room) => {
+        if (this.ircBridge.userHasMessagesInFlight(room, matrixUser)) {
+            req.log.info(`User has messages inflight, delaying for ${LEAVE_INFLIGHT_DELAY}ms`);
+            return Promise.delay(LEAVE_INFLIGHT_DELAY).then(() => {
+                return delayForInflight(room);
+            });
+        }
+        return Promise.resolve();
+    };
+
     let promises = matrixRooms.map((room) => {
-        req.log.info("Leaving room %s", room.getId());
-        return this.ircBridge.getAppServiceBridge().getIntent(
-            matrixUser.getId()
-        ).leave(room.getId());
+        return delayForInflight(room).then(() => {
+            req.log.info("Leaving room %s", room.getId());
+            return this.ircBridge.getAppServiceBridge().getIntent(
+                matrixUser.getId()
+            ).leave(room.getId());
+        });
     });
     stats.membership(true, "part");
     yield Promise.all(promises);

--- a/lib/bridge/IrcHandler.js
+++ b/lib/bridge/IrcHandler.js
@@ -778,7 +778,8 @@ IrcHandler.prototype.delayMembershipWhileInFlight = function(room, matrixUser, o
 
 IrcHandler.prototype.processDelayedMembership = function(room, matrixUser, req) {
     const key = `${room.getId()}:${matrixUser.getId()}`;
-    if (this.membershipWaiting.has(key) || this.ircBridge.userHasMessagesInFlight(room, matrixUser)) {
+    if ( this.membershipWaiting.has(key) ||
+         this.ircBridge.userHasMessagesInFlight(room, matrixUser)) {
         return;
     }
     const membership = this.membershipWaiting.get(key);

--- a/lib/bridge/IrcHandler.js
+++ b/lib/bridge/IrcHandler.js
@@ -755,7 +755,7 @@ IrcHandler.prototype.onPart = Promise.coroutine(function*(req, server, leavingUs
             room, matrixUser, "leave", intent
         ).then((delayed) => {
             req.log.info(
-                `User has ${this.ircBridge.userHasMessagesInFlight(room, matrixUser)} messages in flight.`
+                `User has ${this.ircBridge.getUserMessagesInFlightCount(room, matrixUser)} messages in flight.`
             );
             req.log.info(`Left room ${room.getId()} (delayed:${delayed === true})`);
         });

--- a/lib/bridge/IrcHandler.js
+++ b/lib/bridge/IrcHandler.js
@@ -52,7 +52,10 @@ function IrcHandler(ircBridge) {
         //'$fromUserId $toUserId' : Promise
     };
 
-    this.membershipWaiting = new Map(); //userId => join|leave|kick|ban
+    this.membershipWaiting = new Map(); //userId => {
+    //    operation = intent function to call
+    //    reason = reason code if kicking
+    //    intent = intent that is doing the action }
 
     this.nickUserIdMapCache = new Map(); // server:channel => mapping
 

--- a/lib/bridge/IrcHandler.js
+++ b/lib/bridge/IrcHandler.js
@@ -754,6 +754,9 @@ IrcHandler.prototype.onPart = Promise.coroutine(function*(req, server, leavingUs
         return this.delayMembershipWhileInFlight(
             room, matrixUser, "leave", intent
         ).then((delayed) => {
+            req.log.info(
+                `User has ${this.ircBridge.userHasMessagesInFlight(room, matrixUser)} messages in flight.`
+            );
             req.log.info(`Left room ${room.getId()} (delayed:${delayed === true})`);
         });
     });
@@ -767,6 +770,7 @@ IrcHandler.prototype.delayMembershipWhileInFlight = function(room, matrixUser, o
         // We don't need to wait, just dooo it.
         return intent[operation](room.getId(), matrixUser.getId(), reason);
     }
+    
     /* This either sets or overwrites membership on purpose so we don't
     have conflicting, and possibly racy operations for a user.
 

--- a/lib/bridge/IrcHandler.js
+++ b/lib/bridge/IrcHandler.js
@@ -15,9 +15,6 @@ var QuitDebouncer = require("./QuitDebouncer.js");
 const JOIN_DELAY_MS = 250;
 const JOIN_DELAY_CAP_MS = 30 * 60 * 1000; // 30 mins
 
-// Delay for when messages are inflight and we want to leave.
-const LEAVE_IN_FLIGHT_DELAY_MS = 500;
-
 function IrcHandler(ircBridge) {
     this.ircBridge = ircBridge;
     // maintain a map of which user ID is in which PM room, so we know if we
@@ -45,6 +42,10 @@ function IrcHandler(ircBridge) {
     // prevent many pm rooms from being created.
     this.pmRoomPromises = {
         //'$fromUserId $toUserId' : Promise
+    };
+
+    this.membershipWaiting = {
+        //userId => join|leave|kick|ban
     };
 
     // Map<string,bool> which contains nicks we know have been registered/has display name
@@ -488,7 +489,9 @@ IrcHandler.prototype.onMessage = Promise.coroutine(function*(req, server, fromUs
         req.log.info(
             "Relaying in room %s", room.getId()
         );
-        return this.ircBridge.sendMatrixAction(room, virtualMatrixUser, mxAction, req);
+        return this.ircBridge.sendMatrixAction(room, virtualMatrixUser, mxAction, req).finally(() => {
+            return this.processDelayedMembership(room, virtualMatrixUser, req);
+        });
     });
     if (matrixRooms.length === 0) {
         req.log.info(
@@ -655,11 +658,11 @@ IrcHandler.prototype.onKick = Promise.coroutine(function*(req, server,
             return;
         }
         let promises = matrixRooms.map((room) => {
-            return this.delayWhileInFlight(room, matrixUser).then(() => {
-                req.log.info("Leaving (due to kick) room %s", room.getId());
-                return this.ircBridge.getAppServiceBridge().getIntent(
-                    matrixUser.getId()
-                ).leave(room.getId());
+            const intent = this.ircBridge.getAppServiceBridge().getIntent(
+                matrixUser.getId()
+            );
+            return this.delayMembershipWhileInFlight(room, matrixUser, "leave", intent).then((delayed) => {
+                req.log.info(`Left room (due to kick) ${room.getId()} (delayed:${Boolean(delayed)})`);
             });
         });
         yield Promise.all(promises);
@@ -710,25 +713,45 @@ IrcHandler.prototype.onPart = Promise.coroutine(function*(req, server, leavingUs
     }
 
     let promises = matrixRooms.map((room) => {
-        return this.delayWhileInFlight(room, matrixUser).then(() => {
-            req.log.info("Leaving room %s", room.getId());
-            return this.ircBridge.getAppServiceBridge().getIntent(
-                matrixUser.getId()
-            ).leave(room.getId());
+        const intent = this.ircBridge.getAppServiceBridge().getIntent(
+            matrixUser.getId()
+        );
+        return this.delayMembershipWhileInFlight(room, matrixUser, "leave", intent).then((delayed) => {
+            req.log.info(`Left room ${room.getId()} (delayed:${Boolean(delayed)})`);
         });
     });
     stats.membership(true, "part");
     yield Promise.all(promises);
 });
 
-IrcHandler.prototype.delayWhileInFlight = function(room, matrixUser) {
+IrcHandler.prototype.delayMembershipWhileInFlight = function(room, matrixUser, operation, intent, reason=null) {
     if (this.ircBridge.userHasMessagesInFlight(room, matrixUser)) {
-        return Promise.delay(LEAVE_IN_FLIGHT_DELAY_MS).then(() => {
-            return this.delayWhileInFlight(room, matrixUser);
-        });
+        /* This either sets or overwrites membership on purpose so we don't
+           have conflicting, and possibly racy operations for a user.
+
+           This comes at the cost of not fully replicating a leave and join on the
+           matrix side, but just the membership delta.
+           I.e a leave,join,leave will be sent as a single leave if lots of messages are in flight.*/
+        this.membershipWaiting[`${room.getId()}:${matrixUser.getId()}`] = {operation, reason, intent};
+        return Promise.resolve(true);
+    } else {
+        // We don't need to wait, just dooo it.
+        return intent[operation](room.getId(), matrixUser.getId(), reason);
     }
-    return Promise.resolve();
 }
+
+IrcHandler.prototype.processDelayedMembership = function(room, matrixUser, req) {
+    const key = `${room.getId()}:${matrixUser.getId()}`;
+    const membership = this.membershipWaiting[key];
+    if (!this.membershipWaiting[key] || this.ircBridge.userHasMessagesInFlight(room, matrixUser)) {
+        return;
+    }
+    // Drop since we are now processing it.
+    delete this.membershipWaiting[key];
+    req.log.info(`Sending delayed membership ${membership.operation} for ${matrixUser.getId()} in ${room.getId()}`);
+    const intent = membership.intent;
+    return intent[membership.operation](room.getId(), matrixUser.getId(), membership.reason);
+};
 
 IrcHandler.prototype.onMode = Promise.coroutine(function*(req, server, channel, by,
                                                 mode, enabled, arg) {

--- a/lib/bridge/IrcHandler.js
+++ b/lib/bridge/IrcHandler.js
@@ -1032,7 +1032,7 @@ IrcHandler.prototype.incrementMetric = function(metric) {
 }
 
 IrcHandler.prototype.getMetrics = function() {
-    const metrics = Object.assign({}, this._callCountMetrics);
+    const callCounters = Object.assign({}, this._callCountMetrics);
     this._callCountMetrics = {
         "join.names": 0,
         "join": 0,
@@ -1044,7 +1044,10 @@ IrcHandler.prototype.getMetrics = function() {
         "kick": 0,
         "mode": 0,
     };
-    return metrics;
+    return {
+        callCounters,
+        delayedMembership: this.membershipWaiting.length,
+    };
 }
 
 module.exports = IrcHandler;

--- a/lib/bridge/IrcHandler.js
+++ b/lib/bridge/IrcHandler.js
@@ -1074,7 +1074,7 @@ IrcHandler.prototype.getMetrics = function() {
     };
     return {
         callCounters,
-        delayedMembership: this.memberStateBuffer.membershipWaiting,
+        delayedMembership: this.memberStateBuffer.waitingMemberships,
     };
 }
 

--- a/lib/bridge/IrcHandler.js
+++ b/lib/bridge/IrcHandler.js
@@ -16,7 +16,7 @@ const JOIN_DELAY_MS = 250;
 const JOIN_DELAY_CAP_MS = 30 * 60 * 1000; // 30 mins
 
 // Delay for when messages are inflight and we want to leave.
-const LEAVE_INFLIGHT_DELAY_MS = 500;
+const LEAVE_IN_FLIGHT_DELAY_MS = 500;
 
 function IrcHandler(ircBridge) {
     this.ircBridge = ircBridge;
@@ -246,6 +246,7 @@ IrcHandler.prototype.onPrivateMessage = Promise.coroutine(function*(req, server,
     req.log.info("Relaying PM in room %s", pmRoom.getId());
     yield this.ircBridge.sendMatrixAction(pmRoom, virtualMatrixUser, mxAction, req);
 });
+
 /**
  * Called when the AS receives an IRC invite event.
  * @param {IrcServer} server : The sending IRC server.
@@ -654,7 +655,7 @@ IrcHandler.prototype.onKick = Promise.coroutine(function*(req, server,
             return;
         }
         let promises = matrixRooms.map((room) => {
-            return this.delayWhileInflight(room, matrixUser).then(() => {
+            return this.delayWhileInFlight(room, matrixUser).then(() => {
                 req.log.info("Leaving (due to kick) room %s", room.getId());
                 return this.ircBridge.getAppServiceBridge().getIntent(
                     matrixUser.getId()
@@ -709,7 +710,7 @@ IrcHandler.prototype.onPart = Promise.coroutine(function*(req, server, leavingUs
     }
 
     let promises = matrixRooms.map((room) => {
-        return this.delayWhileInflight(room, matrixUser).then(() => {
+        return this.delayWhileInFlight(room, matrixUser).then(() => {
             req.log.info("Leaving room %s", room.getId());
             return this.ircBridge.getAppServiceBridge().getIntent(
                 matrixUser.getId()
@@ -720,10 +721,10 @@ IrcHandler.prototype.onPart = Promise.coroutine(function*(req, server, leavingUs
     yield Promise.all(promises);
 });
 
-IrcHandler.prototype.delayWhileInflight = function(room, matrixUser) {
+IrcHandler.prototype.delayWhileInFlight = function(room, matrixUser) {
     if (this.ircBridge.userHasMessagesInFlight(room, matrixUser)) {
-        return Promise.delay(LEAVE_INFLIGHT_DELAY_MS).then(() => {
-            return this.delayWhileInflight(room, matrixUser);
+        return Promise.delay(LEAVE_IN_FLIGHT_DELAY_MS).then(() => {
+            return this.delayWhileInFlight(room, matrixUser);
         });
     }
     return Promise.resolve();

--- a/lib/bridge/IrcMemberStateBuffer.js
+++ b/lib/bridge/IrcMemberStateBuffer.js
@@ -1,0 +1,121 @@
+const Promise = require("bluebird");
+
+/*
+   This class handles cases where we want to modify a virtual users memberstate,
+   but we aren't sure if they have finished sending messages. This will make a rough
+   attempt to stop joins resulting from messages not arriving before a leave.
+*/
+
+const DEFAULT_WAIT_TIME_MS = 15 * 1000;
+const HIGH_WATER_MARK = 2048;
+
+class IrcMemberStateBuffer {
+    constructor(ircBridge, opts={}) {
+        this.membershipWaiting = new Map(); //roomId:userId => {
+            //    operation = intent function to call
+            //    reason = reason code if kicking
+            //    intent = intent that is doing the action }
+        
+            // Used to determine how long ago someone spoke in a room.
+        this.lastMessageTime = new Map(); //roomId:userId => ts
+        this.activeDuration = opts.activeDuration === undefined ? DEFAULT_WAIT_TIME_MS : opts.activeDuration;
+        this.ircBridge = ircBridge;
+    }
+
+    bumpMessageTime(room, matrixUser) {
+        const key = `${room.getId()}:${matrixUser.getId()}`;
+        this.lastMessageTime.set(key, Date.now());
+    }
+
+    delayMembership(room, matrixUser, operation, intent, reason=null) {
+        const userIsActive = this._userRecentlySentMessage(room, matrixUser);
+        const messagesInFlight = this.ircBridge.userHasMessagesInFlight(room, matrixUser);
+
+        /* This either sets or overwrites membership on purpose so we don't
+        have conflicting, and possibly racy operations for a user.
+
+        This comes at the cost of not fully replicating a leave and join on the
+        matrix side, but just the membership delta. A leave,join,leave will
+        be sent as a single leave if lots of messages are in flight. */
+        if (messagesInFlight) {
+            const key = `${room.getId()}:${matrixUser.getId()}`;
+            this.membershipWaiting.set(
+                key,
+                { operation, reason, intent }
+            );
+            return Promise.resolve(true);
+        }
+
+        /* IRC has a tendency to push events out of order, it is *very good*
+           at sending parts before finishing sending messages.
+           The best solution here is to delay membership for a period
+           of time until we fairly certain they have stopped talking. */
+        if (userIsActive) {
+            // Call this some time in the future.
+            const timeDelta = this.activeDuration - this._durationSinceLastMessage(room, matrixUser);
+            Promise.delay(timeDelta).then(() => {
+                return this.delayMembership(room, matrixUser, operation, intent, reason);
+            });
+
+            // Do a bit of cleanup.
+            this._cleanUpLastMessageTimes();
+
+            // Still return true immediately to let the caller know we delayed.
+            return Promise.resolve(true);
+        }
+
+        // We don't need to wait, just dooo it.
+        return intent[operation](room.getId(), matrixUser.getId(), reason);
+    }
+
+    /* eslint-disable */
+    processMembership(room, matrixUser, req) {
+        const key = `${room.getId()}:${matrixUser.getId()}`;
+        // Don't do anything if requests are still in flight,
+        // or we don't have any membership to process.
+        if (this.ircBridge.userHasMessagesInFlight(room, matrixUser)) {
+            req.log.debug("Didn't process membership because requests are still waiting.");
+            return;
+        }
+
+        if (!this.membershipWaiting.has(key)) {
+            req.log.debug("Didn't process membership since none is waiting.");
+            return;
+        }
+            
+        const membership = this.membershipWaiting.get(key);
+
+        // Drop since we are now processing it.
+        this.membershipWaiting.delete(key);
+        req.log.info(`Sending delayed membership ${membership.operation} ` +
+                     `for ${matrixUser.getId()} in ${room.getId()}`);
+        const intent = membership.intent;
+        return intent[membership.operation](room.getId(), matrixUser.getId(), membership.reason);
+    }
+
+    _durationSinceLastMessage(room, matrixUser) {
+        const key = `${room.getId()}:${matrixUser.getId()}`;
+        return Date.now() - this.lastMessageTime.get(key);
+    }
+
+    _userRecentlySentMessage(room, matrixUser) {
+        return this._durationSinceLastMessage(room, matrixUser) < this.activeDuration;
+    }
+
+    _cleanUpLastMessageTimes() {
+        if (this.lastMessageTime.size < HIGH_WATER_MARK) {
+            return;
+        }
+        this.lastMessageTime.forEach((value, key) => {
+            if (value > this.activeDuration) {
+                this.lastMessageTime.delete(key);
+            }
+        });
+    }
+
+    get waitingMemberships() {
+        return this.membershipWaiting.size;
+    }
+}
+
+module.exports = IrcMemberStateBuffer;

--- a/lib/bridge/IrcMemberStateBuffer.js
+++ b/lib/bridge/IrcMemberStateBuffer.js
@@ -20,6 +20,7 @@ class IrcMemberStateBuffer {
         this.lastMessageTime = new Map(); //roomId:userId => ts
         this.activeDuration = opts.activeDuration === undefined ? DEFAULT_WAIT_TIME_MS : opts.activeDuration;
         this.ircBridge = ircBridge;
+        this.delayedDueToActivityCount = 0;
     }
 
     bumpMessageTime(room, matrixUser) {
@@ -53,7 +54,9 @@ class IrcMemberStateBuffer {
         if (userIsActive) {
             // Call this some time in the future.
             const timeDelta = this.activeDuration - this._durationSinceLastMessage(room, matrixUser);
+            this.delayedDueToActivityCount++;
             Promise.delay(timeDelta).then(() => {
+                this.delayedDueToActivityCount--;
                 return this.delayMembership(room, matrixUser, operation, intent, reason);
             });
 
@@ -114,7 +117,7 @@ class IrcMemberStateBuffer {
     }
 
     get waitingMemberships() {
-        return this.membershipWaiting.size;
+        return this.membershipWaiting.size + this.delayedDueToActivityCount;
     }
 }
 

--- a/lib/bridge/MatrixHandler.js
+++ b/lib/bridge/MatrixHandler.js
@@ -1541,7 +1541,9 @@ MatrixHandler.prototype.onUserQuery = function(req, userId) {
 };
 
 MatrixHandler.prototype.getMetrics = function(serverDomain) {
-    return this.metrics[serverDomain] || {};
+    const metrics = this.metrics[serverDomain] || {};
+    this.metrics[serverDomain] = {}
+    return metrics || {};
 }
 
 function reqHandler(req, promise) {

--- a/lib/main.js
+++ b/lib/main.js
@@ -145,6 +145,12 @@ module.exports.runBridge = Promise.coroutine(function*(port, config, reg, isDBIn
         ident.run();
     }
 
+    console.log(config);
+
+    if (config.ircService.ircHandler === undefined) {
+        config.ircService.ircHandler = {};
+    }
+
     // backwards compat for 1 release. TODO remove
     if (config.appService && !config.homeserver) {
         config.homeserver = config.appService.homeserver;

--- a/lib/main.js
+++ b/lib/main.js
@@ -145,8 +145,6 @@ module.exports.runBridge = Promise.coroutine(function*(port, config, reg, isDBIn
         ident.run();
     }
 
-    console.log(config);
-
     if (config.ircService.ircHandler === undefined) {
         config.ircService.ircHandler = {};
     }

--- a/spec/integ/kicking.spec.js
+++ b/spec/integ/kicking.spec.js
@@ -89,14 +89,14 @@ describe("Kicking", function() {
             yield kickPromise;
         }));
         it("should not leave until all messages are sent", test.coroutine(function*() {
-            let SENT_MESSAGES = -1; // We send a message to in the beforeEach
+            // This is offset by 1 because all clients send a message in beforeEach.
+            let SENT_MESSAGES = -1;
             const kickPromise = new Promise(function(resolve, reject) {
                 const ircUserSdk = env.clientMock._client(ircUser.id);
                 ircUserSdk.leave.and.callFake(function(roomId) {
                     expect(roomId).toEqual(config._roomid);
                     expect(SENT_MESSAGES).toEqual(3);
                     resolve();
-                    return Promise.resolve();
                 });
                 ircUserSdk.sendEvent.and.callFake(() => {
                     return Promise.delay(250).then(() => {

--- a/spec/integ/mirroring.spec.js
+++ b/spec/integ/mirroring.spec.js
@@ -276,5 +276,28 @@ describe("Mirroring", function() {
                 client.emit("part", roomMapping.channel, ircUser.nick);
             });
         });
+        it("should only leave after all messages have been sent", function(done) {
+            let MESSAGES_SENT = 0;
+            sdk.leave.and.callFake((roomId) => {
+                expect(roomId).toEqual(roomMapping.roomId);
+                expect(MESSAGES_SENT).toEqual(3);
+                done();
+                return Promise.resolve();
+            });
+            sdk.sendEvent.and.callFake(() => {
+                return Promise.delay(250).then(() => {
+                    MESSAGES_SENT += 1;
+                    return {};
+                });
+            });
+
+            env.ircMock._findClientAsync(roomMapping.server, roomMapping.botNick).done(
+            function(client) {
+                client.emit("message", ircUser.nick, roomMapping.channel, "1");
+                client.emit("message", ircUser.nick, roomMapping.channel, "2");
+                client.emit("message", ircUser.nick, roomMapping.channel, "3");
+                client.emit("part", roomMapping.channel, ircUser.nick);
+            });
+        });
     });
 });

--- a/spec/util/test-config.json
+++ b/spec/util/test-config.json
@@ -105,6 +105,9 @@
         "provisioning": {
             "enabled": true,
             "requestTimeoutSeconds": 1
+        },
+        "ircHandler": {
+            "activeDuration": 100
         }
     }
 }


### PR DESCRIPTION
This PR will count the number of inflight requests for a given room+user pair, sent via ``sendMatrixAction()``. Calls to leave/kick by the IrcHandler will be delayed until the count is 0. Note that a failed request is still counted as a completed request, so we won't spin forever.

This does not block on events we have yet to start sending, so it's possible for this to still race if a user is sufficiently unlucky enough. Steps to mitigate that would include counting an inflight request from the point of receiving a message which might be more difficult.