### PR TITLE
Idle connection metrics

### DIFF
--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -377,8 +377,15 @@ ircService:
   # Optional. Enable Prometheus metrics. If this is enabled, you MUST install `prom-client`:
   #   $ npm install prom-client@6.3.0
   # Metrics will then be available via GET /metrics on the bridge listening port (-p).
-  # metrics:
-  #   enabled: true
+  metrics:
+    # Whether to actually enable the metric endpoint. Default: false
+    enabled: true
+    # When collecting remote user active times, which "buckets" should be used. Defaults are given below.
+    # The bucket name is formed of a duration and a period. (h=hours,d=days,w=weeks).
+    remoteUserAgeBuckets:
+      - "1h"
+      - "1d"
+      - "1w"
 
   # The nedb database URI to connect to. This is the name of the directory to
   # dump .db files to. This is relative to the project directory.

--- a/lib/bridge/IrcBridge.js
+++ b/lib/bridge/IrcBridge.js
@@ -164,6 +164,12 @@ IrcBridge.prototype._initialiseMetrics = function() {
         labels: ["server"]
     });
 
+    const idleConnections = metrics.addGauge({
+        name: "clientpool_idle_connections",
+        help: "Idle connections on the bridge, grouped into period buckets.",
+        labels: ["server", "period"]
+    });
+
     const memberListLeaveQueue = metrics.addGauge({
         name: "user_leave_queue",
         help: "Number of leave requests queued up for virtual users on the bridge.",
@@ -186,6 +192,11 @@ IrcBridge.prototype._initialiseMetrics = function() {
             reconnQueue.set({server: server.domain},
                 this._clientPool.totalReconnectsWaiting(server.domain)
             );
+            this._clientPool.getIdleConnectionMetrics(server.domain).then((idleBuckets) => {
+                for (const bucket in idleBuckets) {
+                    idleConnections.set({server: server.domain, period: bucket}, idleBuckets[bucket]);
+                }
+            });
         });
 
         Object.keys(this.memberListSyncers).forEach((server) => {

--- a/lib/bridge/IrcBridge.js
+++ b/lib/bridge/IrcBridge.js
@@ -125,6 +125,14 @@ IrcBridge.prototype._initialiseMetrics = function() {
     const metrics = this._bridge.getPrometheusMetrics();
 
     this._bridge.registerBridgeGauges(() => {
+        const remoteUsersByAge = new AgeCounters(
+            this.config.ircService.metrics.remoteUserAgeBuckets || ["1h", "1d", "1w"]
+        );
+
+        this.ircServers.forEach((server) => {
+            this._clientPool.updateActiveConnectionMetrics(server.domain, remoteUsersByAge);
+        });
+
         return {
             // TODO(paul): actually fill these in
             matrixRoomConfigs: 0,
@@ -140,7 +148,7 @@ IrcBridge.prototype._initialiseMetrics = function() {
             remoteRoomsByAge: zeroAge,
 
             matrixUsersByAge: zeroAge,
-            remoteUsersByAge: zeroAge,
+            remoteUsersByAge,
         };
     });
 
@@ -162,12 +170,6 @@ IrcBridge.prototype._initialiseMetrics = function() {
         name: "clientpool_reconnect_queue",
         help: "Number of disconnected irc connections waiting to reconnect.",
         labels: ["server"]
-    });
-
-    const idleConnections = metrics.addGauge({
-        name: "clientpool_idle_connections",
-        help: "Idle connections on the bridge, grouped into period buckets.",
-        labels: ["server", "period"]
     });
 
     const memberListLeaveQueue = metrics.addGauge({
@@ -192,11 +194,6 @@ IrcBridge.prototype._initialiseMetrics = function() {
             reconnQueue.set({server: server.domain},
                 this._clientPool.totalReconnectsWaiting(server.domain)
             );
-            this._clientPool.getIdleConnectionMetrics(server.domain).then((idleBuckets) => {
-                Object.keys(idleBuckets).forEach((bucket) => {
-                    idleConnections.set({server: server.domain, period: bucket}, idleBuckets[bucket]);
-                });
-            });
         });
 
         Object.keys(this.memberListSyncers).forEach((server) => {

--- a/lib/bridge/IrcBridge.js
+++ b/lib/bridge/IrcBridge.js
@@ -193,9 +193,9 @@ IrcBridge.prototype._initialiseMetrics = function() {
                 this._clientPool.totalReconnectsWaiting(server.domain)
             );
             this._clientPool.getIdleConnectionMetrics(server.domain).then((idleBuckets) => {
-                for (const bucket in idleBuckets) {
+                Object.keys(idleBuckets).forEach((bucket) => {
                     idleConnections.set({server: server.domain, period: bucket}, idleBuckets[bucket]);
-                }
+                });
             });
         });
 

--- a/lib/config/schema.yml
+++ b/lib/config/schema.yml
@@ -25,6 +25,11 @@ properties:
                 properties:
                     enabled:
                         type: "boolean"
+                    remoteUserAgeBuckets:
+                        type: "array"
+                        items:
+                            type: "string"
+                            pattern: "^[0-9]+(h|d|w)$"
             statsd:
                 type: "object"
                 properties:

--- a/lib/irc/ClientPool.js
+++ b/lib/irc/ClientPool.js
@@ -248,13 +248,7 @@ ClientPool.prototype.totalReconnectsWaiting = function (serverDomain) {
     return 0;
 };
 
-ClientPool.prototype.getIdleConnectionMetrics = function() {
-    return new Promise((resolve) => {
-        resolve(this._calculateIdleConnectionMetrics());
-    });
-};
-
-ClientPool.prototype._calculateIdleConnectionMetrics = function(server) {
+ClientPool.prototype.getIdleConnectionMetrics = function(server) {
     const SEVEN_DAYS_MS = 1000 * 60 * 60 * 24 * 7;
     const periodBucketTimes = {
         "7d": Date.now() - SEVEN_DAYS_MS,

--- a/lib/irc/ClientPool.js
+++ b/lib/irc/ClientPool.js
@@ -248,34 +248,14 @@ ClientPool.prototype.totalReconnectsWaiting = function (serverDomain) {
     return 0;
 };
 
-ClientPool.prototype.getIdleConnectionMetrics = function(server) {
-    const SEVEN_DAYS_MS = 1000 * 60 * 60 * 24 * 7;
-    const periodBucketTimes = {
-        "7d": Date.now() - SEVEN_DAYS_MS,
-        "14d": Date.now() - SEVEN_DAYS_MS*2,
-        "21d": Date.now() - SEVEN_DAYS_MS*3,
-    };
-
-    const _idleConnectionMetrics = {
-        "7d": 0,
-        "14d": 0,
-        "21d": 0,
-    };
+ClientPool.prototype.updateActiveConnectionMetrics = function(server, ageCounter) {
     const clients = Object.values(this._virtualClients[server].userIds);
-    for (const bridgedClient of clients) {
-        const lastActionMS = bridgedClient.getLastActionTs();
-        let bucket = null;
-        for (const periodBucket in periodBucketTimes) {
-            if (lastActionMS > periodBucketTimes[periodBucket]) {
-                break;
-            }
-            bucket = periodBucket;
+    clients.forEach((bridgedClient) => {
+        if (bridgedClient.isDead()) {
+            return; // We don't want to include dead ones.
         }
-        if (bucket !== null) {
-            _idleConnectionMetrics[bucket]++;
-        }
-    }
-    return _idleConnectionMetrics;
+        ageCounter.bump((Date.now() - bridgedClient.getLastActionTs()) / 1000);
+    });
 };
 
 ClientPool.prototype._sendConnectionMetric = function(server) {

--- a/lib/irc/ClientPool.js
+++ b/lib/irc/ClientPool.js
@@ -246,7 +246,43 @@ ClientPool.prototype.totalReconnectsWaiting = function (serverDomain) {
         return this._reconnectQueues[serverDomain].waitingItems;
     }
     return 0;
-}
+};
+
+ClientPool.prototype.getIdleConnectionMetrics = function() {
+    return new Promise((resolve) => {
+        resolve(this._calculateIdleConnectionMetrics());
+    });
+};
+
+ClientPool.prototype._calculateIdleConnectionMetrics = function(server) {
+    const SEVEN_DAYS_MS = 1000 * 60 * 60 * 24 * 7;
+    const periodBucketTimes = {
+        "7d": Date.now() - SEVEN_DAYS_MS,
+        "14d": Date.now() - SEVEN_DAYS_MS*2,
+        "21d": Date.now() - SEVEN_DAYS_MS*3,
+    };
+
+    const _idleConnectionMetrics = {
+        "7d": 0,
+        "14d": 0,
+        "21d": 0,
+    };
+    const clients = Object.values(this._virtualClients[server].userIds);
+    for (const bridgedClient of clients) {
+        const lastActionMS = bridgedClient.getLastActionTs();
+        let bucket = null;
+        for (const periodBucket in periodBucketTimes) {
+            if (lastActionMS > periodBucketTimes[periodBucket]) {
+                break;
+            }
+            bucket = periodBucket;
+        }
+        if (bucket !== null) {
+            _idleConnectionMetrics[bucket]++;
+        }
+    }
+    return _idleConnectionMetrics;
+};
 
 ClientPool.prototype._sendConnectionMetric = function(server) {
     stats.ircClients(server.domain, this._getNumberOfConnections(server));

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "extend": "^2.0.0",
     "irc": "matrix-org/node-irc#b1614bc784200c65247784d7b9e9ab867140412d",
     "js-yaml": "^3.2.7",
-    "matrix-appservice-bridge": "1.5.0a",
+    "matrix-appservice-bridge": "matrix-org/matrix-appservice-bridge#89d5e0763f1d19be55fbabbc9d021560c1332b54",
     "nedb": "^1.1.2",
     "nopt": "^3.0.1",
     "prom-client": "^6.3.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "extend": "^2.0.0",
     "irc": "matrix-org/node-irc#c9abb427bec5016d94a2abf3e058cc62de09ea5a",
     "js-yaml": "^3.2.7",
-    "matrix-appservice-bridge": "matrix-org/matrix-appservice-bridge#89d5e0763f1d19be55fbabbc9d021560c1332b54",
+    "matrix-appservice-bridge": "matrix-org/matrix-appservice-bridge#4175ff0bd2b0626402d8992deb3af78ba45a7a41",
     "nedb": "^1.1.2",
     "nopt": "^3.0.1",
     "prom-client": "^6.3.0",


### PR DESCRIPTION
This PR exports the number of users considered to be idle. ~Currently this is grouped into 3 buckets:~

~Considering making the bucket periods configurable..~

*EDIT*: This PR now uses AgeCounters and an existing matrix-appservice-bridge metric for tracking this. You can also specify the buckets you'd like to use in the metrics portion of the config file. This PR has a pin on AgeCounters so the tests will pass, but the changes will be unpinned pending a release of the appservice-bridge.

https://github.com/matrix-org/matrix-appservice-bridge/pull/82 is the PR this depends on