### PR TITLE
Replace nicks with user pill mentions

### DIFF
--- a/lib/bridge/IrcHandler.js
+++ b/lib/bridge/IrcHandler.js
@@ -468,7 +468,7 @@ IrcHandler.prototype.onMessage = Promise.coroutine(function*(req, server, fromUs
     );
 
     let mxAction = MatrixAction.fromIrcAction(action);
-    action.formatMentions(
+    mxAction.formatMentions(
         this.ircBridge.getClientPool().getNickUserIdMappingForChannel(server, channel)
     );
 

--- a/lib/bridge/IrcHandler.js
+++ b/lib/bridge/IrcHandler.js
@@ -21,6 +21,8 @@ const MODES_TO_WATCH = [
     "s"
 ];
 
+const NICK_USERID_CACHE_MAX = 512;
+
 function IrcHandler(ircBridge) {
     this.ircBridge = ircBridge;
     // maintain a map of which user ID is in which PM room, so we know if we
@@ -50,6 +52,8 @@ function IrcHandler(ircBridge) {
         //'$fromUserId $toUserId' : Promise
     };
 
+    this.nickUserIdMapCache = new Map(); // server:channel => mapping
+    
     // Map<string,bool> which contains nicks we know have been registered/has display name
     this._registeredNicks = Object.create(null);
     this.getMetrics();
@@ -468,8 +472,22 @@ IrcHandler.prototype.onMessage = Promise.coroutine(function*(req, server, fromUs
     );
 
     let mxAction = MatrixAction.fromIrcAction(action);
+    let mapping;
+    if (this.nickUserIdMapCache.has(`${server.domain}:${channel}`)) {
+        mapping = this.nickUserIdMapCache.get(`${server.domain}:${channel}`);
+    }
+    else {
+        mapping = this.ircBridge.getClientPool().getNickUserIdMappingForChannel(
+            server, channel
+        );
+        this.nickUserIdMapCache.set(`${server.domain}:${channel}`, mapping);
+        if (this.nickUserIdMapCache.size > NICK_USERID_CACHE_MAX) {
+            this.nickUserIdMapCache.delete(this.nickUserIdMapCache.keys()[0]);
+        }
+    }
+
     mxAction.formatMentions(
-        this.ircBridge.getClientPool().getNickUserIdMappingForChannel(server, channel)
+        mapping
     );
 
     if (!mxAction) {
@@ -521,6 +539,8 @@ IrcHandler.prototype.onJoin = Promise.coroutine(function*(req, server, joiningUs
     else { // Let's avoid any surprises
         this.incrementMetric("join");
     }
+
+    this._invalidateNickUserIdMap(server, chan);
 
     let nick = joiningUser.nick;
     let syncType = kind === "names" ? "initial" : "incremental";
@@ -681,6 +701,7 @@ IrcHandler.prototype.onKick = Promise.coroutine(function*(req, server,
  */
 IrcHandler.prototype.onPart = Promise.coroutine(function*(req, server, leavingUser, chan, kind) {
     this.incrementMetric("part");
+    this._invalidateNickUserIdMap(server, chan);
     // parts are always incremental (only NAMES are initial)
     if (!server.shouldSyncMembershipToMatrix("incremental", chan)) {
         req.log.info("Server doesn't mirror parts.");
@@ -1005,6 +1026,10 @@ IrcHandler.prototype._setMatrixRoomAsInviteOnly = function(room, isInviteOnly) {
         }, ""
     );
 };
+
+IrcHandler.prototype._invalidateNickUserIdMap = function(server, channel) {
+    this.nickUserIdMapCache.delete(`${server.domain}:${channel}`);
+}
 
 IrcHandler.prototype.incrementMetric = function(metric) {
     if (this._callCountMetrics[metric] === undefined) {

--- a/lib/bridge/IrcHandler.js
+++ b/lib/bridge/IrcHandler.js
@@ -53,7 +53,7 @@ function IrcHandler(ircBridge) {
     };
 
     this.nickUserIdMapCache = new Map(); // server:channel => mapping
-    
+
     // Map<string,bool> which contains nicks we know have been registered/has display name
     this._registeredNicks = Object.create(null);
     this.getMetrics();

--- a/lib/bridge/IrcHandler.js
+++ b/lib/bridge/IrcHandler.js
@@ -468,6 +468,9 @@ IrcHandler.prototype.onMessage = Promise.coroutine(function*(req, server, fromUs
     );
 
     let mxAction = MatrixAction.fromIrcAction(action);
+    action.formatMentions(
+        this.ircBridge.getClientPool().getNickUserIdMappingForChannel(server, channel)
+    );
 
     if (!mxAction) {
         req.log.error("Couldn't map IRC action to matrix action");

--- a/lib/bridge/IrcHandler.js
+++ b/lib/bridge/IrcHandler.js
@@ -486,9 +486,7 @@ IrcHandler.prototype.onMessage = Promise.coroutine(function*(req, server, fromUs
         }
     }
 
-    mxAction.formatMentions(
-        mapping
-    );
+    mxAction.formatMentions(mapping);
 
     if (!mxAction) {
         req.log.error("Couldn't map IRC action to matrix action");

--- a/lib/irc/ClientPool.js
+++ b/lib/irc/ClientPool.js
@@ -252,7 +252,7 @@ ClientPool.prototype.getNickUserIdMappingForChannel = function(server, channel) 
     const nickUserIdMap = {};
     const cliSet = this._virtualClients[server.domain].userIds;
     Object.keys(cliSet).filter((userId) =>
-        cliSet.chanList.includes(channel)
+        cliSet[userId].chanList.includes(channel)
     ).forEach((userId) => {
         nickUserIdMap[cliSet[userId].nick] = userId;
     });

--- a/lib/irc/ClientPool.js
+++ b/lib/irc/ClientPool.js
@@ -248,6 +248,16 @@ ClientPool.prototype.totalReconnectsWaiting = function (serverDomain) {
     return 0;
 }
 
+ClientPool.prototype.getNickUserIdMappingForChannel = function(server, channel) {
+    const nickUserIdMap = {};
+    Object.keys(this._virtualClients[server.domain].userIds).filter((userId) =>
+        this._virtualClients[server.domain][userId].chanList.includes(channel)
+    ).forEach((userId) => {
+        nickUserIdMap[this._virtualClients[server.domain][userId].nick] = userId;
+    });
+    return nickUserIdMap;
+};
+
 ClientPool.prototype._sendConnectionMetric = function(server) {
     stats.ircClients(server.domain, this._getNumberOfConnections(server));
 };

--- a/lib/irc/ClientPool.js
+++ b/lib/irc/ClientPool.js
@@ -250,10 +250,11 @@ ClientPool.prototype.totalReconnectsWaiting = function (serverDomain) {
 
 ClientPool.prototype.getNickUserIdMappingForChannel = function(server, channel) {
     const nickUserIdMap = {};
-    Object.keys(this._virtualClients[server.domain].userIds).filter((userId) =>
-        this._virtualClients[server.domain][userId].chanList.includes(channel)
+    const cliSet = this._virtualClients[server.domain].userIds;
+    Object.keys(cliSet).filter((userId) =>
+        cliSet.chanList.includes(channel)
     ).forEach((userId) => {
-        nickUserIdMap[this._virtualClients[server.domain][userId].nick] = userId;
+        nickUserIdMap[cliSet[userId].nick] = userId;
     });
     return nickUserIdMap;
 };

--- a/lib/irc/formatting.js
+++ b/lib/irc/formatting.js
@@ -80,6 +80,9 @@ function escapeHtmlChars(text) {
          .replace(/'/g, "&#39;"); // to work on HTML4 (&apos; is HTML5 only)
 }
 
+// It's useful!
+module.exports.escapeHtmlChars = escapeHtmlChars;
+
 /**
  * Given the state of the message, open or close an HTML tag with the
  * appropriate attributes.

--- a/lib/models/MatrixAction.js
+++ b/lib/models/MatrixAction.js
@@ -63,7 +63,7 @@ MatrixAction.prototype.formatMentions = function(nickUserIdMap) {
             this.htmlText = this.text;
         }
         this.htmlText = this.htmlText.replace(
-            new RegExp(matchName, "igm"),
+            new RegExp(escapeStringRegexp(matchName), "igm"),
             `<a href="https://matrix.to/#/${userId}">${matchName}</a>`
         );
         matched.add(matchName.toLowerCase());

--- a/lib/models/MatrixAction.js
+++ b/lib/models/MatrixAction.js
@@ -18,7 +18,7 @@ const MSGTYPE_TO_TYPE = {
     "m.file": "file"
 };
 
-const MIN_LENGTH_TO_MATCH = 4;
+const PILL_MIN_LENGTH_TO_MATCH = 4;
 const MAX_MATCHES = 5;
 
 function MatrixAction(type, text, htmlText, timestamp) {
@@ -43,7 +43,7 @@ MatrixAction.prototype.formatMentions = function(nickUserIdMap) {
         i++;
         let matchName = match[1];
         // Deliberately have a minimum length to match on, so we don't match smaller nicks accidentally.
-        if (matchName.length < MIN_LENGTH_TO_MATCH || matched.has(matchName.toLowerCase())) {
+        if (matchName.length < PILL_MIN_LENGTH_TO_MATCH || matched.has(matchName.toLowerCase())) {
             continue;
         }
         let userId = nickUserIdMap[matchName];

--- a/lib/models/MatrixAction.js
+++ b/lib/models/MatrixAction.js
@@ -32,24 +32,23 @@ function MatrixAction(type, text, htmlText, timestamp) {
 }
 
 MatrixAction.prototype.formatMentions = function(nickUserIdMap) {
-    // Get people this message could be mentioning.
     const regexString = "(" +
         Object.keys(nickUserIdMap).map((value) => escapeStringRegexp(value)).join("|")
         + ")";
     const userRegex = new RegExp(regexString, "igm");
-    const matched = new Set();
+    const matched = new Set(); // lowercased nicknames we have matched already.
     let match;
     let i = 0;
     while ((match = userRegex.exec(this.text)) !== null && i < MAX_MATCHES) {
         i++;
         let matchName = match[1];
+        // Deliberately have a minimum length to match on, so we don't match smaller nicks accidentally.
         if (matchName.length < MIN_LENGTH_TO_MATCH || matched.has(matchName.toLowerCase())) {
             continue;
         }
-        log.debug(`Matched ${matchName} in ${this.text}`);
         let userId = nickUserIdMap[matchName];
         if (userId === undefined) {
-            // Might be casing.
+            // We might need to search case-insensitive.
             const nicks = Object.keys(nickUserIdMap).filter((nick) =>
                 nick.toLowerCase() === matchName.toLowerCase()
             );
@@ -59,6 +58,7 @@ MatrixAction.prototype.formatMentions = function(nickUserIdMap) {
             userId = nickUserIdMap[nicks[0]];
             matchName = nicks[0];
         }
+        // If this is not HTML text already, make it so.
         if (this.htmlText === undefined) {
             this.htmlText = this.text;
         }
@@ -66,6 +66,7 @@ MatrixAction.prototype.formatMentions = function(nickUserIdMap) {
             new RegExp(escapeStringRegexp(matchName), "igm"),
             `<a href="https://matrix.to/#/${userId}">${matchName}</a>`
         );
+        // Don't match this name twice, we've already replaced all entries.
         matched.add(matchName.toLowerCase());
     }
 }

--- a/lib/models/MatrixAction.js
+++ b/lib/models/MatrixAction.js
@@ -37,12 +37,13 @@ MatrixAction.prototype.formatMentions = function(nickUserIdMap) {
         Object.keys(nickUserIdMap).map((value) => escapeStringRegexp(value)).join("|")
         + ")";
     const userRegex = new RegExp(regexString, "igm");
+    const matched = new Set();
     let match;
     let i = 0;
     while ((match = userRegex.exec(this.text)) !== null && i < MAX_MATCHES) {
         i++;
         let matchName = match[1];
-        if (matchName.length < MIN_LENGTH_TO_MATCH) {
+        if (matchName.length < MIN_LENGTH_TO_MATCH || matched.has(matchName.toLowerCase())) {
             continue;
         }
         log.debug(`Matched ${matchName} in ${this.text}`);
@@ -62,9 +63,10 @@ MatrixAction.prototype.formatMentions = function(nickUserIdMap) {
             this.htmlText = this.text;
         }
         this.htmlText = this.htmlText.replace(
-            matchName,
+            new RegExp(matchName, "igm"),
             `<a href="https://matrix.to/#/${userId}">${matchName}</a>`
         );
+        matched.add(matchName.toLowerCase());
     }
 }
 

--- a/lib/models/MatrixAction.js
+++ b/lib/models/MatrixAction.js
@@ -1,7 +1,8 @@
 "use strict";
-var ircFormatting = require("../irc/formatting");
-var log = require("../logging").get("MatrixAction");
-var ContentRepo = require("matrix-appservice-bridge").ContentRepo;
+const ircFormatting = require("../irc/formatting");
+const log = require("../logging").get("MatrixAction");
+const ContentRepo = require("matrix-appservice-bridge").ContentRepo;
+const escapeStringRegexp = require('escape-string-regexp');
 
 const ACTION_TYPES = ["message", "emote", "topic", "notice", "file", "image", "video", "audio"];
 const EVENT_TO_TYPE = {
@@ -17,6 +18,8 @@ const MSGTYPE_TO_TYPE = {
     "m.file": "file"
 };
 
+const MIN_LENGTH_TO_MATCH = 4;
+
 function MatrixAction(type, text, htmlText, timestamp) {
     if (ACTION_TYPES.indexOf(type) === -1) {
         throw new Error("Unknown MatrixAction type: " + type);
@@ -26,6 +29,39 @@ function MatrixAction(type, text, htmlText, timestamp) {
     this.htmlText = htmlText;
     this.ts = timestamp || 0;
 }
+
+MatrixAction.prototype.formatMentions = function(nickUserIdMap) {
+    // Get people this message could be mentioning.
+    const regexString = "(" +
+        Object.keys(nickUserIdMap).map((value) => escapeStringRegexp(value)).join("|")
+        + ")";
+    const userRegex = new RegExp(regexString, "igm");
+    let match;
+    while ((match = userRegex.exec(this.text)) !== null) {
+        let matchName = match[1];
+        if (matchName.length < MIN_LENGTH_TO_MATCH) {
+            continue;
+        }
+        log.debug(`Matched ${matchName} in ${this.text}`);
+        let userId = nickUserIdMap[matchName];
+        if (userId === undefined) {
+            // Might be casing.
+            const nicks = Object.keys(nickUserIdMap).filter((nick) =>
+                nick.toLowerCase() === matchName.toLowerCase()
+            );
+            if (nicks.length === 0) {
+                continue;
+            }
+            userId = nickUserIdMap[nicks[0]];
+            matchName = nicks[0];
+        }
+        this.htmlText = this.htmlText.replace(
+            new RegExp(matchName, 'igm'),
+            `<a href="https://matrix.to/#/${userId}">${matchName}</a>`
+        );
+    }
+}
+
 MatrixAction.fromEvent = function(client, event, mediaUrl) {
     event.content = event.content || {};
     let type = EVENT_TO_TYPE[event.type] || "message"; // mx event type to action type

--- a/lib/models/MatrixAction.js
+++ b/lib/models/MatrixAction.js
@@ -38,9 +38,7 @@ MatrixAction.prototype.formatMentions = function(nickUserIdMap) {
     const userRegex = new RegExp(regexString, "igm");
     const matched = new Set(); // lowercased nicknames we have matched already.
     let match;
-    let i = 0;
-    while ((match = userRegex.exec(this.text)) !== null && i < MAX_MATCHES) {
-        i++;
+    for (let i = 0; i < MAX_MATCHES && (match = userRegex.exec(this.text)) !== null; i++) {
         let matchName = match[1];
         // Deliberately have a minimum length to match on, so we don't match smaller nicks accidentally.
         if (matchName.length < PILL_MIN_LENGTH_TO_MATCH || matched.has(matchName.toLowerCase())) {

--- a/lib/models/MatrixAction.js
+++ b/lib/models/MatrixAction.js
@@ -55,8 +55,11 @@ MatrixAction.prototype.formatMentions = function(nickUserIdMap) {
             userId = nickUserIdMap[nicks[0]];
             matchName = nicks[0];
         }
+        if (this.htmlText === undefined) {
+            this.htmlText = this.text;
+        }
         this.htmlText = this.htmlText.replace(
-            new RegExp(matchName, 'igm'),
+            matchName,
             `<a href="https://matrix.to/#/${userId}">${matchName}</a>`
         );
     }

--- a/lib/models/MatrixAction.js
+++ b/lib/models/MatrixAction.js
@@ -58,8 +58,10 @@ MatrixAction.prototype.formatMentions = function(nickUserIdMap) {
         }
         // If this is not HTML text already, make it so.
         if (this.htmlText === undefined) {
-            this.htmlText = this.text;
+            this.htmlText = ircFormatting.escapeHtmlChars(this.text);
         }
+        userId = ircFormatting.escapeHtmlChars(userId);
+        matchName = ircFormatting.escapeHtmlChars(matchName);
         this.htmlText = this.htmlText.replace(
             new RegExp(escapeStringRegexp(matchName), "igm"),
             `<a href="https://matrix.to/#/${userId}">${matchName}</a>`

--- a/lib/models/MatrixAction.js
+++ b/lib/models/MatrixAction.js
@@ -47,17 +47,19 @@ MatrixAction.prototype.formatMentions = function(nickUserIdMap) {
         let userId = nickUserIdMap[matchName];
         if (userId === undefined) {
             // We might need to search case-insensitive.
-            const nicks = Object.keys(nickUserIdMap).filter((nick) =>
-                nick.toLowerCase() === matchName.toLowerCase()
+            const nick = Object.keys(nickUserIdMap).find((n) =>
+                n.toLowerCase() === matchName.toLowerCase()
             );
-            if (nicks.length === 0) {
+            if (nick === undefined) {
                 continue;
             }
-            userId = nickUserIdMap[nicks[0]];
-            matchName = nicks[0];
+            userId = nickUserIdMap[nick];
+            matchName = nick;
         }
-        // If this is not HTML text already, make it so.
+        // If this message is not HTML, we should make it so.
         if (this.htmlText === undefined) {
+            // This looks scary and unsafe, but further down we check
+            // if `text` contains any HTML and escape + set `htmlText` appropriately.
             this.htmlText = this.text;
         }
         userId = ircFormatting.escapeHtmlChars(userId);

--- a/lib/models/MatrixAction.js
+++ b/lib/models/MatrixAction.js
@@ -40,7 +40,8 @@ MatrixAction.prototype.formatMentions = function(nickUserIdMap) {
     let match;
     for (let i = 0; i < MAX_MATCHES && (match = userRegex.exec(this.text)) !== null; i++) {
         let matchName = match[1];
-        // Deliberately have a minimum length to match on, so we don't match smaller nicks accidentally.
+        // Deliberately have a minimum length to match on,
+        // so we don't match smaller nicks accidentally.
         if (matchName.length < PILL_MIN_LENGTH_TO_MATCH || matched.has(matchName.toLowerCase())) {
             continue;
         }
@@ -65,7 +66,7 @@ MatrixAction.prototype.formatMentions = function(nickUserIdMap) {
         userId = ircFormatting.escapeHtmlChars(userId);
         this.htmlText = this.htmlText.replace(
             new RegExp(escapeStringRegexp(matchName), "igm"),
-            `<a href="https://matrix.to/#/${userId}">${ircFormatting.escapeHtmlChars(matchName)}</a>`
+`<a href="https://matrix.to/#/${userId}">${ircFormatting.escapeHtmlChars(matchName)}</a>`
         );
         // Don't match this name twice, we've already replaced all entries.
         matched.add(matchName.toLowerCase());

--- a/lib/models/MatrixAction.js
+++ b/lib/models/MatrixAction.js
@@ -58,13 +58,12 @@ MatrixAction.prototype.formatMentions = function(nickUserIdMap) {
         }
         // If this is not HTML text already, make it so.
         if (this.htmlText === undefined) {
-            this.htmlText = ircFormatting.escapeHtmlChars(this.text);
+            this.htmlText = this.text;
         }
         userId = ircFormatting.escapeHtmlChars(userId);
-        matchName = ircFormatting.escapeHtmlChars(matchName);
         this.htmlText = this.htmlText.replace(
             new RegExp(escapeStringRegexp(matchName), "igm"),
-            `<a href="https://matrix.to/#/${userId}">${matchName}</a>`
+            `<a href="https://matrix.to/#/${userId}">${ircFormatting.escapeHtmlChars(matchName)}</a>`
         );
         // Don't match this name twice, we've already replaced all entries.
         matched.add(matchName.toLowerCase());

--- a/lib/models/MatrixAction.js
+++ b/lib/models/MatrixAction.js
@@ -19,6 +19,7 @@ const MSGTYPE_TO_TYPE = {
 };
 
 const MIN_LENGTH_TO_MATCH = 4;
+const MAX_MATCHES = 5;
 
 function MatrixAction(type, text, htmlText, timestamp) {
     if (ACTION_TYPES.indexOf(type) === -1) {
@@ -37,7 +38,9 @@ MatrixAction.prototype.formatMentions = function(nickUserIdMap) {
         + ")";
     const userRegex = new RegExp(regexString, "igm");
     let match;
-    while ((match = userRegex.exec(this.text)) !== null) {
+    let i = 0;
+    while ((match = userRegex.exec(this.text)) !== null && i < MAX_MATCHES) {
+        i++;
         let matchName = match[1];
         if (matchName.length < MIN_LENGTH_TO_MATCH) {
             continue;

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "bluebird": "^3.1.1",
     "crc": "^3.2.1",
+    "escape-string-regexp": "^1.0.5",
     "extend": "^2.0.0",
     "irc": "matrix-org/node-irc#b1614bc784200c65247784d7b9e9ab867140412d",
     "js-yaml": "^3.2.7",

--- a/spec/unit/MatrixAction.spec.js
+++ b/spec/unit/MatrixAction.spec.js
@@ -35,12 +35,12 @@ describe("MatrixAction", function() {
         expect(action.htmlText).toEqual("<a href=\"https://matrix.to/#/@jc.denton:unatco.gov\">JCDenton</a>, it's a bomb!");
     });
     it("should highlight a user, with weird characters", () => {
-        let action = new MatrixAction("message", "JCDenton[m], it's a bomb!");
+        let action = new MatrixAction("message", "`||JCDenton[m], it's a bomb!");
         action.formatMentions({
-            "JCDenton[m]": "@jc.denton:unatco.gov"
+            "`||JCDenton[m]": "@jc.denton:unatco.gov"
         });
-        expect(action.htmlText).toEqual("<a href=\"https://matrix.to/#/@jc.denton:unatco.gov\">JCDenton[m]</a>, it's a bomb!");
         expect(action.text).toEqual("`||JCDenton[m], it's a bomb!");
+        expect(action.htmlText).toEqual("<a href=\"https://matrix.to/#/@jc.denton:unatco.gov\">`||JCDenton[m]</a>, it's a bomb!");
     });
     it("should highlight multiple users", () => {
         let action = new MatrixAction("message", "JCDenton is sent to assassinate PaulDenton", "JCDenton is sent to assassinate PaulDenton", null);

--- a/spec/unit/MatrixAction.spec.js
+++ b/spec/unit/MatrixAction.spec.js
@@ -1,0 +1,50 @@
+"use strict";
+const MatrixAction = require("../../lib/models/MatrixAction");
+
+describe("MatrixAction", function() {
+    it("should not highlight mentions to text without mentions", () => {
+        let action = new MatrixAction("message", "Some text", "Some text", null);
+        action.formatMentions({
+            "Some Person": "@foobar:localhost"
+        });
+        expect(action.text).toEqual("Some text");
+    });
+    it("should highlight a user", () => {
+        let action = new MatrixAction("message", "JCDenton, it's a bomb!", "JCDenton, it's a bomb!", null);
+        action.formatMentions({
+            "JCDenton": "@jc.denton:unatco.gov"
+        });
+        expect(action.htmlText).toEqual("<a href=\"https://matrix.to/#/@jc.denton:unatco.gov\">JCDenton</a>, it's a bomb!");
+    });
+    it("should highlight a user, regardless of case", () => {
+        let action = new MatrixAction("message", "JCDenton, it's a bomb!", "JCDenton, it's a bomb!", null);
+        action.formatMentions({
+            "jcdenton": "@jc.denton:unatco.gov"
+        });
+        expect(action.htmlText).toEqual("<a href=\"https://matrix.to/#/@jc.denton:unatco.gov\">jcdenton</a>, it's a bomb!");
+    });
+    it("should highlight a user, with plain text", () => {
+        let action = new MatrixAction("message", "JCDenton, it's a bomb!");
+        action.formatMentions({
+            "JCDenton": "@jc.denton:unatco.gov"
+        });
+        expect(action.htmlText).toEqual("<a href=\"https://matrix.to/#/@jc.denton:unatco.gov\">JCDenton</a>, it's a bomb!");
+    });
+    it("should highlight multiple users", () => {
+        let action = new MatrixAction("message", "JCDenton is sent to assassinate PaulDenton", "JCDenton is sent to assassinate PaulDenton", null);
+        action.formatMentions({
+            "JCDenton": "@jc.denton:unatco.gov",
+            "PaulDenton": "@paul.denton:unatco.gov"
+        });
+        expect(action.htmlText).toEqual(
+            "<a href=\"https://matrix.to/#/@jc.denton:unatco.gov\">JCDenton</a> is sent" +
+            " to assassinate <a href=\"https://matrix.to/#/@paul.denton:unatco.gov\">PaulDenton</a>");
+    });
+    it("should highlight multiple mentions of the same user", () => {
+        let action = new MatrixAction("message", "JCDenton, meet JCDenton", "JCDenton, meet JCDenton", null);
+        action.formatMentions({
+            "JCDenton": "@jc.denton:unatco.gov"
+        });
+        expect(action.htmlText).toEqual("<a href=\"https://matrix.to/#/@jc.denton:unatco.gov\">JCDenton</a>, meet <a href=\"https://matrix.to/#/@jc.denton:unatco.gov\">JCDenton</a>");
+    });
+});

--- a/spec/unit/MatrixAction.spec.js
+++ b/spec/unit/MatrixAction.spec.js
@@ -11,20 +11,34 @@ describe("MatrixAction", function() {
         expect(action.htmlText).toBeUndefined();
     });
     it("should highlight a user", () => {
-        let action = new MatrixAction("message", "JCDenton, it's a bomb!", "JCDenton, it's a bomb!", null);
+        let action = new MatrixAction(
+            "message",
+            "JCDenton, it's a bomb!",
+            "JCDenton, it's a bomb!",
+            null
+        );
         action.formatMentions({
             "JCDenton": "@jc.denton:unatco.gov"
         });
         expect(action.text).toEqual("JCDenton, it's a bomb!");
-        expect(action.htmlText).toEqual("<a href=\"https://matrix.to/#/@jc.denton:unatco.gov\">JCDenton</a>, it's a bomb!");
+        expect(action.htmlText).toEqual(
+            "<a href=\"https://matrix.to/#/@jc.denton:unatco.gov\">JCDenton</a>, it's a bomb!"
+        );
     });
     it("should highlight a user, regardless of case", () => {
-        let action = new MatrixAction("message", "JCDenton, it's a bomb!", "JCDenton, it's a bomb!", null);
+        let action = new MatrixAction(
+            "message",
+            "JCDenton, it's a bomb!",
+            "JCDenton, it's a bomb!",
+            null
+        );
         action.formatMentions({
             "jcdenton": "@jc.denton:unatco.gov"
         });
         expect(action.text).toEqual("JCDenton, it's a bomb!");
-        expect(action.htmlText).toEqual("<a href=\"https://matrix.to/#/@jc.denton:unatco.gov\">jcdenton</a>, it's a bomb!");
+        expect(action.htmlText).toEqual(
+            "<a href=\"https://matrix.to/#/@jc.denton:unatco.gov\">jcdenton</a>, it's a bomb!"
+        );
     });
     it("should highlight a user, with plain text", () => {
         let action = new MatrixAction("message", "JCDenton, it's a bomb!");
@@ -32,7 +46,9 @@ describe("MatrixAction", function() {
             "JCDenton": "@jc.denton:unatco.gov"
         });
         expect(action.text).toEqual("JCDenton, it's a bomb!");
-        expect(action.htmlText).toEqual("<a href=\"https://matrix.to/#/@jc.denton:unatco.gov\">JCDenton</a>, it's a bomb!");
+        expect(action.htmlText).toEqual(
+            "<a href=\"https://matrix.to/#/@jc.denton:unatco.gov\">JCDenton</a>, it's a bomb!"
+        );
     });
     it("should highlight a user, with weird characters", () => {
         let action = new MatrixAction("message", "`||JCDenton[m], it's a bomb!");
@@ -40,10 +56,17 @@ describe("MatrixAction", function() {
             "`||JCDenton[m]": "@jc.denton:unatco.gov"
         });
         expect(action.text).toEqual("`||JCDenton[m], it's a bomb!");
-        expect(action.htmlText).toEqual("<a href=\"https://matrix.to/#/@jc.denton:unatco.gov\">`||JCDenton[m]</a>, it's a bomb!");
+        expect(action.htmlText).toEqual(
+            "<a href=\"https://matrix.to/#/@jc.denton:unatco.gov\">`||JCDenton[m]</a>, it's a bomb!"
+        );
     });
     it("should highlight multiple users", () => {
-        let action = new MatrixAction("message", "JCDenton is sent to assassinate PaulDenton", "JCDenton is sent to assassinate PaulDenton", null);
+        let action = new MatrixAction(
+            "message",
+            "JCDenton is sent to assassinate PaulDenton",
+            "JCDenton is sent to assassinate PaulDenton",
+            null
+        );
         action.formatMentions({
             "JCDenton": "@jc.denton:unatco.gov",
             "PaulDenton": "@paul.denton:unatco.gov"
@@ -51,14 +74,23 @@ describe("MatrixAction", function() {
         expect(action.text).toEqual("JCDenton is sent to assassinate PaulDenton");
         expect(action.htmlText).toEqual(
             "<a href=\"https://matrix.to/#/@jc.denton:unatco.gov\">JCDenton</a> is sent" +
-            " to assassinate <a href=\"https://matrix.to/#/@paul.denton:unatco.gov\">PaulDenton</a>");
+            " to assassinate <a href=\"https://matrix.to/#/@paul.denton:unatco.gov\">PaulDenton</a>"
+        );
     });
     it("should highlight multiple mentions of the same user", () => {
-        let action = new MatrixAction("message", "JCDenton, meet JCDenton", "JCDenton, meet JCDenton", null);
+        let action = new MatrixAction(
+            "message",
+            "JCDenton, meet JCDenton",
+            "JCDenton, meet JCDenton",
+            null
+        );
         action.formatMentions({
             "JCDenton": "@jc.denton:unatco.gov"
         });
         expect(action.text).toEqual("JCDenton, meet JCDenton");
-        expect(action.htmlText).toEqual("<a href=\"https://matrix.to/#/@jc.denton:unatco.gov\">JCDenton</a>, meet <a href=\"https://matrix.to/#/@jc.denton:unatco.gov\">JCDenton</a>");
+        expect(action.htmlText).toEqual(
+            "<a href=\"https://matrix.to/#/@jc.denton:unatco.gov\">JCDenton</a>," +
+            " meet <a href=\"https://matrix.to/#/@jc.denton:unatco.gov\">JCDenton</a>"
+        );
     });
 });

--- a/spec/unit/MatrixAction.spec.js
+++ b/spec/unit/MatrixAction.spec.js
@@ -8,12 +8,14 @@ describe("MatrixAction", function() {
             "Some Person": "@foobar:localhost"
         });
         expect(action.text).toEqual("Some text");
+        expect(action.text).toEqual("Some text");
     });
     it("should highlight a user", () => {
         let action = new MatrixAction("message", "JCDenton, it's a bomb!", "JCDenton, it's a bomb!", null);
         action.formatMentions({
             "JCDenton": "@jc.denton:unatco.gov"
         });
+        expect(action.text).toEqual("JCDenton, it's a bomb!");
         expect(action.htmlText).toEqual("<a href=\"https://matrix.to/#/@jc.denton:unatco.gov\">JCDenton</a>, it's a bomb!");
     });
     it("should highlight a user, regardless of case", () => {
@@ -21,6 +23,7 @@ describe("MatrixAction", function() {
         action.formatMentions({
             "jcdenton": "@jc.denton:unatco.gov"
         });
+        expect(action.text).toEqual("JCDenton, it's a bomb!");
         expect(action.htmlText).toEqual("<a href=\"https://matrix.to/#/@jc.denton:unatco.gov\">jcdenton</a>, it's a bomb!");
     });
     it("should highlight a user, with plain text", () => {
@@ -28,6 +31,7 @@ describe("MatrixAction", function() {
         action.formatMentions({
             "JCDenton": "@jc.denton:unatco.gov"
         });
+        expect(action.text).toEqual("JCDenton, it's a bomb!");
         expect(action.htmlText).toEqual("<a href=\"https://matrix.to/#/@jc.denton:unatco.gov\">JCDenton</a>, it's a bomb!");
     });
     it("should highlight a user, with weird characters", () => {
@@ -36,6 +40,7 @@ describe("MatrixAction", function() {
             "JCDenton[m]": "@jc.denton:unatco.gov"
         });
         expect(action.htmlText).toEqual("<a href=\"https://matrix.to/#/@jc.denton:unatco.gov\">JCDenton[m]</a>, it's a bomb!");
+        expect(action.text).toEqual("`||JCDenton[m], it's a bomb!");
     });
     it("should highlight multiple users", () => {
         let action = new MatrixAction("message", "JCDenton is sent to assassinate PaulDenton", "JCDenton is sent to assassinate PaulDenton", null);
@@ -43,6 +48,7 @@ describe("MatrixAction", function() {
             "JCDenton": "@jc.denton:unatco.gov",
             "PaulDenton": "@paul.denton:unatco.gov"
         });
+        expect(action.text).toEqual("JCDenton is sent to assassinate PaulDenton");
         expect(action.htmlText).toEqual(
             "<a href=\"https://matrix.to/#/@jc.denton:unatco.gov\">JCDenton</a> is sent" +
             " to assassinate <a href=\"https://matrix.to/#/@paul.denton:unatco.gov\">PaulDenton</a>");
@@ -52,6 +58,7 @@ describe("MatrixAction", function() {
         action.formatMentions({
             "JCDenton": "@jc.denton:unatco.gov"
         });
+        expect(action.text).toEqual("JCDenton, meet JCDenton");
         expect(action.htmlText).toEqual("<a href=\"https://matrix.to/#/@jc.denton:unatco.gov\">JCDenton</a>, meet <a href=\"https://matrix.to/#/@jc.denton:unatco.gov\">JCDenton</a>");
     });
 });

--- a/spec/unit/MatrixAction.spec.js
+++ b/spec/unit/MatrixAction.spec.js
@@ -3,12 +3,12 @@ const MatrixAction = require("../../lib/models/MatrixAction");
 
 describe("MatrixAction", function() {
     it("should not highlight mentions to text without mentions", () => {
-        let action = new MatrixAction("message", "Some text", "Some text", null);
+        let action = new MatrixAction("message", "Some text");
         action.formatMentions({
             "Some Person": "@foobar:localhost"
         });
         expect(action.text).toEqual("Some text");
-        expect(action.text).toEqual("Some text");
+        expect(action.htmlText).toBeUndefined();
     });
     it("should highlight a user", () => {
         let action = new MatrixAction("message", "JCDenton, it's a bomb!", "JCDenton, it's a bomb!", null);

--- a/spec/unit/MatrixAction.spec.js
+++ b/spec/unit/MatrixAction.spec.js
@@ -30,6 +30,13 @@ describe("MatrixAction", function() {
         });
         expect(action.htmlText).toEqual("<a href=\"https://matrix.to/#/@jc.denton:unatco.gov\">JCDenton</a>, it's a bomb!");
     });
+    it("should highlight a user, with weird characters", () => {
+        let action = new MatrixAction("message", "JCDenton[m], it's a bomb!");
+        action.formatMentions({
+            "JCDenton[m]": "@jc.denton:unatco.gov"
+        });
+        expect(action.htmlText).toEqual("<a href=\"https://matrix.to/#/@jc.denton:unatco.gov\">JCDenton[m]</a>, it's a bomb!");
+    });
     it("should highlight multiple users", () => {
         let action = new MatrixAction("message", "JCDenton is sent to assassinate PaulDenton", "JCDenton is sent to assassinate PaulDenton", null);
         action.formatMentions({


### PR DESCRIPTION
Which should hopefully ping the right user. This PR will fetch a list of nick->userIds based off the collection of clients connected and try to match on that. Includes a free set of unit tests.

Fixes #573 and makes @ara4n happy.