### PR TITLE
Mark some variables as constants for readability in Debouncer

### DIFF
--- a/lib/bridge/QuitDebouncer.js
+++ b/lib/bridge/QuitDebouncer.js
@@ -109,7 +109,9 @@ QuitDebouncer.prototype.debounceQuit = Promise.coroutine(function*(req, server, 
     const debounceDelayMinMs = server.getQuitDebounceDelayMinMs();
     const debounceDelayMaxMs = server.getQuitDebounceDelayMaxMs();
 
-    const debounceMs = debounceDelayMinMs + Math.random() * (debounceDelayMaxMs - debounceDelayMinMs);
+    const debounceMs = debounceDelayMinMs + Math.random() * (
+        debounceDelayMaxMs - debounceDelayMinMs
+    );
 
     // We do want to immediately bridge a leave if <= 0
     if (debounceMs <= 0) {

--- a/lib/bridge/QuitDebouncer.js
+++ b/lib/bridge/QuitDebouncer.js
@@ -2,6 +2,10 @@
 "use strict";
 var Promise = require("bluebird");
 
+const QUIT_WAIT_DELAY_MS = 100;
+const QUIT_WINDOW_MS = 1000;
+const QUIT_PRESENCE = "offline";
+
 function QuitDebouncer(ircBridge) {
     this.ircBridge = ircBridge;
 
@@ -64,33 +68,31 @@ QuitDebouncer.prototype.onJoin = function (nick, server) {
  */
 QuitDebouncer.prototype.debounceQuit = Promise.coroutine(function*(req, server, matrixUser, nick) {
     // Maintain the last windowMs worth of timestamps corresponding with calls to this function.
-    let debouncer = this._debouncerForServer[server.domain];
+    const debouncer = this._debouncerForServer[server.domain];
 
-    let now = Date.now();
+    const now = Date.now();
     debouncer.quitTimestampsMs.push(now);
 
-    let windowMs = 1000;// Window starts 1s ago
-    let threshold = server.getDebounceQuitsPerSecond();// Rate of quits to call net-split
+    const threshold = server.getDebounceQuitsPerSecond();// Rate of quits to call net-split
 
-    // Filter out timestamps from more than windowMs ago
+    // Filter out timestamps from more than QUIT_WINDOW_MS ago
     debouncer.quitTimestampsMs = debouncer.quitTimestampsMs.filter(
-        (t) => t > (now - windowMs)
+        (t) => t > (now - QUIT_WINDOW_MS)
     );
 
     // Wait for a short time to allow other potential splitters to send QUITs
-    yield Promise.delay(100);
-    let isSplitOccuring = debouncer.quitTimestampsMs.length > threshold;
+    yield Promise.delay(QUIT_WAIT_DELAY_MS);
+    const isSplitOccuring = debouncer.quitTimestampsMs.length > threshold;
 
     // TODO: This should be replaced with "disconnected" as per matrix-appservice-irc#222
-    let presence = "offline";
     try {
         yield this.ircBridge.getAppServiceBridge().getIntent(
             matrixUser.getId()
-        ).setPresence(presence);
+        ).setPresence(QUIT_PRESENCE);
     }
     catch (err) {
         req.log.error(
-            'QuitDebouncer Failed to set presence to offline for user %s: %s',
+            `QuitDebouncer Failed to set presence to ${QUIT_PRESENCE} for user %s: %s`,
             matrixUser.getId(),
             err.message
         );
@@ -104,10 +106,10 @@ QuitDebouncer.prototype.debounceQuit = Promise.coroutine(function*(req, server, 
         return true;
     }
 
-    let debounceDelayMinMs = server.getQuitDebounceDelayMinMs();
-    let debounceDelayMaxMs = server.getQuitDebounceDelayMaxMs();
+    const debounceDelayMinMs = server.getQuitDebounceDelayMinMs();
+    const debounceDelayMaxMs = server.getQuitDebounceDelayMaxMs();
 
-    let debounceMs = debounceDelayMinMs + Math.random() * (debounceDelayMaxMs - debounceDelayMinMs);
+    const debounceMs = debounceDelayMinMs + Math.random() * (debounceDelayMaxMs - debounceDelayMinMs);
 
     // We do want to immediately bridge a leave if <= 0
     if (debounceMs <= 0) {


### PR DESCRIPTION
It's just a personal thing, but I prefer values to be capitalised at the top of a file rather than ``lets``s strewn around the function. It gives the false impression they are mutable.