### PR TITLE
IRC Memberstate tracking

### DIFF
--- a/lib/bridge/IrcHandler.js
+++ b/lib/bridge/IrcHandler.js
@@ -547,14 +547,15 @@ IrcHandler.prototype.onMessage = Promise.coroutine(function*(req, server, fromUs
 });
 
 IrcHandler.prototype._incrementResyncChannelCounter = function(server, channel, req) {
-    let counter = (this.resyncChannelCounter.get(`${server.domain}:${channel}`) || 0) + 1;
+    const key = `${server.domain}:${channel}`;
+    let counter = (this.resyncChannelCounter.get(key) || 0) + 1;
     if (counter >= RESYNC_IRC_USERS_THRESHOLD) {
         req.log.warn("Channel has gotten out of sync, fetching names");
         // Firing a request for getNicks will send a names request
         this.ircBridge.getClientPool().getBot().getNicks();
         counter = 0;
     }
-    this.resyncChannelCounter.set(counter);
+    this.resyncChannelCounter.set(key, counter);
 };
 
 IrcHandler.prototype._shouldBeInChannel = function(server, channel, user) {

--- a/lib/bridge/IrcHandler.js
+++ b/lib/bridge/IrcHandler.js
@@ -514,7 +514,7 @@ IrcHandler.prototype.onMessage = Promise.coroutine(function*(req, server, fromUs
     let matrixRooms = yield this.ircBridge.getStore().getMatrixRoomsForChannel(server, channel);
     const shouldBeInChannel = this._shouldBeInChannel(server, channel, fromUser);
     if (!shouldBeInChannel) {
-        eq.log.warn("Didn't expect user to be in this channel, leaving them from room(s)");
+        req.log.warn("Didn't expect user to be in this channel, leaving them from room(s)");
     }
     let promises = matrixRooms.map((room) => {
         req.log.info(
@@ -603,7 +603,7 @@ IrcHandler.prototype.onJoin = Promise.coroutine(function*(req, server, joiningUs
         return BridgeRequest.ERR_VIRTUAL_USER;
     }
 
-    this.realIrcUsersInChannels.set(`${server.domain}:${chan}:${nick}`);
+    this.realIrcUsersInChannels.add(`${server.domain}:${chan}:${nick}`);
 
     this.quitDebouncer.onJoin(nick, server);
 

--- a/lib/bridge/IrcHandler.js
+++ b/lib/bridge/IrcHandler.js
@@ -25,7 +25,7 @@ const NICK_USERID_CACHE_MAX = 512;
 
 // Refetch "names" after this many unexpected messages.
 // This is to avoid getting massively out of sync.
-const RESYNC_IRC_USERS_THRESHOLD = 5;
+const RESYNC_IRC_USERS_THRESHOLD = 10;
 
 function IrcHandler(ircBridge) {
     this.ircBridge = ircBridge;
@@ -520,13 +520,19 @@ IrcHandler.prototype.onMessage = Promise.coroutine(function*(req, server, fromUs
         req.log.info(
             "Relaying in room %s", room.getId()
         );
-        const actionPromise = this.ircBridge.sendMatrixAction(room, virtualMatrixUser, mxAction, req)
+        const actionPromise = this.ircBridge.sendMatrixAction(
+            room, virtualMatrixUser, mxAction, req
+        );
         if (!shouldBeInChannel) {
             this._incrementResyncChannelCounter(server, channel, req);
             actionPromise.then(() => {
                 return this.ircBridge.getAppServiceBridge().getIntent(
                     virtualMatrixUser.getId()
-                ).kick(room.getId(), virtualMatrixUser.getId(), "User is not a member of this channel");
+                ).kick(
+                    room.getId(),
+                    virtualMatrixUser.getId(),
+                    "User is not a member of this channel"
+                );
             });
         }
         return actionPromise;

--- a/lib/bridge/IrcHandler.js
+++ b/lib/bridge/IrcHandler.js
@@ -23,6 +23,10 @@ const MODES_TO_WATCH = [
 
 const NICK_USERID_CACHE_MAX = 512;
 
+// Refetch "names" after this many unexpected messages.
+// This is to avoid getting massively out of sync.
+const RESYNC_IRC_USERS_THRESHOLD = 5;
+
 function IrcHandler(ircBridge) {
     this.ircBridge = ircBridge;
     // maintain a map of which user ID is in which PM room, so we know if we
@@ -53,6 +57,8 @@ function IrcHandler(ircBridge) {
     };
 
     this.nickUserIdMapCache = new Map(); // server:channel => mapping
+    this.realIrcUsersInChannels = new Set(); //server:channel:nick
+    this.resyncChannelCounter = new Map(); //server:channel => counter
 
     // Map<string,bool> which contains nicks we know have been registered/has display name
     this._registeredNicks = Object.create(null);
@@ -506,11 +512,26 @@ IrcHandler.prototype.onMessage = Promise.coroutine(function*(req, server, fromUs
     }
 
     let matrixRooms = yield this.ircBridge.getStore().getMatrixRoomsForChannel(server, channel);
+    const shouldBeInChannel = this.realIrcUsersInChannels.has(
+        `${server.domain}:${channel}:${fromUser.nick}`
+    );
+    if (!shouldBeInChannel) {
+        eq.log.warn("Didn't expect user to be in this channel, leaving them from room(s)");
+    }
     let promises = matrixRooms.map((room) => {
         req.log.info(
             "Relaying in room %s", room.getId()
         );
-        return this.ircBridge.sendMatrixAction(room, virtualMatrixUser, mxAction, req);
+        const actionPromise = this.ircBridge.sendMatrixAction(room, virtualMatrixUser, mxAction, req)
+        if (!shouldBeInChannel) {
+            this._incrementResyncChannelCounter(server, channel, req);
+            actionPromise.then(() => {
+                return this.ircBridge.getAppServiceBridge().getIntent(
+                    virtualMatrixUser.getId()
+                ).kick(room.getId(), virtualMatrixUser.getId(), "User is not a member of this channel");
+            });
+        }
+        return actionPromise;
     });
     if (matrixRooms.length === 0) {
         req.log.info(
@@ -520,6 +541,17 @@ IrcHandler.prototype.onMessage = Promise.coroutine(function*(req, server, fromUs
     }
     yield Promise.all(promises);
 });
+
+IrcHandler.prototype._incrementResyncChannelCounter = function(server, channel, req) {
+    let counter = (this.resyncChannelCounter.get(`${server.domain}:${channel}`) || 0) + 1;
+    if (counter >= RESYNC_IRC_USERS_THRESHOLD) {
+        req.log.warn("Channel has gotten out of sync, fetching names");
+        // Firing a request for getNicks will send a names request
+        this.ircBridge.getClientPool().getBot().getNicks();
+        counter = 0;
+    }
+    this.resyncChannelCounter.set(counter);
+}
 
 /**
  * Called when the AS receives an IRC join event.
@@ -538,6 +570,7 @@ IrcHandler.prototype.onJoin = Promise.coroutine(function*(req, server, joiningUs
         this.incrementMetric("join");
     }
 
+
     this._invalidateNickUserIdMap(server, chan);
 
     let nick = joiningUser.nick;
@@ -552,6 +585,8 @@ IrcHandler.prototype.onJoin = Promise.coroutine(function*(req, server, joiningUs
     if (joiningUser.isVirtual) {
         return BridgeRequest.ERR_VIRTUAL_USER;
     }
+
+    this.realIrcUsersInChannels.set(`${server.domain}:${chan}:${nick}`);
 
     this.quitDebouncer.onJoin(nick, server);
 
@@ -671,6 +706,7 @@ IrcHandler.prototype.onKick = Promise.coroutine(function*(req, server,
         // will NOT send a PART command. We equally cannot make a fake PART command and
         // reuse the same code path as we want to force this to go through, regardless of
         // whether incremental join/leave syncing is turned on.
+        this.realIrcUsersInChannels.delete(`${server.domain}:${chan}:${kickee}`);
         let matrixUser = yield this.ircBridge.getMatrixUser(kickee);
         req.log.info("Mapped kickee nick %s to %s", kickee.nick, JSON.stringify(matrixUser));
         let matrixRooms = yield this.ircBridge.getStore().getMatrixRoomsForChannel(server, chan);
@@ -700,12 +736,13 @@ IrcHandler.prototype.onKick = Promise.coroutine(function*(req, server,
 IrcHandler.prototype.onPart = Promise.coroutine(function*(req, server, leavingUser, chan, kind) {
     this.incrementMetric("part");
     this._invalidateNickUserIdMap(server, chan);
+    let nick = leavingUser.nick;
+    this.realIrcUsersInChannels.delete(`${server.domain}:${chan}:${nick}`);
     // parts are always incremental (only NAMES are initial)
     if (!server.shouldSyncMembershipToMatrix("incremental", chan)) {
         req.log.info("Server doesn't mirror parts.");
         return;
     }
-    let nick = leavingUser.nick;
     req.log.info("onPart(%s) %s to %s", kind, nick, chan);
 
     // if the person leaving is a virtual IRC user, do nothing.

--- a/lib/bridge/IrcHandler.js
+++ b/lib/bridge/IrcHandler.js
@@ -554,7 +554,7 @@ IrcHandler.prototype._incrementResyncChannelCounter = function(server, channel, 
         // Firing a request for getNicks will send a names request
         counter = 0;
         this.ircBridge.getBotClient(server).then((cli) => {
-            cli.getNicks();
+            cli.getNicks(channel);
         }).catch((err) => {
             req.log.warn(`Couldn't get bot client to fetch nicks: ${err}`);
         });

--- a/lib/bridge/IrcHandler.js
+++ b/lib/bridge/IrcHandler.js
@@ -565,6 +565,7 @@ IrcHandler.prototype._shouldBeInChannel = function(server, channel, user) {
     }
     if (!this.ircBridge.isStartedUp()) {
         // Not finished starting up, so let's not kick people out prematurely.
+        return true;
     }
     return this.realIrcUsersInChannels.has(
         `${server.domain}:${channel}:${user.nick}`

--- a/lib/bridge/IrcHandler.js
+++ b/lib/bridge/IrcHandler.js
@@ -552,8 +552,12 @@ IrcHandler.prototype._incrementResyncChannelCounter = function(server, channel, 
     if (counter >= RESYNC_IRC_USERS_THRESHOLD) {
         req.log.warn("Channel has gotten out of sync, fetching names");
         // Firing a request for getNicks will send a names request
-        this.ircBridge.getClientPool().getBot().getNicks();
         counter = 0;
+        this.ircBridge.getBotClient().then((cli) => {
+            cli.getNicks();
+        }).catch((err) => {
+            req.log.warn(`Couldn't get bot client to fetch nicks: ${err}`);
+        });
     }
     this.resyncChannelCounter.set(key, counter);
 };

--- a/lib/bridge/IrcHandler.js
+++ b/lib/bridge/IrcHandler.js
@@ -23,10 +23,6 @@ const MODES_TO_WATCH = [
 
 const NICK_USERID_CACHE_MAX = 512;
 
-// Refetch "names" after this many unexpected messages.
-// This is to avoid getting massively out of sync.
-const RESYNC_IRC_USERS_THRESHOLD = 10;
-
 function IrcHandler(ircBridge) {
     this.ircBridge = ircBridge;
     // maintain a map of which user ID is in which PM room, so we know if we
@@ -58,7 +54,6 @@ function IrcHandler(ircBridge) {
 
     this.nickUserIdMapCache = new Map(); // server:channel => mapping
     this.realIrcUsersInChannels = new Set(); //server:channel:nick
-    this.resyncChannelCounter = new Map(); //server:channel => counter
 
     // Map<string,bool> which contains nicks we know have been registered/has display name
     this._registeredNicks = Object.create(null);
@@ -524,7 +519,6 @@ IrcHandler.prototype.onMessage = Promise.coroutine(function*(req, server, fromUs
             room, virtualMatrixUser, mxAction, req
         );
         if (!shouldBeInChannel) {
-            this._incrementResyncChannelCounter(server, channel, req);
             actionPromise.then(() => {
                 return this.ircBridge.getAppServiceBridge().getIntent(
                     virtualMatrixUser.getId()
@@ -545,22 +539,6 @@ IrcHandler.prototype.onMessage = Promise.coroutine(function*(req, server, fromUs
     }
     yield Promise.all(promises);
 });
-
-IrcHandler.prototype._incrementResyncChannelCounter = function(server, channel, req) {
-    const key = `${server.domain}:${channel}`;
-    let counter = (this.resyncChannelCounter.get(key) || 0) + 1;
-    if (counter >= RESYNC_IRC_USERS_THRESHOLD) {
-        req.log.warn("Channel has gotten out of sync, fetching names");
-        // Firing a request for getNicks will send a names request
-        counter = 0;
-        this.ircBridge.getBotClient(server).then((cli) => {
-            cli.getNicks(channel);
-        }).catch((err) => {
-            req.log.warn(`Couldn't get bot client to fetch nicks: ${err}`);
-        });
-    }
-    this.resyncChannelCounter.set(key, counter);
-};
 
 IrcHandler.prototype._shouldBeInChannel = function(server, channel, user) {
     if (!this.ircBridge.isStartedUp()) {

--- a/lib/bridge/IrcHandler.js
+++ b/lib/bridge/IrcHandler.js
@@ -553,7 +553,7 @@ IrcHandler.prototype._incrementResyncChannelCounter = function(server, channel, 
         req.log.warn("Channel has gotten out of sync, fetching names");
         // Firing a request for getNicks will send a names request
         counter = 0;
-        this.ircBridge.getBotClient().then((cli) => {
+        this.ircBridge.getBotClient(server).then((cli) => {
             cli.getNicks();
         }).catch((err) => {
             req.log.warn(`Couldn't get bot client to fetch nicks: ${err}`);
@@ -563,12 +563,12 @@ IrcHandler.prototype._incrementResyncChannelCounter = function(server, channel, 
 };
 
 IrcHandler.prototype._shouldBeInChannel = function(server, channel, user) {
-    if (!server.shouldSyncMembershipToMatrix("incremental", channel)) {
-        // We don't sync membershio, so we don't really care.
-        return true;
-    }
     if (!this.ircBridge.isStartedUp()) {
         // Not finished starting up, so let's not kick people out prematurely.
+        return true;
+    }
+    if (!server.shouldSyncMembershipToMatrix("incremental", channel)) {
+        // We don't sync membershio, so we don't really care.
         return true;
     }
     return this.realIrcUsersInChannels.has(

--- a/lib/bridge/IrcHandler.js
+++ b/lib/bridge/IrcHandler.js
@@ -512,9 +512,7 @@ IrcHandler.prototype.onMessage = Promise.coroutine(function*(req, server, fromUs
     }
 
     let matrixRooms = yield this.ircBridge.getStore().getMatrixRoomsForChannel(server, channel);
-    const shouldBeInChannel = this.realIrcUsersInChannels.has(
-        `${server.domain}:${channel}:${fromUser.nick}`
-    );
+    const shouldBeInChannel = this._shouldBeInChannel(server, channel, fromUser);
     if (!shouldBeInChannel) {
         eq.log.warn("Didn't expect user to be in this channel, leaving them from room(s)");
     }
@@ -551,7 +549,20 @@ IrcHandler.prototype._incrementResyncChannelCounter = function(server, channel, 
         counter = 0;
     }
     this.resyncChannelCounter.set(counter);
-}
+};
+
+IrcHandler.prototype._shouldBeInChannel = function(server, channel, user) {
+    if (!server.shouldSyncMembershipToMatrix("incremental", channel)) {
+        // We don't sync membershio, so we don't really care.
+        return true;
+    }
+    if (!this.ircBridge.isStartedUp()) {
+        // Not finished starting up, so let's not kick people out prematurely.
+    }
+    return this.realIrcUsersInChannels.has(
+        `${server.domain}:${channel}:${user.nick}`
+    );
+};
 
 /**
  * Called when the AS receives an IRC join event.


### PR DESCRIPTION
This is an experimental PR to leave users who we don't expect  to be in the room. It's pretty simple:
- We track all joins in a big ``Set``
- Any users not in that set are left after they send a message.
- This hopefully catches the case where notice bots are not left in rooms until restart, or users who have left and we've decided to keep around.

This comes with the pitfall that if a join is not caught (either via a join or names call), then that user will be stuck in limbo until someone else from matrix joins and forces a new names set containing the user. There is definitely a non zero chance of this happening, but it's *rare* for us to outright miss a join unless we were falling over in traffic which would probably be bridge death anyway.

This solves the problems where:
- Users aren't actually in the channel, but sending messages into it causing the member to be stuck there forever.
- This also solves the problem of /parts arriving ahead of the full set of messages being sent, and leaving the user stuck again. However it will also come with a bundle of join/leaves which probably means we need to set some delays up.

