### PR TITLE
Unpack freenode changes and add an option for maxHttpSockets

### DIFF
--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -27,7 +27,7 @@ homeserver:
   # is the "domain name" part of the HS URL.
   domain: "localhost"
 
-  # Should presence be enabledfor matrix clients on this bridge. If disabled on the 
+  # Should presence be enabledfor matrix clients on this bridge. If disabled on the
   # homeserver then it should also be disabled here to avoid excess traffic.
   # Default: true
   enablePresence: true
@@ -318,9 +318,9 @@ ircService:
         reconnectIntervalMs: 5000
         # The number of concurrent reconnects if a user has been disconnected unexpectedly
         # (e.g. a netsplit). You should set this to a reasonably high number so that
-        # bridges are not waiting an eternity to reconnect all its clients if 
+        # bridges are not waiting an eternity to reconnect all its clients if
         # we see a massive number of disconnect. This is unrelated to the reconnectIntervalMs
-        # setting above which is for connecting on restart of the bridge. Set to 0 to 
+        # setting above which is for connecting on restart of the bridge. Set to 0 to
         # immediately try to reconnect all users.
         # Default: 50
         concurrentReconnectLimit: 50
@@ -446,3 +446,12 @@ ircService:
     # This is used to stem the flow of requests in case of a mass quit/leave, which might
     # slow down the homeserver.
     leaveConcurrency: 10
+
+# Options here are generally only applicable to large-scale bridges and may have
+# consequences greater than other options in this configuration file.
+advanced:
+  # The maximum number of HTTP(S) sockets to maintain. Usually this is unlimited
+  # however for large bridges it is important to rate limit the bridge to avoid
+  # accidentally overloading the homeserver. Defaults to 1000, which should be
+  # enough for the vast majority of use cases.
+  maxHttpSockets: 1000

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -27,7 +27,7 @@ homeserver:
   # is the "domain name" part of the HS URL.
   domain: "localhost"
 
-  # Should presence be enabledfor matrix clients on this bridge. If disabled on the
+  # Should presence be enabled for matrix clients on this bridge. If disabled on the
   # homeserver then it should also be disabled here to avoid excess traffic.
   # Default: true
   enablePresence: true

--- a/lib/bridge/IrcHandler.js
+++ b/lib/bridge/IrcHandler.js
@@ -637,16 +637,6 @@ IrcHandler.prototype.onJoin = Promise.coroutine(function*(req, server, joiningUs
         return Promise.all([
             joinRetry(0),
             intent.setPresence("online")
-/*
-            this.ircBridge.getAppServiceBridge().getIntent(
-                matrixUser.getId()
-            ).join(room.getId()),
-*/
-/*
-            this.ircBridge.getAppServiceBridge().getIntent(
-                matrixUser.getId()
-            ).client.setPresence("online")
-*/
         ]);
     });
     if (matrixRooms.length === 0) {

--- a/lib/bridge/QuitDebouncer.js
+++ b/lib/bridge/QuitDebouncer.js
@@ -84,7 +84,6 @@ QuitDebouncer.prototype.debounceQuit = Promise.coroutine(function*(req, server, 
     yield Promise.delay(QUIT_WAIT_DELAY_MS);
     const isSplitOccuring = debouncer.quitTimestampsMs.length > threshold;
 
-/*
     // TODO: This should be replaced with "disconnected" as per matrix-appservice-irc#222
     try {
         yield this.ircBridge.getAppServiceBridge().getIntent(
@@ -98,7 +97,6 @@ QuitDebouncer.prototype.debounceQuit = Promise.coroutine(function*(req, server, 
             err.message
         );
     }
-*/
 
     // Bridge QUITs if a net split is not occurring. This is in the case where a QUIT is
     // received for reasons such as ping timeout or IRC client (G)UI being killed.

--- a/lib/config/schema.yml
+++ b/lib/config/schema.yml
@@ -1,6 +1,11 @@
 "$schema": "http://json-schema.org/draft-04/schema#"
 type: "object"
 properties:
+    advanced:
+        type: "object"
+        properties:
+            maxHttpSockets:
+                type: "integer"
     homeserver:
         type: "object"
         properties:

--- a/lib/main.js
+++ b/lib/main.js
@@ -16,8 +16,8 @@ var log = logging.get("main");
 
 // Allow up to 1000 HTTP(S) sockets. Default is Infinity, which means that a slow HS coupled
 // with lots of traffic could consume up to the fd ulimit on a process.
-require("http").globalAgent.maxSockets = 4000;
-require("https").globalAgent.maxSockets = 4000;
+require("http").globalAgent.maxSockets = 1000;
+require("https").globalAgent.maxSockets = 1000;
 
 process.on("unhandledRejection", function(reason, promise) {
     log.error(reason ? reason.stack : "No reason given");

--- a/lib/main.js
+++ b/lib/main.js
@@ -14,8 +14,8 @@ var ident = require("./irc/ident");
 var logging = require("./logging");
 var log = logging.get("main");
 
-// Allow up to 1000 HTTP(S) sockets. Default is Infinity, which means that a slow HS coupled
-// with lots of traffic could consume up to the fd ulimit on a process.
+// We set this to 1000 by default now to set a default, and to ensure we're the first
+// one to load the libraries in. Later on in runBridge we actually define the real limit.
 require("http").globalAgent.maxSockets = 1000;
 require("https").globalAgent.maxSockets = 1000;
 
@@ -144,6 +144,10 @@ module.exports.runBridge = Promise.coroutine(function*(port, config, reg, isDBIn
         ident.configure(config.ircService.ident);
         ident.run();
     }
+
+    const maxSockets = (config["advanced"] || {})["maxHttpSockets"] || 1000;
+    require("http").globalAgent.maxSockets = maxSockets;
+    require("https").globalAgent.maxSockets = maxSockets;
 
     // backwards compat for 1 release. TODO remove
     if (config.appService && !config.homeserver) {


### PR DESCRIPTION
Presence is disabled at the bridge lib layer, and therefore we don't need to comment it out. Similarly, the maxSockets option should be an option.