### PR TITLE
Double bridging rule files

### DIFF
--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -422,6 +422,11 @@ ircService:
     # allotted time period, the provisioning request will fail.
     # Default: 300 seconds (5 mins)
     requestTimeoutSeconds: 300
+    # A file defining the provisioning rules for rooms. Format is documented
+    # in rules.sample.yaml. Leave undefined to not specify any rules.
+    ruleFile: "./provisioning.rules.yaml"
+    # Watch the file for changes, and apply the rules. Default: false
+    watch: true
 
   # WARNING: The bridge needs to send plaintext passwords to the IRC server, it cannot
   # send a password hash. As a result, passwords (NOT hashes) are stored encrypted in

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -426,7 +426,7 @@ ircService:
     # in rules.sample.yaml. Leave undefined to not specify any rules.
     ruleFile: "./provisioning.rules.yaml"
     # Watch the file for changes, and apply the rules. Default: false
-    watch: true
+    enableReload: true
 
   # WARNING: The bridge needs to send plaintext passwords to the IRC server, it cannot
   # send a password hash. As a result, passwords (NOT hashes) are stored encrypted in

--- a/lib/bridge/IrcBridge.js
+++ b/lib/bridge/IrcBridge.js
@@ -52,6 +52,16 @@ function IrcBridge(config, registration) {
     this.ircHandler = new IrcHandler(this);
     this._clientPool = new ClientPool(this);
     var dirPath = this.config.ircService.databaseUri.substring("nedb://".length);
+    let roomLinkValidation = undefined;
+    let provisioning = config.ircService.provisioning;
+    if (provisioning && provisioning.enabled &&
+        typeof (provisioning.ruleFile) === "string") {
+        roomLinkValidation = {
+            ruleFile: provisioning.ruleFile,
+            watch: provisioning.watch
+        };
+    }
+
     this._bridge = new Bridge({
         registration: this.registration,
         homeserverUrl: this.config.homeserver.url,
@@ -89,7 +99,8 @@ function IrcBridge(config, registration) {
                 dontCheckPowerLevel: true,
                 enablePresence: this.config.homeserver.enablePresence,
             }
-        }
+        },
+        roomLinkValidation,
     });
 
     this._timers = null; // lazy map of Histogram instances used as metrics

--- a/lib/bridge/IrcBridge.js
+++ b/lib/bridge/IrcBridge.js
@@ -58,7 +58,7 @@ function IrcBridge(config, registration) {
         typeof (provisioning.ruleFile) === "string") {
         roomLinkValidation = {
             ruleFile: provisioning.ruleFile,
-            watch: provisioning.watch
+            triggerEndpoint: provisioning.enableReload
         };
     }
 

--- a/lib/config/schema.yml
+++ b/lib/config/schema.yml
@@ -83,7 +83,7 @@ properties:
                         type: "number"
                     ruleFile:
                         type: "string"
-                    watch:
+                    enableReload:
                         type: "boolean"
             passwordEncryptionKeyPath:
                 type: "string"

--- a/lib/config/schema.yml
+++ b/lib/config/schema.yml
@@ -81,6 +81,10 @@ properties:
                         type: "boolean"
                     requestTimeoutSeconds:
                         type: "number"
+                    ruleFile:
+                        type: "string"
+                    watch:
+                        type: "boolean"
             passwordEncryptionKeyPath:
                 type: "string"
             matrixHandler:

--- a/lib/provisioning/Provisioner.js
+++ b/lib/provisioning/Provisioner.js
@@ -254,7 +254,7 @@ Provisioner.prototype._userHasProvisioningPower = Promise.coroutine(
                 ' Error: ' + err
             );
         }
-        
+
         try {
             powerState = yield matrixClient.getStateEvent(roomId, 'm.room.power_levels');
         }

