### PR TITLE
QueuePool.waitingItems should use it's internal queue size

### DIFF
--- a/lib/util/QueuePool.js
+++ b/lib/util/QueuePool.js
@@ -28,7 +28,7 @@ class QueuePool {
     }
 
     // Get number of items waiting to be inserted into a queue.
-    get waitingItems() { return this._overflowCount; }
+    get waitingItems() { return this.overflow.size(); }
 
     // Add an item to the queue. ID and item are passed directly to the Queue.
     // Index is optional and should be between 0 ~ poolSize-1. It determines
@@ -54,7 +54,6 @@ class QueuePool {
         // onto the queue pool. We want to return a promise which resolves
         // after the item has finished executing on the queue pool, hence
         // the promise chain here.
-        this._overflowCount++;
         return this.overflow.enqueue(id, {
             id: id,
             item: item,
@@ -78,7 +77,6 @@ class QueuePool {
             return q.onceFree();
         });
         return Promise.any(promises).then((q) => {
-            this._overflowCount--;
             if (q.size() !== 0) {
                 throw new Error(`QueuePool overflow: starvation. No free queues.`);
             }

--- a/spec/unit/Queue.spec.js
+++ b/spec/unit/Queue.spec.js
@@ -115,4 +115,25 @@ describe("Queue", function() {
             done();
         });
     });
+
+    it("should have the correct size.", (done) => {
+        var thing1 = { foo: "bar"};
+        var thing2 = { bar: "baz"};
+        var things = [thing1, thing2];
+        let expectedSize = things.length;
+        procFn.and.callFake((thing) => {
+            things.shift();
+            expect(queue.size()).toEqual(expectedSize);
+            if (things.length === 0) {
+                done();
+            }
+            expectedSize--;
+            return Promise.resolve();
+        });
+        expect(queue.size()).toEqual(0);
+        queue.enqueue("id1", thing1);
+        expect(queue.size()).toEqual(1);
+        queue.enqueue("id2", thing2);
+        expect(queue.size()).toEqual(2);
+    });
 });

--- a/spec/unit/Queue.spec.js
+++ b/spec/unit/Queue.spec.js
@@ -116,10 +116,10 @@ describe("Queue", function() {
         });
     });
 
-    it("should have the correct size.", (done) => {
-        var thing1 = { foo: "bar"};
-        var thing2 = { bar: "baz"};
-        var things = [thing1, thing2];
+    it("should have the correct size", (done) => {
+        const thing1 = { foo: "bar"};
+        const thing2 = { bar: "baz"};
+        const things = [thing1, thing2];
         let expectedSize = things.length;
         procFn.and.callFake((thing) => {
             things.shift();

--- a/spec/unit/QueuePool.spec.js
+++ b/spec/unit/QueuePool.spec.js
@@ -137,7 +137,7 @@ describe("QueuePool", function() {
     }));
 
     it("should accurately track waiting items", test.coroutine(function*() {
-        for (let i = 0;i<10;i++) {
+        for (let i = 0; i < 10; i++) {
             pool.enqueue(i, i);
         }
         expect(pool.waitingItems).toEqual(7);

--- a/spec/unit/QueuePool.spec.js
+++ b/spec/unit/QueuePool.spec.js
@@ -34,7 +34,7 @@ describe("QueuePool", function() {
         procFn.and.callFake((item) => {
             itemToDeferMap[item] = new promiseutil.defer();
             return itemToDeferMap[item].promise;
-        })
+        });
     });
 
     it("should let multiple items be processed at once",

--- a/spec/unit/QueuePool.spec.js
+++ b/spec/unit/QueuePool.spec.js
@@ -135,4 +135,16 @@ describe("QueuePool", function() {
         yield nextTick();
         expect(Object.keys(itemToDeferMap).sort()).toEqual(["b"]);
     }));
+
+    it("should accurately track waiting items", test.coroutine(function*() {
+        for (let i = 0;i<10;i++) {
+            pool.enqueue(i, i);
+        }
+        expect(pool.waitingItems).toEqual(7);
+        for (let j = 0; j < 10; j++) {
+            yield nextTick();
+            resolveItem(j);
+        }
+        expect(pool.waitingItems).toEqual(0);
+    }));
 });


### PR DESCRIPTION
I suspect somehow we were racing which made the Freenode graphs have a deficit of 1.5k reconnecting users, which I believe do not exist. This PR adds some tests to ensure the sizes are correct, and that QueuePool uses Queue.size() to determine waiting items.