### PR TITLE
Formatting of replies

### DIFF
--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -431,5 +431,5 @@ ircService:
 
   # Config for Matrix -> IRC bridging
   matrixHandler:
-    # Cache this many matrix events in memory to be used for m.relates_to messages.
+    # Cache this many matrix events in memory to be used for m.relates_to messages (usually replies).
     eventCacheSize: 4096

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -428,3 +428,8 @@ ircService:
   # `!storepass server.name passw0rd. When a connection is made to IRC on behalf of
   # the Matrix user, this password will be sent as the server password (PASS command).
   passwordEncryptionKeyPath: "passkey.pem"
+
+  # Config for Matrix -> IRC bridging
+  matrixHandler:
+    # Cache this many matrix events in memory to be used for m.relates_to messages.
+    eventCacheSize: 4096

--- a/lib/bridge/IrcBridge.js
+++ b/lib/bridge/IrcBridge.js
@@ -48,7 +48,7 @@ function IrcBridge(config, registration) {
     this.joinedRoomList = [];
 
     // Dependency graph
-    this.matrixHandler = new MatrixHandler(this);
+    this.matrixHandler = new MatrixHandler(this, this.config.matrixHandler);
     this.ircHandler = new IrcHandler(this);
     this._clientPool = new ClientPool(this);
     var dirPath = this.config.ircService.databaseUri.substring("nedb://".length);

--- a/lib/bridge/MatrixHandler.js
+++ b/lib/bridge/MatrixHandler.js
@@ -1263,22 +1263,25 @@ MatrixHandler.prototype._sendIrcAction = Promise.coroutine(
         yield this.ircBridge.sendIrcAction(ircRoom, ircClient, ircAction);
         return;
     }
+
+    let text = event.content.body;
+    let cacheText = text;
+    if (event.content["m.relates_to"] && event.content["m.relates_to"]["m.in_reply_to"]) {
+        const reply = yield this._textForReplyEvent(event, ircRoom);
+        ircAction.text = text = reply.formatted;
+        cacheText = reply.reply;
+    }
+    this._eventCache.set(event.event_id, {
+        body: cacheText.substr(0, REPLY_SOURCE_MAX_LENGTH),
+        sender: event.sender
+    });
+
     /**
      * Cache events in here so we can refer to them for replies.
-     */
-    this._eventCache.set(event.event_id, {
-        body: event.content.body.substr(0, REPLY_SOURCE_MAX_LENGTH),
-        sender: event.sender }
-    );
+    */
     if (this._eventCache.size > this._eventCacheMaxSize) {
         const delKey = this._eventCache.entries().next().value[0];
         this._eventCache.delete(delKey);
-    }
-
-    let text = event.content.body;
-    if (event.content["m.relates_to"] && event.content["m.relates_to"]["m.in_reply_to"]) {
-        text = yield this._textForReplyEvent(event, ircRoom);
-        ircAction.text = text;
     }
 
     // Check for the existance of the getSplitMessages method.
@@ -1527,7 +1530,10 @@ MatrixHandler.prototype._textForReplyEvent = Promise.coroutine(function*(event, 
                 this._eventCache.set(eventId, {sender: rplName, body: rplSource});
             } catch (err) {
                 // If we couldn't find the event, then frankly we can't trust it and we won't treat it as a reply.
-                return rplText;
+                return {
+                    formatted: rplText,
+                    reply: rplText,
+                };
             }
         }
 
@@ -1560,7 +1566,10 @@ MatrixHandler.prototype._textForReplyEvent = Promise.coroutine(function*(event, 
             );
         }
 
-        return `<${rplName}${rplSource}> ${rplText}`;
+        return {
+            formatted: `<${rplName}${rplSource}> ${rplText}`,
+            reply: rplText,
+        };
     }
 });
 

--- a/lib/bridge/MatrixHandler.js
+++ b/lib/bridge/MatrixHandler.js
@@ -1262,6 +1262,29 @@ MatrixHandler.prototype._sendIrcAction = Promise.coroutine(
     }
 
     let text = event.content.body;
+    const REPLY_SOURCE_MAX_LENGTH = 32;
+    const REPLY_NAME_MAX_LENGTH = 12;
+    if (event.content["m.relates_to"] && event.content["m.in_reply_to"]) {
+        // This is a reply.
+        const match = /> <(@.*:.*)>(.*)\n\n(.*)/.exec(text);
+        if (match.length === 4) {
+            let rplName;
+            let sourceLength = REPLY_SOURCE_MAX_LENGTH - "...".length;
+            const rplSource = match[2].substr(0, sourceLength) + (match[2].length > sourceLength ? "..." : "");
+            const rplText = match[3];
+            
+            // Fetch the sender's IRC nick.
+            const sourceClient = this.ircBridge.getIrcUserFromCache(ircRoom.server, match[1]);
+            if (sourceClient) {
+                rplName = sourceClient.nick;
+            }
+            else {
+                // Somehow we failed, so fallback to userid.
+                rplName = match[1].substr(1, Math.min(REPLY_NAME_MAX_LENGTH, userid.indexOf(":") - 1));
+            }
+            text = `<reply to ${rplName} "${rplSource}"> ${rplText}`;
+        }
+    }
 
     // Generate an array of individual messages that would be sent
     let potentialMessages = ircClient.unsafeClient.getSplitMessages(ircRoom.channel, text);

--- a/lib/bridge/MatrixHandler.js
+++ b/lib/bridge/MatrixHandler.js
@@ -19,6 +19,7 @@ const MSG_PMS_DISABLED_FEDERATION = "[Bridge] Sorry, PMs are disabled on " +
 
 const KICK_RETRY_DELAY_MS = 15000;
 const KICK_DELAY_JITTER = 30000;
+const EVENT_CACHE_SIZE = 4096;
 
 function MatrixHandler(ircBridge) {
     this.ircBridge = ircBridge;
@@ -30,6 +31,7 @@ function MatrixHandler(ircBridge) {
     };
 
     this._memberTracker = null;
+    this._eventCache = new Map(); //eventId => {body, sender}
 }
 
 // ===== Matrix Invite Handling =====
