### PR TITLE
Fix invalidchar nick

### DIFF
--- a/lib/bridge/MatrixHandler.js
+++ b/lib/bridge/MatrixHandler.js
@@ -911,7 +911,7 @@ MatrixHandler.prototype._onJoin = Promise.coroutine(function*(req, event, user) 
                         bridgedClient.changeNick(newNick, false);
                     }
                     catch (e) {
-                        req.log.warn(`Didn't change nick on the IRC side:${e}`);
+                        req.log.warn(`Didn't change nick on the IRC side: ${e}`);
                     }
                 }
             }

--- a/lib/bridge/MatrixHandler.js
+++ b/lib/bridge/MatrixHandler.js
@@ -904,9 +904,15 @@ MatrixHandler.prototype._onJoin = Promise.coroutine(function*(req, event, user) 
                 if (room.server.allowsNickChanges() &&
                     config.getDesiredNick() === null
                 ) {
-                    bridgedClient.changeNick(
-                        room.server.getNick(bridgedClient.userId, event.content.displayname),
-                        false);
+                    try {
+                        const newNick = room.server.getNick(
+                            bridgedClient.userId, event.content.displayname
+                        );
+                        bridgedClient.changeNick(newNick, false);
+                    }
+                    catch (e) {
+                        req.log.warn(`Didn't change nick on the IRC side:${e}`);
+                    }
                 }
             }
 