--- a/lib/provisioning/Provisioner.js
+++ b/lib/provisioning/Provisioner.js
@@ -244,7 +244,17 @@ Provisioner.prototype._userHasProvisioningPower = Promise.coroutine(
 
         // Try 100 times to join a room, or timeout after 10 min
         yield retry(req, 100, 5000, matrixClient, matrixClient.joinRoom, roomId).timeout(600000);
-
+        try {
+            yield this._ircBridge.getAppServiceBridge().canProvisionRoom(roomId);
+        }
+        catch (err) {
+            req.log.error(`Room failed room validator check: (${err})`);
+            throw new Error(
+                'Room failed validation. You may be attempting to "double bridge" this room.' +
+                ' Error: ' + err
+            );
+        }
+        
         try {
             powerState = yield matrixClient.getStateEvent(roomId, 'm.room.power_levels');
         }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "he": "^1.1.1",
     "irc": "matrix-org/node-irc#c9abb427bec5016d94a2abf3e058cc62de09ea5a",
     "js-yaml": "^3.2.7",
-    "matrix-appservice-bridge": "matrix-org/matrix-appservice-bridge#8c4f2bc39fabb88e0069010a212706905c3d90c5",
+    "matrix-appservice-bridge": "^1.7.0",
     "nedb": "^1.1.2",
     "nopt": "^3.0.1",
     "prom-client": "^6.3.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "extend": "^2.0.0",
     "irc": "matrix-org/node-irc#c9abb427bec5016d94a2abf3e058cc62de09ea5a",
     "js-yaml": "^3.2.7",
-    "matrix-appservice-bridge": "matrix-org/matrix-appservice-bridge#d61883be21f6f641e7edcf6fea0ba447ffcf8def",
+    "matrix-appservice-bridge": "matrix-org/matrix-appservice-bridge#903a0c98517732c9d26e3392a4ea5cc4bf966c98",
     "nedb": "^1.1.2",
     "nopt": "^3.0.1",
     "prom-client": "^6.3.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "extend": "^2.0.0",
     "irc": "matrix-org/node-irc#c9abb427bec5016d94a2abf3e058cc62de09ea5a",
     "js-yaml": "^3.2.7",
-    "matrix-appservice-bridge": "1.6.0c",
+    "matrix-appservice-bridge": "matrix-org/matrix-appservice-bridge#d61883be21f6f641e7edcf6fea0ba447ffcf8def",
     "nedb": "^1.1.2",
     "nopt": "^3.0.1",
     "prom-client": "^6.3.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "extend": "^2.0.0",
     "irc": "matrix-org/node-irc#c9abb427bec5016d94a2abf3e058cc62de09ea5a",
     "js-yaml": "^3.2.7",
-    "matrix-appservice-bridge": "matrix-org/matrix-appservice-bridge#903a0c98517732c9d26e3392a4ea5cc4bf966c98",
+    "matrix-appservice-bridge": "matrix-org/matrix-appservice-bridge#8c4f2bc39fabb88e0069010a212706905c3d90c5",
     "nedb": "^1.1.2",
     "nopt": "^3.0.1",
     "prom-client": "^6.3.0",

--- a/provisioning.rules.sample.yaml
+++ b/provisioning.rules.sample.yaml
@@ -2,9 +2,11 @@
 # If one of the regexes matches a userId, then do not allow provisioning
 # to the room UNLESS it also matches a exempt regex.
 # This doesn't affect existing bridge entrys, only new provisioned rooms.
+#
+# For this to work, config.provisioning.ruleFile must point to this file.
 userIds:
-    exempt: 
+    exempt:
       - "@appservice-irc:localhost"
-      - "@irc_:localhost"
-    conflict: 
-      - "@irc_:.+"
+      - "@irc_.+:localhost"
+    conflict:
+      - "@irc_.+:.+"

--- a/rules.sample.yaml
+++ b/rules.sample.yaml
@@ -1,0 +1,10 @@
+# A set of regexes to match against joined members in rooms.
+# If one of the regexes matches a userId, then do not allow provisioning
+# to the room UNLESS it also matches a exempt regex.
+# This doesn't affect existing bridge entrys, only new provisioned rooms.
+userIds:
+    exempt: 
+      - "@appservice-irc:localhost"
+      - "@irc_:localhost"
+    conflict: 
+      - "@irc_:.+"

--- a/spec/util/client-sdk-mock.js
+++ b/spec/util/client-sdk-mock.js
@@ -23,6 +23,7 @@ function MockClient(config) {
     this.setRoomTopic = jasmine.createSpy("sdk.setRoomTopic(roomId, topic)");
     this.setDisplayName = jasmine.createSpy("sdk.setDisplayName(name)");
     this.getStateEvent = jasmine.createSpy("sdk.getStateEvent(room,type,key)");
+    this.fetchRoomEvent = jasmine.createSpy("sdk.fetchRoomEvent(room,event_id)");
     this.sendStateEvent = jasmine.createSpy("sdk.sendStateEvent(room,type,content,key)");
     this.sendEvent = jasmine.createSpy("sdk.sendEvent(roomId,type,content)");
     this.invite = jasmine.createSpy("sdk.invite(roomId, userId)");


### PR DESCRIPTION
Depends on: https://github.com/matrix-org/matrix-appservice-bridge/pull/85

This change allows you to do rule specifying on what is allowed to be provisioned to avoid some cases of double bridging. New provision requests would check against the rule file to see if the members in a certain room were excluded from being bridged e.g. not mixing "@snoonet-irc:matrix.org" and "@gimpnet-irc:matrix.org" in the same room. 

This doesn't yet affect existing bridged rooms, which would need us to manually intervene. 