### PR TITLE
Use html if entities exist

### DIFF
--- a/lib/irc/formatting.js
+++ b/lib/irc/formatting.js
@@ -1,7 +1,7 @@
 "use strict";
 
-var sanitizeHtml = require('sanitize-html');
-var htmlNamesToColorCodes = {
+const sanitizeHtml = require('sanitize-html');
+const htmlNamesToColorCodes = {
     white:     ['00', '0'],
     black:     ['01', '1'],
     navy:      ['02', '2'],
@@ -21,7 +21,7 @@ var htmlNamesToColorCodes = {
 };
 
 // These map the CSS color names to mIRC hex colors
-var htmlNamesToHex = {
+const htmlNamesToHex = {
     white:     '#FFFFFF',
     black:     '#000000',
     navy:      '#00007F',

--- a/lib/irc/formatting.js
+++ b/lib/irc/formatting.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const sanitizeHtml = require('sanitize-html');
+const he = require("he");
 const htmlNamesToColorCodes = {
     white:     ['00', '0'],
     black:     ['01', '1'],
@@ -156,13 +157,14 @@ module.exports.htmlToIrc = function(html) {
     }
 
     // Sanitize the HTML first to allow us to regex parse this (which also does
-    // things like case-sensitivity and spacing)
-    var cleanHtml = sanitizeHtml(html, {
+    // things like case-sensitivity and spacing). Use he to decode any html entities
+    // because we don't want those.
+    var cleanHtml = he.decode(sanitizeHtml(html, {
         allowedTags: ["b", "i", "u", "strong", "font", "em"],
         allowedAttributes: {
             font: ["color"]
         }
-    });
+    }));
     if (cleanHtml !== html) {
         // There are unrecognised tags. Let's play it safe and break, we can always
         // use the fallback text.

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "crc": "^3.2.1",
     "escape-string-regexp": "^1.0.5",
     "extend": "^2.0.0",
+    "he": "^1.1.1",
     "irc": "matrix-org/node-irc#c9abb427bec5016d94a2abf3e058cc62de09ea5a",
     "js-yaml": "^3.2.7",
     "matrix-appservice-bridge": "1.6.0c",

--- a/spec/unit/formatting.spec.js
+++ b/spec/unit/formatting.spec.js
@@ -34,7 +34,8 @@ describe("Formatting", function() {
         });
         it("should be null for unsupported tags", function() {
             expect(
-                formatting.htmlToIrc("The quick brown <iframe>fox</iframe> jumps over the lazy <b>dog</b>.")
+                formatting.htmlToIrc("The quick brown <iframe>fox</iframe>"+
+                                     "jumps over the lazy <b>dog</b>.")
             ).toBe(null);
         });
     });

--- a/spec/unit/formatting.spec.js
+++ b/spec/unit/formatting.spec.js
@@ -1,0 +1,41 @@
+"use strict";
+const formatting = require("../../lib/irc/formatting.js");
+
+describe("Formatting", function() {
+    describe("htmlToIrc", function() {
+        it("should have non-formatted for non-html inputs", function() {
+            expect(
+                formatting.htmlToIrc("The quick brown fox jumps over the lazy dog.")
+            ).toBe("The quick brown fox jumps over the lazy dog.");
+        });
+        it("should bold formatting for <b> inputs", function() {
+            expect(
+                formatting.htmlToIrc("The quick brown <b>fox</b> jumps over the lazy <b>dog</b>.")
+            ).toBe("The quick brown \u0002fox\u000f jumps over the lazy \u0002dog\u000f.");
+        });
+        it("should have regular characters for inputs containing non-safe html chars", function() {
+            expect(
+                formatting.htmlToIrc("%100 of \"homes\" should have <u>dogs</u>. Facts © Half-Shot")
+            ).toBe("%100 of \"homes\" should have \u001fdogs\u000f. Facts © Half-Shot");
+        });
+        it("should colourise many text", function() {
+            expect(
+                formatting.htmlToIrc(`<font color="red">R</font><font color="orange">a</font>`+
+                                     `<font color="yellow">i</font><font color="green">n</font>`+
+                                     `<font color="blue">b</font><font color="purple">o</font>`+
+                                     `<font color="fuchsia">w</font>`)
+            ).toBe("\u000304R\u000f" +
+                   "\u000307a\u000f" +
+                   "\u000308i\u000f" +
+                   "\u000303n\u000f" +
+                   "\u000312b\u000f" +
+                   "\u000306o\u000f" +
+                   "\u000313w\u000f");
+        });
+        it("should be null for unsupported tags", function() {
+            expect(
+                formatting.htmlToIrc("The quick brown <iframe>fox</iframe> jumps over the lazy <b>dog</b>.")
+            ).toBe(null);
+        });
+    });
+});


### PR DESCRIPTION
The htmlSantizer was replacing characters with html entities which meant that perfectly fine HTML was not being sent as formatted to IRC. This fixes that by removing the entities after sanitizing. 

Some unit tests were thrown in for the formatter also.

Fixes #662 