--- a/lib/irc/BridgedClient.js
+++ b/lib/irc/BridgedClient.js
@@ -491,7 +491,7 @@ BridgedClient.prototype._getValidNick = function(nick, throwOnInvalid) {
 
 
     // strip illegal chars according to RFC 2812 Sect 2.3.1
-    let n = nick.replace(/[^A-Za-z0-9\]\[\^\\\{\}\-`_\|]/g, "");
+    let n = nick.replace(BridgedClient.illegalCharactersRegex, "");
     if (throwOnInvalid && n !== nick) {
         throw new Error(`Nick '${nick}' contains illegal characters.`);
     }
@@ -737,5 +737,7 @@ BridgedClient.prototype._joinChannel = function(channel, key, attemptCount) {
 
     return defer.promise;
 }
+
+BridgedClient.illegalCharactersRegex = /[^A-Za-z0-9\]\[\^\\\{\}\-`_\|]/g;
 
 module.exports = BridgedClient;

--- a/lib/irc/IrcServer.js
+++ b/lib/irc/IrcServer.js
@@ -435,9 +435,12 @@ IrcServer.prototype.getAliasFromChannel = function(channel) {
 
 IrcServer.prototype.getNick = function(userId, displayName) {
     var localpart = userId.substring(1).split(":")[0];
+    localpart = localpart.replace(BridgedClient.illegalCharactersRegex, "");
+    if (displayName) {
+        // Carefully replace any characters that will never be displayed.
+        displayName = displayName.replace(BridgedClient.illegalCharactersRegex, "");
+    }
     var display = displayName || localpart;
-    // Carefully replace any characters that will never be displayed.
-    display = BridgedClient.illegalCharactersRegex.replace(display, "");
     var template = this.config.ircClients.nickTemplate;
     var nick = template.replace(/\$USERID/g, userId);
     nick = nick.replace(/\$LOCALPART/g, localpart);

--- a/lib/irc/IrcServer.js
+++ b/lib/irc/IrcServer.js
@@ -5,6 +5,7 @@
 const logging = require("../logging");
 const IrcClientConfig = require("../models/IrcClientConfig");
 const log = logging.get("IrcServer");
+const BridgedClient = require("./BridgedClient");
 
 const GROUP_ID_REGEX = /^\+\S+:\S+$/;
 
@@ -435,6 +436,8 @@ IrcServer.prototype.getAliasFromChannel = function(channel) {
 IrcServer.prototype.getNick = function(userId, displayName) {
     var localpart = userId.substring(1).split(":")[0];
     var display = displayName || localpart;
+    // Carefully replace any characters that will never be displayed.
+    display = BridgedClient.illegalCharactersRegex.replace(display, "");
     var template = this.config.ircClients.nickTemplate;
     var nick = template.replace(/\$USERID/g, userId);
     nick = nick.replace(/\$LOCALPART/g, localpart);

--- a/lib/irc/IrcServer.js
+++ b/lib/irc/IrcServer.js
@@ -434,15 +434,16 @@ IrcServer.prototype.getAliasFromChannel = function(channel) {
 };
 
 IrcServer.prototype.getNick = function(userId, displayName) {
-    var localpart = userId.substring(1).split(":")[0];
-    localpart = localpart.replace(BridgedClient.illegalCharactersRegex, "");
-    if (displayName) {
-        // Carefully replace any characters that will never be displayed.
-        displayName = displayName.replace(BridgedClient.illegalCharactersRegex, "");
+    const illegalChars = BridgedClient.illegalCharactersRegex;
+    let localpart = userId.substring(1).split(":")[0];
+    localpart = localpart.replace(illegalChars, "");
+    displayName = displayName ? displayName.replace(illegalChars, "") : undefined;
+    let display = [displayName, localpart].find((n) => Boolean(n));
+    if (!display) {
+        throw new Error("Could not get nick for user, all characters were invalid");
     }
-    var display = displayName || localpart;
-    var template = this.config.ircClients.nickTemplate;
-    var nick = template.replace(/\$USERID/g, userId);
+    const template = this.config.ircClients.nickTemplate;
+    let nick = template.replace(/\$USERID/g, userId);
     nick = nick.replace(/\$LOCALPART/g, localpart);
     nick = nick.replace(/\$DISPLAY/g, display);
     return nick;

--- a/lib/irc/IrcServer.js
+++ b/lib/irc/IrcServer.js
@@ -438,7 +438,7 @@ IrcServer.prototype.getNick = function(userId, displayName) {
     let localpart = userId.substring(1).split(":")[0];
     localpart = localpart.replace(illegalChars, "");
     displayName = displayName ? displayName.replace(illegalChars, "") : undefined;
-    let display = [displayName, localpart].find((n) => Boolean(n));
+    const display = [displayName, localpart].find((n) => Boolean(n));
     if (!display) {
         throw new Error("Could not get nick for user, all characters were invalid");
     }

--- a/lib/irc/IrcServer.js
+++ b/lib/irc/IrcServer.js
@@ -2,9 +2,9 @@
  * Represents a single IRC server from config.yaml
  */
 "use strict";
-var logging = require("../logging");
-var IrcClientConfig = require("../models/IrcClientConfig");
-var log = logging.get("IrcServer");
+const logging = require("../logging");
+const IrcClientConfig = require("../models/IrcClientConfig");
+const log = logging.get("IrcServer");
 
 const GROUP_ID_REGEX = /^\+\S+:\S+$/;
 

--- a/spec/unit/IrcServer.spec.js
+++ b/spec/unit/IrcServer.spec.js
@@ -21,11 +21,30 @@ describe("IrcServer", function() {
             );
             expect(server.getNick("@foobar:foobar", "💩wiggleケ")).toBe("M-wiggle");
         });
-        it("should use userid if the displayname is all invalid chars", function() {
+        it("should use localpart if the displayname is all invalid chars", function() {
             const server = new IrcServer("irc.foobar",
                 extend(true, IrcServer.DEFAULT_CONFIG, {})
             );
             expect(server.getNick("@foobar:foobar", "💩ケ")).toBe("M-foobar");
+        });
+        // These situations shouldn't happen, but we want to avoid rogue homeservers blowing us up.
+        it("should get a reduced nick if the localpart contains some invalid chars", function() {
+            const server = new IrcServer("irc.foobar",
+                extend(true, IrcServer.DEFAULT_CONFIG, {})
+            );
+            expect(server.getNick("@💩foobarケ:foobar")).toBe("M-foobar");
+        });
+        it("should use displayname if the localpart is all invalid chars", function() {
+            const server = new IrcServer("irc.foobar",
+                extend(true, IrcServer.DEFAULT_CONFIG, {})
+            );
+            expect(server.getNick("@💩ケ:foobar", "wiggle")).toBe("M-wiggle");
+        });
+        it("should throw if no characters could be used", function() {
+            const server = new IrcServer("irc.foobar",
+                extend(true, IrcServer.DEFAULT_CONFIG, {})
+            );
+            expect(() => {server.getNick("@💩ケ:foobar", "💩ケ")}).toThrow();
         });
     });
 });

--- a/spec/unit/IrcServer.spec.js
+++ b/spec/unit/IrcServer.spec.js
@@ -1,0 +1,31 @@
+"use strict";
+const IrcServer = require("../../lib/irc/IrcServer");
+const extend = require("extend");
+describe("IrcServer", function() {
+    describe("getNick", function() {
+        it("should get a nick from a userid", function() {
+            const server = new IrcServer("irc.foobar",
+                extend(true, IrcServer.DEFAULT_CONFIG, {})
+            );
+            expect(server.getNick("@foobar:foobar")).toBe("M-foobar");
+        });
+        it("should get a nick from a displayname", function() {
+            const server = new IrcServer("irc.foobar",
+                extend(true, IrcServer.DEFAULT_CONFIG, {})
+            );
+            expect(server.getNick("@foobar:foobar", "wiggle")).toBe("M-wiggle");
+        });
+        it("should get a reduced nick if the displayname contains some invalid chars", function() {
+            const server = new IrcServer("irc.foobar",
+                extend(true, IrcServer.DEFAULT_CONFIG, {})
+            );
+            expect(server.getNick("@foobar:foobar", "💩wiggleケ")).toBe("M-wiggle");
+        });
+        it("should use userid if the displayname is all invalid chars", function() {
+            const server = new IrcServer("irc.foobar",
+                extend(true, IrcServer.DEFAULT_CONFIG, {})
+            );
+            expect(server.getNick("@foobar:foobar", "💩ケ")).toBe("M-foobar");
+        });
+    });
+});

--- a/spec/unit/IrcServer.spec.js
+++ b/spec/unit/IrcServer.spec.js
@@ -40,11 +40,17 @@ describe("IrcServer", function() {
             );
             expect(server.getNick("@💩ケ:foobar", "wiggle")).toBe("M-wiggle");
         });
-        it("should throw if no characters could be used", function() {
+        it("should throw if no characters could be used, with displayname", function() {
             const server = new IrcServer("irc.foobar",
                 extend(true, IrcServer.DEFAULT_CONFIG, {})
             );
             expect(() => {server.getNick("@💩ケ:foobar", "💩ケ")}).toThrow();
+        });
+        it("should throw if no characters could be used, with displayname", function() {
+            const server = new IrcServer("irc.foobar",
+                extend(true, IrcServer.DEFAULT_CONFIG, {})
+            );
+            expect(() => {server.getNick("@💩ケ:foobar")}).toThrow();
         });
     });
 });


### PR DESCRIPTION
Fixes #654. This checks for invalid characters much earlier during templating and throws more aggressively if the nickname looks wrong. This change comes with a nice set of unit tests, too.