### PR TITLE
Fix provisoner leaving users on unlink

### DIFF
--- a/lib/provisioning/Provisioner.js
+++ b/lib/provisioning/Provisioner.js
@@ -935,7 +935,7 @@ Provisioner.prototype._partUnlinkedIrcClients = Promise.coroutine(
 
         // For each room, get the list of real matrix users and tally up how many times each one
         // appears as joined
-        let joinedUserCounts = Object.create(null); // user_id => Number
+        let joinedUserCounts = {}; // user_id => Number
         let unlinkedUserIds = [];
         let asBot = this._ircBridge.getAppServiceBridge().getBot();
         for (let i = 0; i < matrixRooms.length; i++) {
@@ -947,7 +947,14 @@ Provisioner.prototype._partUnlinkedIrcClients = Promise.coroutine(
                 req.log.error("Failed to hit /state for room " + matrixRooms[i].getId());
                 req.log.error(err.stack);
             }
-            let roomInfo = asBot._getRoomInfo(roomId, stateEvents);
+            
+            // _getRoomInfo takes a particular format.
+            const joinedRoom = {
+                state: {
+                    events: stateEvents
+                }
+            }
+            let roomInfo = asBot._getRoomInfo(roomId, joinedRoom);
             for (let j = 0; j < roomInfo.realJoinedUsers.length; j++) {
                 let userId = roomInfo.realJoinedUsers[j];
                 if (!joinedUserCounts[userId]) {


### PR DESCRIPTION
There were a few bugs which stopped us from leaving users from the rooms, baffling IRC users and Matrix users alike.