### PR TITLE
Add err_nononreg so we can announce PMs that failed

### DIFF
--- a/lib/irc/BridgedClient.js
+++ b/lib/irc/BridgedClient.js
@@ -175,6 +175,7 @@ BridgedClient.prototype.connect = Promise.coroutine(function*() {
             }
         });
         connInst.client.addListener("error", (err) => {
+            // Errors we MUST notify the user about, regardless of the bridge's admin room config.
             const ERRORS_TO_FORCE = ["err_nononreg"]
             if (!err || !err.command || connInst.dead) {
                 return;

--- a/lib/irc/BridgedClient.js
+++ b/lib/irc/BridgedClient.js
@@ -175,12 +175,13 @@ BridgedClient.prototype.connect = Promise.coroutine(function*() {
             }
         });
         connInst.client.addListener("error", (err) => {
+            const ERRORS_TO_FORCE = ["err_nononreg"]
             if (!err || !err.command || connInst.dead) {
                 return;
             }
             var msg = "Received an error on " + this.server.domain + ": " + err.command + "\n";
             msg += JSON.stringify(err.args);
-            this._eventBroker.sendMetadata(this, msg);
+            this._eventBroker.sendMetadata(this, msg, ERRORS_TO_FORCE.includes(err.command));
         });
         return connInst;
     }

--- a/lib/irc/ConnectionInstance.js
+++ b/lib/irc/ConnectionInstance.js
@@ -171,7 +171,7 @@ ConnectionInstance.prototype._listenForErrors = function() {
             "err_banonchan", "err_nickcollision", "err_nicknameinuse",
             "err_erroneusnickname", "err_nonicknamegiven", "err_eventnickchange",
             "err_nicktoofast", "err_unknowncommand", "err_unavailresource",
-            "err_umodeunknownflag"
+            "err_umodeunknownflag", "err_nononreg"
         ];
         if (err && err.command) {
             if (failCodes.indexOf(err.command) !== -1) {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "bluebird": "^3.1.1",
     "crc": "^3.2.1",
     "extend": "^2.0.0",
-    "irc": "matrix-org/node-irc#b1614bc784200c65247784d7b9e9ab867140412d",
+    "irc": "matrix-org/node-irc#c9abb427bec5016d94a2abf3e058cc62de09ea5a",
     "js-yaml": "^3.2.7",
     "matrix-appservice-bridge": "1.5.0a",
     "nedb": "^1.1.2",


### PR DESCRIPTION
This adds a dependency on the latest version of matrix-org/node-irc