@@ -1259,6 +1261,16 @@ MatrixHandler.prototype._sendIrcAction = Promise.coroutine(
         !(ircClient.unsafeClient && ircClient.unsafeClient.getSplitMessages)) {
         yield this.ircBridge.sendIrcAction(ircRoom, ircClient, ircAction);
         return;
+    }
+
+    /**
+     * Cache events in here so we can refer to them for replies.
+     * We deliberately avoid fetching events from the homeserver due to speed concerns.
+     */
+    this._eventCache.set(event.event_id, { body: event.content.body, sender: event.sender });
+    if (this._eventCache.size > EVENT_CACHE_SIZE) {
+        const delKey = this._eventCache.entries().next().value[0];
+        this._eventCache.delete(delKey);
     }
 
     let text = event.content.body;

--- a/lib/bridge/MatrixHandler.js
+++ b/lib/bridge/MatrixHandler.js
@@ -1284,9 +1284,7 @@ MatrixHandler.prototype._sendIrcAction = Promise.coroutine(
         sender: event.sender
     });
 
-    /**
-     * Cache events in here so we can refer to them for replies.
-    */
+    // Cache events in here so we can refer to them for replies.
     if (this._eventCache.size > this._eventCacheMaxSize) {
         const delKey = this._eventCache.entries().next().value[0];
         this._eventCache.delete(delKey);
@@ -1571,11 +1569,11 @@ MatrixHandler.prototype._textForReplyEvent = Promise.coroutine(function*(event, 
         // Cut to a maximum length.
         rplSource = lines[0].substr(0, REPLY_SOURCE_MAX_LENGTH);
         // Ellipsis if needed.
-        if (rplSource.length > REPLY_SOURCE_MAX_LENGTH) {
+        if (lines[0].length > REPLY_SOURCE_MAX_LENGTH) {
             rplSource = rplSource + "...";
         }
         // Wrap in formatting
-        rplSource = ` "${lines[0]}"`;
+        rplSource = ` "${rplSource}"`;
     }
     else {
         // Don't show a source because we couldn't format one.
@@ -1588,7 +1586,7 @@ MatrixHandler.prototype._textForReplyEvent = Promise.coroutine(function*(event, 
         rplName = sourceClient.nick;
     }
     else {
-        // Somehow we failed, so fallback to userid.
+        // Somehow we failed, so fallback to localpart.
         rplName = rplName.substr(1,
             Math.min(REPLY_NAME_MAX_LENGTH, rplName.indexOf(":") - 1)
         );

--- a/lib/bridge/MatrixHandler.js
+++ b/lib/bridge/MatrixHandler.js
@@ -1282,7 +1282,7 @@ MatrixHandler.prototype._sendIrcAction = Promise.coroutine(
                 // Somehow we failed, so fallback to userid.
                 rplName = match[1].substr(1, Math.min(REPLY_NAME_MAX_LENGTH, userid.indexOf(":") - 1));
             }
-            text = `<reply to ${rplName} "${rplSource}"> ${rplText}`;
+            text = `<${rplName} "${rplSource.trim()}"> ${rplText}`;
             ircAction.text = text;
         }
     }

--- a/lib/bridge/MatrixHandler.js
+++ b/lib/bridge/MatrixHandler.js
@@ -1526,7 +1526,7 @@ MatrixHandler.prototype._textForReplyEvent = Promise.coroutine(function*(event, 
             try {
                 const eventContent = yield this.ircBridge.getAppServiceBridge().getIntent().getEvent(event.room_id, eventId);
                 rplName = eventContent.sender;
-                rplSource = eventContent.body.substr(0, REPLY_SOURCE_MAX_LENGTH);
+                rplSource = eventContent.content.body.substr(0, EVENT_CACHE_LENGTH);
                 this._eventCache.set(eventId, {sender: rplName, body: rplSource});
             } catch (err) {
                 // If we couldn't find the event, then frankly we can't trust it and we won't treat it as a reply.

--- a/lib/bridge/MatrixHandler.js
+++ b/lib/bridge/MatrixHandler.js
@@ -1265,14 +1265,14 @@ MatrixHandler.prototype._sendIrcAction = Promise.coroutine(
     }
 
     let text = event.content.body;
-    let cacheText = text;
+    let cacheBody = text;
     if (event.content["m.relates_to"] && event.content["m.relates_to"]["m.in_reply_to"]) {
         const reply = yield this._textForReplyEvent(event, ircRoom);
         ircAction.text = text = reply.formatted;
-        cacheText = reply.reply;
+        cacheBody = reply.reply;
     }
     this._eventCache.set(event.event_id, {
-        body: cacheText.substr(0, REPLY_SOURCE_MAX_LENGTH),
+        body: cacheBody.substr(0, REPLY_SOURCE_MAX_LENGTH),
         sender: event.sender
     });
 

--- a/lib/bridge/MatrixHandler.js
+++ b/lib/bridge/MatrixHandler.js
@@ -1264,7 +1264,7 @@ MatrixHandler.prototype._sendIrcAction = Promise.coroutine(
     let text = event.content.body;
     const REPLY_SOURCE_MAX_LENGTH = 32;
     const REPLY_NAME_MAX_LENGTH = 12;
-    if (event.content["m.relates_to"] && event.content["m.in_reply_to"]) {
+    if (event.content["m.relates_to"] && event.content["m.relates_to"]["m.in_reply_to"]) {
         // This is a reply.
         const match = /> <(@.*:.*)>(.*)\n\n(.*)/.exec(text);
         if (match.length === 4) {

--- a/lib/bridge/MatrixHandler.js
+++ b/lib/bridge/MatrixHandler.js
@@ -1256,15 +1256,11 @@ MatrixHandler.prototype._onMessage = Promise.coroutine(function*(req, event) {
 
 MatrixHandler.prototype._sendIrcAction = Promise.coroutine(
     function*(req, ircRoom, ircClient, ircAction, event) {
-
     // Send the action as is if it is not a text message
-    //  Also, check for the existance of the getSplitMessages method.
-    if (event.content.msgtype !== "m.text" ||
-        !(ircClient.unsafeClient && ircClient.unsafeClient.getSplitMessages)) {
+    if (event.content.msgtype !== "m.text") {
         yield this.ircBridge.sendIrcAction(ircRoom, ircClient, ircAction);
         return;
     }
-
     /**
      * Cache events in here so we can refer to them for replies.
      */
@@ -1308,6 +1304,10 @@ MatrixHandler.prototype._sendIrcAction = Promise.coroutine(
             text = `<${rplName} "${rplSource.trim()}"> ${rplText}`;
             ircAction.text = text;
         }
+    // Check for the existance of the getSplitMessages method.
+    if (!(ircClient.unsafeClient && ircClient.unsafeClient.getSplitMessages)) {
+        yield this.ircBridge.sendIrcAction(ircRoom, ircClient, ircAction);
+        return;
     }
 
     // Generate an array of individual messages that would be sent

--- a/lib/bridge/MatrixHandler.js
+++ b/lib/bridge/MatrixHandler.js
@@ -1270,9 +1270,10 @@ MatrixHandler.prototype._sendIrcAction = Promise.coroutine(
         if (match.length === 4) {
             let rplName;
             let sourceLength = REPLY_SOURCE_MAX_LENGTH - "...".length;
-            const rplSource = match[2].substr(0, sourceLength) + (match[2].length > sourceLength ? "..." : "");
+            const rplSource = match[2].substr(0, sourceLength) +
+                              (match[2].length > sourceLength ? "..." : "");
             const rplText = match[3];
-            
+
             // Fetch the sender's IRC nick.
             const sourceClient = this.ircBridge.getIrcUserFromCache(ircRoom.server, match[1]);
             if (sourceClient) {
@@ -1280,7 +1281,9 @@ MatrixHandler.prototype._sendIrcAction = Promise.coroutine(
             }
             else {
                 // Somehow we failed, so fallback to userid.
-                rplName = match[1].substr(1, Math.min(REPLY_NAME_MAX_LENGTH, userid.indexOf(":") - 1));
+                rplName = match[1].substr(1,
+                    Math.min(REPLY_NAME_MAX_LENGTH, userid.indexOf(":") - 1)
+                );
             }
             text = `<${rplName} "${rplSource.trim()}"> ${rplText}`;
             ircAction.text = text;

--- a/lib/bridge/MatrixHandler.js
+++ b/lib/bridge/MatrixHandler.js
@@ -1518,75 +1518,77 @@ MatrixHandler.prototype._textForReplyEvent = Promise.coroutine(function*(event, 
     const REPLY_NAME_MAX_LENGTH = 12;
     const eventId = event.content["m.relates_to"]["m.in_reply_to"].event_id;
     const match = REPLY_REGEX.exec(event.content.body);
-    if (match.length === 4) {
-        let rplName;
-        let rplSource;
-        const rplText = match[3];
-        if (!this._eventCache.has(eventId)) {
-            // Fallback to fetching from the homeserver.
-            try {
-                const eventContent = yield this.ircBridge.getAppServiceBridge().getIntent().getEvent(event.room_id, eventId);
-                rplName = eventContent.sender;
-                if (typeof(eventContent.content.body) !== "string") {
-                    throw Error("'body' was not a string.");
-                }
-                const isReply = event.content["m.relates_to"] && event.content["m.relates_to"]["m.in_reply_to"];
-                if (isReply) {
-                    let match = REPLY_REGEX.exec(event.content.body);
-                    rplSource = match.length === 4 ? match[3] : event.content.body;
-                }
-                else {
-                    rplSource = eventContent.content.body;
-                }
-                rplSource = eventContent.content.body.substr(0, REPLY_SOURCE_MAX_LENGTH);
-                this._eventCache.set(eventId, {sender: rplName, body: rplSource});
-            } catch (err) {
-                // If we couldn't find the event, then frankly we can't trust it and we won't treat it as a reply.
-                return {
-                    formatted: rplText,
-                    reply: rplText,
-                };
-            }
-        }
-        else {
-            rplName = this._eventCache.get(eventId).sender;
-            rplSource = this._eventCache.get(eventId).body;
-        }
-
-        // Get the first non-blank line from the source.
-        const lines = rplSource.split('\n').filter((line) => !/^\s*$/.test(line))
-        if (lines.length > 0) {
-            // Cut to a maximum length.
-            rplSource = lines[0].substr(0, REPLY_SOURCE_MAX_LENGTH);
-            // Ellipsis if needed.
-            if (rplSource.length > REPLY_SOURCE_MAX_LENGTH) {
-                rplSource = rplSource + "...";
-            }
-            // Wrap in formatting
-            rplSource = ` "${lines[0]}"`;
-        }
-        else {
-            // Don't show a source because we couldn't format one.
-            rplSource = "";
-        }
-        
-        // Fetch the sender's IRC nick.
-        const sourceClient = this.ircBridge.getIrcUserFromCache(ircRoom.server, rplName);
-        if (sourceClient) {
-            rplName = sourceClient.nick;
-        }
-        else {
-            // Somehow we failed, so fallback to userid.
-            rplName = rplName.substr(1,
-                Math.min(REPLY_NAME_MAX_LENGTH, rplName.indexOf(":") - 1)
-            );
-        }
-
-        return {
-            formatted: `<${rplName}${rplSource}> ${rplText}`,
-            reply: rplText,
-        };
+    if (match.length !== 4) {
+        return;
     }
+    
+    let rplName;
+    let rplSource;
+    const rplText = match[3];
+    if (!this._eventCache.has(eventId)) {
+        // Fallback to fetching from the homeserver.
+        try {
+            const eventContent = yield this.ircBridge.getAppServiceBridge().getIntent().getEvent(event.room_id, eventId);
+            rplName = eventContent.sender;
+            if (typeof(eventContent.content.body) !== "string") {
+                throw Error("'body' was not a string.");
+            }
+            const isReply = event.content["m.relates_to"] && event.content["m.relates_to"]["m.in_reply_to"];
+            if (isReply) {
+                let match = REPLY_REGEX.exec(eventContent.content.body);
+                rplSource = match.length === 4 ? match[3] : event.content.body;
+            }
+            else {
+                rplSource = eventContent.content.body;
+            }
+            rplSource = rplSource.substr(0, REPLY_SOURCE_MAX_LENGTH);
+            this._eventCache.set(eventId, {sender: rplName, body: rplSource});
+        } catch (err) {
+            // If we couldn't find the event, then frankly we can't trust it and we won't treat it as a reply.
+            return {
+                formatted: rplText,
+                reply: rplText,
+            };
+        }
+    }
+    else {
+        rplName = this._eventCache.get(eventId).sender;
+        rplSource = this._eventCache.get(eventId).body;
+    }
+
+    // Get the first non-blank line from the source.
+    const lines = rplSource.split('\n').filter((line) => !/^\s*$/.test(line))
+    if (lines.length > 0) {
+        // Cut to a maximum length.
+        rplSource = lines[0].substr(0, REPLY_SOURCE_MAX_LENGTH);
+        // Ellipsis if needed.
+        if (rplSource.length > REPLY_SOURCE_MAX_LENGTH) {
+            rplSource = rplSource + "...";
+        }
+        // Wrap in formatting
+        rplSource = ` "${lines[0]}"`;
+    }
+    else {
+        // Don't show a source because we couldn't format one.
+        rplSource = "";
+    }
+    
+    // Fetch the sender's IRC nick.
+    const sourceClient = this.ircBridge.getIrcUserFromCache(ircRoom.server, rplName);
+    if (sourceClient) {
+        rplName = sourceClient.nick;
+    }
+    else {
+        // Somehow we failed, so fallback to userid.
+        rplName = rplName.substr(1,
+            Math.min(REPLY_NAME_MAX_LENGTH, rplName.indexOf(":") - 1)
+        );
+    }
+
+    return {
+        formatted: `<${rplName}${rplSource}> ${rplText}`,
+        reply: rplText,
+    };
 });
 
 // EXPORTS

--- a/lib/bridge/MatrixHandler.js
+++ b/lib/bridge/MatrixHandler.js
@@ -19,7 +19,9 @@ const MSG_PMS_DISABLED_FEDERATION = "[Bridge] Sorry, PMs are disabled on " +
 
 const KICK_RETRY_DELAY_MS = 15000;
 const KICK_DELAY_JITTER = 30000;
+/* Number of events to store in memory for use in replies. */
 const DEFAULT_EVENT_CACHE_SIZE = 4096;
+/* Length of the source text in a formatted reply message */
 const REPLY_SOURCE_MAX_LENGTH = 32;
 
 function MatrixHandler(ircBridge, config) {

--- a/lib/bridge/MatrixHandler.js
+++ b/lib/bridge/MatrixHandler.js
@@ -1277,17 +1277,22 @@ MatrixHandler.prototype._sendIrcAction = Promise.coroutine(
     const REPLY_SOURCE_MAX_LENGTH = 32;
     const REPLY_NAME_MAX_LENGTH = 12;
     if (event.content["m.relates_to"] && event.content["m.relates_to"]["m.in_reply_to"]) {
+        const eventId = event.content["m.relates_to"]["m.in_reply_to"].event_id;
         // This is a reply.
         const match = /> <(@.*:.*)>(.*)\n\n(.*)/.exec(text);
         if (match.length === 4) {
-            let rplName;
-            const rplSourceTrimmed = match[2].trim();
-            const rplSource = rplSourceTrimmed.substr(0, REPLY_SOURCE_MAX_LENGTH) +
-                              (rplSourceTrimmed.length > REPLY_SOURCE_MAX_LENGTH ? "..." : "");
+            let rplName = match[1];
+            let rplSource = match[2].trim();
+            if (this._eventCache.has(eventId)) {
+                rplName = this._eventCache.get(eventId).sender;
+                rplSource = this._eventCache.get(eventId).body;
+            }
+            rplSource = rplSource.substr(0, REPLY_SOURCE_MAX_LENGTH) +
+                              (rplSource.length > REPLY_SOURCE_MAX_LENGTH ? "..." : "");
             const rplText = match[3];
 
             // Fetch the sender's IRC nick.
-            const sourceClient = this.ircBridge.getIrcUserFromCache(ircRoom.server, match[1]);
+            const sourceClient = this.ircBridge.getIrcUserFromCache(ircRoom.server, rplName);
             if (sourceClient) {
                 rplName = sourceClient.nick;
             }

--- a/lib/bridge/MatrixHandler.js
+++ b/lib/bridge/MatrixHandler.js
@@ -1517,11 +1517,7 @@ MatrixHandler.prototype._textForReplyEvent = Promise.coroutine(function*(event, 
         let rplName;
         let rplSource;
         const rplText = match[3];
-        if (this._eventCache.has(eventId)) {
-            rplName = this._eventCache.get(eventId).sender;
-            rplSource = this._eventCache.get(eventId).body;
-        }
-        else {
+        if (!this._eventCache.has(eventId)) {
             // Fallback to fetching from the homeserver.
             try {
                 const eventContent = yield this.ircBridge.getAppServiceBridge().getIntent().getEvent(event.room_id, eventId);
@@ -1535,6 +1531,10 @@ MatrixHandler.prototype._textForReplyEvent = Promise.coroutine(function*(event, 
                     reply: rplText,
                 };
             }
+        }
+        else {
+            rplName = this._eventCache.get(eventId).sender;
+            rplSource = this._eventCache.get(eventId).body;
         }
 
         // Get the first non-blank line from the source.

--- a/lib/bridge/MatrixHandler.js
+++ b/lib/bridge/MatrixHandler.js
@@ -1270,8 +1270,10 @@ MatrixHandler.prototype._sendIrcAction = Promise.coroutine(
     let cacheBody = text;
     if (event.content["m.relates_to"] && event.content["m.relates_to"]["m.in_reply_to"]) {
         const reply = yield this._textForReplyEvent(event, ircRoom);
-        ircAction.text = text = reply.formatted;
-        cacheBody = reply.reply;
+        if (reply !== undefined) {
+            ircAction.text = text = reply.formatted;
+            cacheBody = reply.reply;
+        }
     }
     this._eventCache.set(event.event_id, {
         body: cacheBody.substr(0, REPLY_SOURCE_MAX_LENGTH),

--- a/lib/bridge/MatrixHandler.js
+++ b/lib/bridge/MatrixHandler.js
@@ -1283,6 +1283,7 @@ MatrixHandler.prototype._sendIrcAction = Promise.coroutine(
                 rplName = match[1].substr(1, Math.min(REPLY_NAME_MAX_LENGTH, userid.indexOf(":") - 1));
             }
             text = `<reply to ${rplName} "${rplSource}"> ${rplText}`;
+            ircAction.text = text;
         }
     }
 

--- a/lib/bridge/MatrixHandler.js
+++ b/lib/bridge/MatrixHandler.js
@@ -19,9 +19,9 @@ const MSG_PMS_DISABLED_FEDERATION = "[Bridge] Sorry, PMs are disabled on " +
 
 const KICK_RETRY_DELAY_MS = 15000;
 const KICK_DELAY_JITTER = 30000;
-const EVENT_CACHE_SIZE = 4096;
+const DEFAULT_EVENT_CACHE_SIZE = 4096;
 
-function MatrixHandler(ircBridge) {
+function MatrixHandler(ircBridge, config) {
     this.ircBridge = ircBridge;
     // maintain a list of room IDs which are being processed invite-wise. This is
     // required because invites are processed asyncly, so you could get invite->msg
@@ -32,6 +32,8 @@ function MatrixHandler(ircBridge) {
 
     this._memberTracker = null;
     this._eventCache = new Map(); //eventId => {body, sender}
+    config = config || {}
+    this._eventCacheMaxSize = config.eventCacheSize || DEFAULT_EVENT_CACHE_SIZE;
 }
 
 // ===== Matrix Invite Handling =====
@@ -1265,10 +1267,8 @@ MatrixHandler.prototype._sendIrcAction = Promise.coroutine(
 
     /**
      * Cache events in here so we can refer to them for replies.
-     * We deliberately avoid fetching events from the homeserver due to speed concerns.
      */
-    this._eventCache.set(event.event_id, { body: event.content.body, sender: event.sender });
-    if (this._eventCache.size > EVENT_CACHE_SIZE) {
+    if (this._eventCache.size > this._eventCacheMaxSize) {
         const delKey = this._eventCache.entries().next().value[0];
         this._eventCache.delete(delKey);
     }

--- a/lib/bridge/MatrixHandler.js
+++ b/lib/bridge/MatrixHandler.js
@@ -1512,14 +1512,22 @@ MatrixHandler.prototype._textForReplyEvent = Promise.coroutine(function*(event, 
     if (match.length === 4) {
         let rplName;
         let rplSource;
+        const rplText = match[3];
         if (this._eventCache.has(eventId)) {
             rplName = this._eventCache.get(eventId).sender;
             rplSource = this._eventCache.get(eventId).body;
         }
         else {
-            // Fallback to what the event says if we can't find a body.
-            rplName = match[1];
-            rplSource = match[2].trim();
+            // Fallback to fetching from the homeserver.
+            try {
+                const eventContent = yield this.ircBridge.getAppServiceBridge().getIntent().getEvent(event.room_id, eventId);
+                rplName = eventContent.sender;
+                rplSource = eventContent.body.substr(0, REPLY_SOURCE_MAX_LENGTH);
+                this._eventCache.set(eventId, {sender: rplName, body: rplSource});
+            } catch (err) {
+                // If we couldn't find the event, then frankly we can't trust it and we won't treat it as a reply.
+                return rplText;
+            }
         }
 
         // Get the first non-blank line from the source.
@@ -1551,7 +1559,6 @@ MatrixHandler.prototype._textForReplyEvent = Promise.coroutine(function*(event, 
             );
         }
 
-        const rplText = match[3];
         return `<${rplName}${rplSource}> ${rplText}`;
     }
 });

--- a/lib/bridge/MatrixHandler.js
+++ b/lib/bridge/MatrixHandler.js
@@ -20,6 +20,7 @@ const MSG_PMS_DISABLED_FEDERATION = "[Bridge] Sorry, PMs are disabled on " +
 const KICK_RETRY_DELAY_MS = 15000;
 const KICK_DELAY_JITTER = 30000;
 const DEFAULT_EVENT_CACHE_SIZE = 4096;
+const REPLY_SOURCE_MAX_LENGTH = 32;
 
 function MatrixHandler(ircBridge, config) {
     this.ircBridge = ircBridge;
@@ -1264,46 +1265,23 @@ MatrixHandler.prototype._sendIrcAction = Promise.coroutine(
     /**
      * Cache events in here so we can refer to them for replies.
      */
+    this._eventCache.set(event.event_id, {
+        body: event.content.body.substr(0, REPLY_SOURCE_MAX_LENGTH),
+        sender: event.sender }
+    );
+    console.log("SET!", this._eventCache, this._eventCache.size);
     if (this._eventCache.size > this._eventCacheMaxSize) {
         const delKey = this._eventCache.entries().next().value[0];
         this._eventCache.delete(delKey);
+        req.log.debug(`Dropping ${delKey} from cache`);
     }
 
     let text = event.content.body;
-    const REPLY_SOURCE_MAX_LENGTH = 32;
-    const REPLY_NAME_MAX_LENGTH = 12;
     if (event.content["m.relates_to"] && event.content["m.relates_to"]["m.in_reply_to"]) {
-        const eventId = event.content["m.relates_to"]["m.in_reply_to"].event_id;
-        // This is a reply.
-        const match = /> <(@.*:.*)>(.*)\n\n(.*)/.exec(text);
-        if (match.length === 4) {
-            let rplName = match[1];
-            let rplSource = match[2].trim();
-            if (this._eventCache.has(eventId)) {
-                rplName = this._eventCache.get(eventId).sender;
-                rplSource = this._eventCache.get(eventId).body;
-            }
-            // Replace newlines so we can fit this in the message body.
-            // It's not a perfect solution but it's legible.
-            rplSource = rplSource.replace(/\v/, '. ');
-            rplSource = rplSource.substr(0, REPLY_SOURCE_MAX_LENGTH) +
-                              (rplSource.length > REPLY_SOURCE_MAX_LENGTH ? "..." : "");
-            const rplText = match[3];
+        text = yield this._textForReplyEvent(event, ircRoom);
+        ircAction.text = text;
+    }
 
-            // Fetch the sender's IRC nick.
-            const sourceClient = this.ircBridge.getIrcUserFromCache(ircRoom.server, rplName);
-            if (sourceClient) {
-                rplName = sourceClient.nick;
-            }
-            else {
-                // Somehow we failed, so fallback to userid.
-                rplName = match[1].substr(1,
-                    Math.min(REPLY_NAME_MAX_LENGTH, userid.indexOf(":") - 1)
-                );
-            }
-            text = `<${rplName} "${rplSource.trim()}"> ${rplText}`;
-            ircAction.text = text;
-        }
     // Check for the existance of the getSplitMessages method.
     if (!(ircClient.unsafeClient && ircClient.unsafeClient.getSplitMessages)) {
         yield this.ircBridge.sendIrcAction(ircRoom, ircClient, ircAction);
@@ -1527,6 +1505,58 @@ MatrixHandler.prototype._onUserQuery = Promise.coroutine(function*(req, userId) 
     let matrixUser = new MatrixUser(userId);
     let ircUser = yield this.ircBridge.matrixToIrcUser(matrixUser);
     yield this.ircBridge.getMatrixUser(ircUser);
+});
+
+MatrixHandler.prototype._textForReplyEvent = Promise.coroutine(function*(event, ircRoom) {
+    const REPLY_NAME_MAX_LENGTH = 12;
+    const eventId = event.content["m.relates_to"]["m.in_reply_to"].event_id;
+    const match = /> <(@.*:.*)>(.*)\n\n(.*)/.exec(event.content.body);
+    if (match.length === 4) {
+        let rplName;
+        let rplSource;
+        console.log(eventId, this._eventCache);
+        if (this._eventCache.has(eventId)) {
+            rplName = this._eventCache.get(eventId).sender;
+            rplSource = this._eventCache.get(eventId).body;
+        }
+        else {
+            // Fallback to what the event says if we can't find a body.
+            rplName = match[1];
+            rplSource = match[2].trim();
+        }
+
+        // Get the first non-blank line from the source.
+        const lines = rplSource.split('\n').filter((line) => !/^\s*$/.test(line))
+        if (lines.length > 0) {
+            // Cut to a maximum length.
+            rplSource = lines[0].substr(0, REPLY_SOURCE_MAX_LENGTH);
+            // Ellipsis if needed.
+            if (rplSource.length > REPLY_SOURCE_MAX_LENGTH) {
+                rplSource = rplSource + "...";
+            }
+            // Wrap in formatting
+            rplSource = ` "${lines[0]}"`;
+        }
+        else {
+            // Don't show a source because we couldn't format one.
+            rplSource = "";
+        }
+        
+        // Fetch the sender's IRC nick.
+        const sourceClient = this.ircBridge.getIrcUserFromCache(ircRoom.server, rplName);
+        if (sourceClient) {
+            rplName = sourceClient.nick;
+        }
+        else {
+            // Somehow we failed, so fallback to userid.
+            rplName = rplName.substr(1,
+                Math.min(REPLY_NAME_MAX_LENGTH, rplName.indexOf(":") - 1)
+            );
+        }
+
+        const rplText = match[3];
+        return `<${rplName}${rplSource}> ${rplText}`;
+    }
 });
 
 // EXPORTS

--- a/lib/bridge/MatrixHandler.js
+++ b/lib/bridge/MatrixHandler.js
@@ -36,7 +36,7 @@ function MatrixHandler(ircBridge, config) {
     this._memberTracker = null;
     this._eventCache = new Map(); //eventId => {body, sender}
     config = config || {}
-    this._eventCacheMaxSize = config.eventCacheSize === undefined ? 
+    this._eventCacheMaxSize = config.eventCacheSize === undefined ?
         DEFAULT_EVENT_CACHE_SIZE : config.eventCacheSize;
     this.metrics = {
         //domain => {"metricname" => value}
@@ -1525,30 +1525,35 @@ MatrixHandler.prototype._textForReplyEvent = Promise.coroutine(function*(event, 
     if (match.length !== 4) {
         return;
     }
-    
+
     let rplName;
     let rplSource;
     const rplText = match[3];
     if (!this._eventCache.has(eventId)) {
         // Fallback to fetching from the homeserver.
         try {
-            const eventContent = yield this.ircBridge.getAppServiceBridge().getIntent().getEvent(event.room_id, eventId);
+            const eventContent = yield this.ircBridge.getAppServiceBridge().getIntent().getEvent(
+                event.room_id, eventId
+            );
             rplName = eventContent.sender;
             if (typeof(eventContent.content.body) !== "string") {
                 throw Error("'body' was not a string.");
             }
-            const isReply = event.content["m.relates_to"] && event.content["m.relates_to"]["m.in_reply_to"];
+            const isReply = event.content["m.relates_to"] &&
+                event.content["m.relates_to"]["m.in_reply_to"];
             if (isReply) {
-                let match = REPLY_REGEX.exec(eventContent.content.body);
-                rplSource = match.length === 4 ? match[3] : event.content.body;
+                const sourceMatch = REPLY_REGEX.exec(eventContent.content.body);
+                rplSource = sourceMatch.length === 4 ? sourceMatch[3] : event.content.body;
             }
             else {
                 rplSource = eventContent.content.body;
             }
             rplSource = rplSource.substr(0, REPLY_SOURCE_MAX_LENGTH);
             this._eventCache.set(eventId, {sender: rplName, body: rplSource});
-        } catch (err) {
-            // If we couldn't find the event, then frankly we can't trust it and we won't treat it as a reply.
+        }
+        catch (err) {
+            // If we couldn't find the event, then frankly we can't
+            // trust it and we won't treat it as a reply.
             return {
                 formatted: rplText,
                 reply: rplText,
@@ -1576,7 +1581,7 @@ MatrixHandler.prototype._textForReplyEvent = Promise.coroutine(function*(event, 
         // Don't show a source because we couldn't format one.
         rplSource = "";
     }
-    
+
     // Fetch the sender's IRC nick.
     const sourceClient = this.ircBridge.getIrcUserFromCache(ircRoom.server, rplName);
     if (sourceClient) {

--- a/lib/bridge/MatrixHandler.js
+++ b/lib/bridge/MatrixHandler.js
@@ -1510,9 +1510,10 @@ MatrixHandler.prototype._onUserQuery = Promise.coroutine(function*(req, userId) 
 });
 
 MatrixHandler.prototype._textForReplyEvent = Promise.coroutine(function*(event, ircRoom) {
+    const REPLY_REGEX = /> <(@.*:.*)>(.*)\n\n(.*)/;
     const REPLY_NAME_MAX_LENGTH = 12;
     const eventId = event.content["m.relates_to"]["m.in_reply_to"].event_id;
-    const match = /> <(@.*:.*)>(.*)\n\n(.*)/.exec(event.content.body);
+    const match = REPLY_REGEX.exec(event.content.body);
     if (match.length === 4) {
         let rplName;
         let rplSource;
@@ -1522,7 +1523,18 @@ MatrixHandler.prototype._textForReplyEvent = Promise.coroutine(function*(event, 
             try {
                 const eventContent = yield this.ircBridge.getAppServiceBridge().getIntent().getEvent(event.room_id, eventId);
                 rplName = eventContent.sender;
-                rplSource = eventContent.content.body.substr(0, EVENT_CACHE_LENGTH);
+                if (typeof(eventContent.content.body) !== "string") {
+                    throw Error("'body' was not a string.");
+                }
+                const isReply = event.content["m.relates_to"] && event.content["m.relates_to"]["m.in_reply_to"];
+                if (isReply) {
+                    let match = REPLY_REGEX.exec(event.content.body);
+                    rplSource = match.length === 4 ? match[3] : event.content.body;
+                }
+                else {
+                    rplSource = eventContent.content.body;
+                }
+                rplSource = eventContent.content.body.substr(0, REPLY_SOURCE_MAX_LENGTH);
                 this._eventCache.set(eventId, {sender: rplName, body: rplSource});
             } catch (err) {
                 // If we couldn't find the event, then frankly we can't trust it and we won't treat it as a reply.

--- a/lib/bridge/MatrixHandler.js
+++ b/lib/bridge/MatrixHandler.js
@@ -34,7 +34,8 @@ function MatrixHandler(ircBridge, config) {
     this._memberTracker = null;
     this._eventCache = new Map(); //eventId => {body, sender}
     config = config || {}
-    this._eventCacheMaxSize = config.eventCacheSize || DEFAULT_EVENT_CACHE_SIZE;
+    this._eventCacheMaxSize = config.eventCacheSize === undefined ? 
+        DEFAULT_EVENT_CACHE_SIZE : config.eventCacheSize;
 }
 
 // ===== Matrix Invite Handling =====

--- a/lib/bridge/MatrixHandler.js
+++ b/lib/bridge/MatrixHandler.js
@@ -1269,11 +1269,9 @@ MatrixHandler.prototype._sendIrcAction = Promise.coroutine(
         body: event.content.body.substr(0, REPLY_SOURCE_MAX_LENGTH),
         sender: event.sender }
     );
-    console.log("SET!", this._eventCache, this._eventCache.size);
     if (this._eventCache.size > this._eventCacheMaxSize) {
         const delKey = this._eventCache.entries().next().value[0];
         this._eventCache.delete(delKey);
-        req.log.debug(`Dropping ${delKey} from cache`);
     }
 
     let text = event.content.body;
@@ -1514,7 +1512,6 @@ MatrixHandler.prototype._textForReplyEvent = Promise.coroutine(function*(event, 
     if (match.length === 4) {
         let rplName;
         let rplSource;
-        console.log(eventId, this._eventCache);
         if (this._eventCache.has(eventId)) {
             rplName = this._eventCache.get(eventId).sender;
             rplSource = this._eventCache.get(eventId).body;

--- a/lib/bridge/MatrixHandler.js
+++ b/lib/bridge/MatrixHandler.js
@@ -1269,9 +1269,9 @@ MatrixHandler.prototype._sendIrcAction = Promise.coroutine(
         const match = /> <(@.*:.*)>(.*)\n\n(.*)/.exec(text);
         if (match.length === 4) {
             let rplName;
-            let sourceLength = REPLY_SOURCE_MAX_LENGTH - "...".length;
-            const rplSource = match[2].substr(0, sourceLength) +
-                              (match[2].length > sourceLength ? "..." : "");
+            const rplSourceTrimmed = match[2].trim();
+            const rplSource = rplSourceTrimmed.substr(0, REPLY_SOURCE_MAX_LENGTH) +
+                              (rplSourceTrimmed.length > REPLY_SOURCE_MAX_LENGTH ? "..." : "");
             const rplText = match[3];
 
             // Fetch the sender's IRC nick.

--- a/lib/bridge/MatrixHandler.js
+++ b/lib/bridge/MatrixHandler.js
@@ -1287,6 +1287,9 @@ MatrixHandler.prototype._sendIrcAction = Promise.coroutine(
                 rplName = this._eventCache.get(eventId).sender;
                 rplSource = this._eventCache.get(eventId).body;
             }
+            // Replace newlines so we can fit this in the message body.
+            // It's not a perfect solution but it's legible.
+            rplSource = rplSource.replace(/\v/, '. ');
             rplSource = rplSource.substr(0, REPLY_SOURCE_MAX_LENGTH) +
                               (rplSource.length > REPLY_SOURCE_MAX_LENGTH ? "..." : "");
             const rplText = match[3];

--- a/lib/config/schema.yml
+++ b/lib/config/schema.yml
@@ -78,6 +78,11 @@ properties:
                         type: "number"
             passwordEncryptionKeyPath:
                 type: "string"
+            matrixHandler:
+                type: "object"
+                properties:
+                    eventCacheSize:
+                        type: "integer"
             servers:
                 type: "object"
                 # all properties must follow the following

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "extend": "^2.0.0",
     "irc": "matrix-org/node-irc#c9abb427bec5016d94a2abf3e058cc62de09ea5a",
     "js-yaml": "^3.2.7",
-    "matrix-appservice-bridge": "matrix-org/matrix-appservice-bridge#b72744cf014fafae4a72dfffe4d290b3f1d44cdf",
+    "matrix-appservice-bridge": "matrix-org/matrix-appservice-bridge#4cba3711ef0fad357a547e0eaca982d652c46f24",
     "nedb": "^1.1.2",
     "nopt": "^3.0.1",
     "prom-client": "^6.3.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "extend": "^2.0.0",
     "irc": "matrix-org/node-irc#c9abb427bec5016d94a2abf3e058cc62de09ea5a",
     "js-yaml": "^3.2.7",
-    "matrix-appservice-bridge": "1.5.0a",
+    "matrix-appservice-bridge": "matrix-org/matrix-appservice-bridge#b72744cf014fafae4a72dfffe4d290b3f1d44cdf",
     "nedb": "^1.1.2",
     "nopt": "^3.0.1",
     "prom-client": "^6.3.0",

--- a/spec/integ/matrix-to-irc.spec.js
+++ b/spec/integ/matrix-to-irc.spec.js
@@ -307,7 +307,7 @@ describe("Matrix-to-IRC message bridging", function() {
                     msgtype: "m.text",
                     "m.relates_to": {
                         "m.in_reply_to": {
-                        "event_id": "$original:bar.com"
+                            "event_id": "$original:bar.com"
                         }
                     },
                 },
@@ -334,7 +334,7 @@ describe("Matrix-to-IRC message bridging", function() {
                 msgtype: "m.text",
                 "m.relates_to": {
                     "m.in_reply_to": {
-                    "event_id": "$original:bar.com"
+                        "event_id": "$original:bar.com"
                     }
                 },
             },
@@ -362,7 +362,7 @@ describe("Matrix-to-IRC message bridging", function() {
                     msgtype: "m.text",
                     "m.relates_to": {
                         "m.in_reply_to": {
-                          "event_id": "$first:bar.com"
+                            "event_id": "$first:bar.com"
                         }
                     },
                 },
@@ -388,7 +388,7 @@ describe("Matrix-to-IRC message bridging", function() {
                     msgtype: "m.text",
                     "m.relates_to": {
                         "m.in_reply_to": {
-                          "event_id": "$second:bar.com"
+                            "event_id": "$second:bar.com"
                         }
                     },
                 },

--- a/spec/integ/matrix-to-irc.spec.js
+++ b/spec/integ/matrix-to-irc.spec.js
@@ -261,7 +261,7 @@ describe("Matrix-to-IRC message bridging", function() {
                 expect(text).toEqual('<friend "This is the real message"> Reply Text');
                 done();
             });
-    
+
             env.mockAppService._trigger("type:m.room.message", {
                 content: {
                     body: "> <@somedude:bar.com> This is the fake message\n\nReply Text",
@@ -318,7 +318,7 @@ describe("Matrix-to-IRC message bridging", function() {
         });
     });
 
-    it("should bridge matrix replies as reply only, if the original event cannot be found", function(done) {
+    it("should bridge matrix replies as reply only, if source not found", function(done) {
         env.ircMock._whenClient(roomMapping.server, testUser.nick, "say",
         function(client, channel, text) {
             expect(client.nick).toEqual(testUser.nick);
@@ -381,7 +381,7 @@ describe("Matrix-to-IRC message bridging", function() {
                 expect(text).toEqual('<friend "Message #2"> Message #3');
                 done();
             });
-    
+
             env.mockAppService._trigger("type:m.room.message", {
                 content: {
                     body: "> <@friend:bar.com> Message#2\n\nMessage #3",

--- a/spec/integ/matrix-to-irc.spec.js
+++ b/spec/integ/matrix-to-irc.spec.js
@@ -318,13 +318,13 @@ describe("Matrix-to-IRC message bridging", function() {
         });
     });
 
-    it("should bridge matrix replies as roughly formatted text, no event edition", function(done) {
+    it("should bridge matrix replies as reply only, if the original event cannot be found", function(done) {
         env.ircMock._whenClient(roomMapping.server, testUser.nick, "say",
         function(client, channel, text) {
             expect(client.nick).toEqual(testUser.nick);
             expect(client.addr).toEqual(roomMapping.server);
             expect(channel).toEqual(roomMapping.channel);
-            expect(text).toEqual('<somedude "This message is possibly fake"> Reply Text');
+            expect(text).toEqual('Reply Text');
             done();
         });
 


### PR DESCRIPTION
Fixes #636

The format turns it into something like `<source sender "source text"> reply text`

Depends on https://github.com/matrix-org/matrix-appservice-bridge/pull/79