### PR TITLE
Add Readme to scripts folder and some options to remove-idle-users.py

### DIFF
--- a/scripts/Readme.md
+++ b/scripts/Readme.md
@@ -1,5 +1,12 @@
 # remove-idle-users.py
-A script to kick idle bridged users from a given Matrix room.
+A script to kick idle Matrix users from a Matrix room that has an IRC bridge. 
+It will only kick Matrix-only users, without a given `prefix` and will never kick
+the appservice bot itself. This is useful, because on the IRC side, bridged matrix
+users, that are offline for a certain period are not shown as joined on the 
+IRC-side user list any more. Kicking them on the matrix side is clearing up these
+cases quite well. You have to determin the timeframe, after which a user is not
+visible any more on the irc side and set that timeframe in this script as `--since`
+option.
 
 ## usage
 
@@ -15,7 +22,7 @@ where you have to set the right options:
     -t or --token:      The access token
     -H or --homeserver: Base homeserver URL eg 'https://matrix.org'
     -s or --since:      Days since idle users have been offline for eg '30'
-    -p or --prefix:     User prefix to determine whether a user should be kicked. E.g. @freenode_
+    -p or --prefix:     User prefix to select which users should not be kicked. E.g. @freenode_
     -u or --user:       The user ID of the AS bot. E.g '@appservice-irc:matrix.org'
 
 ## example:

--- a/scripts/Readme.md
+++ b/scripts/Readme.md
@@ -1,0 +1,52 @@
+# remove-idle-users.py
+A script to kick idle bridged users from a given Matrix room.
+
+## usage
+
+    python remove-idle-users.py <options>
+    
+where you have to set the right options:
+
+#### one of these
+    -a or --alias:      The alias of the room eg '#freenode_#matrix-dev:matrix.org'
+    -r or --room:       Optional. The room ID instead of the alias eg '!curBafw45738:matrix.org'
+    
+#### required
+    -t or --token:      The access token
+    -H or --homeserver: Base homeserver URL eg 'https://matrix.org'
+    -s or --since:      Days since idle users have been offline for eg '30'
+    -p or --prefix:     User prefix to determine whether a user should be kicked. E.g. @freenode_
+    -u or --user:       The user ID of the AS bot. E.g '@appservice-irc:matrix.org'
+
+## example:
+
+    python ./remove-idle-users.py -a '#some-room-alias:matrix.yourserver.org' -t YOUR-ADMIN-TOKEN -H http://matrix.yourserver.org:8008 -s 30 -p irc_ -u @appservice-irc:irc.hackint.org 
+
+# grant-ops-in-room.py
+
+Grant full ops to a user in a portal room.
+
+# migrate-users.py 
+
+A script to remove suffixes from display names the bridge controls.
+
+# remove-user.py 
+
+Remove a Matrix user from all known bridged rooms.
+
+# unbridge.js
+Unbridge a dynamically created room with an alias.
+
+This will DELETE the alias->room_id mapping and make the room's
+join_rules: invite. You can optionally send a message in this
+room to tell users that they should re-join via the alias.
+This script does NOT create a new room. It relies on the AS to
+do this via onAliasQuery pokes.
+
+# upgrade-db-0.1-to-0.2.js
+
+Database Upgrade script (v0.1 => v0.2)
+
+# upgrade-db-0.2-to-0.3.js
+
+Database Upgrade script (v0.2 => v0.3)

--- a/scripts/remove-idle-users.py
+++ b/scripts/remove-idle-users.py
@@ -49,6 +49,7 @@ def get_idle_users(homeserver, room_id, token, since, user_prefix, bot_user_id):
     return [user_id for user_id in user_ids if is_idle(homeserver, user_id, token, activity_threshold_ms)]
 
 def kick_idlers(homeserver, room_id, token, since, user_prefix, bot_user_id):
+    global args
     print("%s : Processing %s" % (str(datetime.now()), room_id))
     reason = "Being idle for >%s days" % since
 
@@ -57,24 +58,29 @@ def kick_idlers(homeserver, room_id, token, since, user_prefix, bot_user_id):
     count = 0
     print("%s :   %s idle users in %s" % (str(datetime.now()), len(user_ids), room_id))
     for user_id in user_ids:
-        res = requests.put(
-            homeserver + "/_matrix/client/r0/rooms/" +
-            urllib.quote(room_id) + "/state/m.room.member/" +
-            urllib.quote(user_id) + "?access_token=" + token,
-            data = json.dumps({
-                "reason": reason,
-                "membership": "leave"
-            })
-        )
-        if res.status_code >= 400:
-            failure = { "user_id" : user_id }
-            try:
-                failure["response_json"] = res.json()
-            except Exception as e:
-                print("Could not get JSON body from failure response: %s" % e)
-            failure_responses.append(failure)
-        else:
+        if args.verbose or args.simulate:
+            print("kick user '%s'" % user_id)
+        if args.simulate:
             count += 1
+        else:
+            res = requests.put(
+                homeserver + "/_matrix/client/r0/rooms/" +
+                urllib.quote(room_id) + "/state/m.room.member/" +
+                urllib.quote(user_id) + "?access_token=" + token,
+                data = json.dumps({
+                    "reason": reason,
+                    "membership": "leave"
+                })
+            )
+            if res.status_code >= 400:
+                failure = { "user_id" : user_id }
+                try:
+                    failure["response_json"] = res.json()
+                except Exception as e:
+                    print("Could not get JSON body from failure response: %s" % e)
+                failure_responses.append(failure)
+            else:
+                count += 1
     if count > 0:
         print("%s :   %s/%s kicked users in total (%s failed requests)" % (str(datetime.now()), count, count + len(failure_responses), len(failure_responses)))
 
@@ -86,7 +92,7 @@ def kick_idlers(homeserver, room_id, token, since, user_prefix, bot_user_id):
 
 def main(token, alias, homeserver, since, user_prefix, user_id, room_id=None):
     if room_id is None:
-        print("Removing idle users in %s" % alias)
+        print("Removing idle users in %s, not starting with prefix '%s'" % (alias, user_prefix))
         room_id = get_room_id(homeserver, alias, token)
 
     if not room_id:
@@ -103,6 +109,8 @@ if __name__ == "__main__":
     parser.add_argument("-s", "--since", type=int, help="Days since idle Matrix users have been offline for eg '30'", required=True)
     parser.add_argument("-p", "--prefix", help="User prefix of bridged IRC users, that should not be kicked. E.g. @freenode_", required=True)
     parser.add_argument("-u", "--user", help="The user ID of the AS bot. E.g '@appservice-irc:matrix.org'", required=True)
+    parser.add_argument('-n', '--simulate', action="count", help="simulate only, see what would happen")
+    parser.add_argument('-v', '--verbose', action="count", help="increase output verbosity")
     args = parser.parse_args()
     if not args.token or not args.homeserver or not args.user or (not args.alias and not args.room):
         parser.print_help()
@@ -110,5 +118,17 @@ if __name__ == "__main__":
     if args.user[0] != "@":
         parser.print_help()
         print("--user must start with '@'")
+        sys.exit(1)
+    if args.prefix[0] != "@":
+        parser.print_help()
+        print("--prefix must start with '@'")
+        sys.exit(1)
+    if args.room and args.room[0] != "!":
+        parser.print_help()
+        print("--room must start with '!'")
+        sys.exit(1)
+    if args.alias and args.alias[0] != "#":
+        parser.print_help()
+        print("--alias must start with '#'")
         sys.exit(1)
     main(token=args.token, alias=args.alias, homeserver=args.homeserver, since=args.since, user_prefix=args.prefix, room_id=args.room, user_id=args.user)

--- a/scripts/remove-idle-users.py
+++ b/scripts/remove-idle-users.py
@@ -1,4 +1,15 @@
 #!/usr/bin/env python
+#
+# kick idle Matrix users from a Matrix room that has an IRC bridge. 
+# 
+# This script will only kick Matrix-only users, without a given `prefix` and
+# will never kick the appservice bot itself. This is useful, because on the IRC
+# side, bridged matrix users, that are offline for a certain period are not
+# shown as joined on the  IRC-side user list any more. Kicking them on the
+# matrix side is clearing up these cases quite well. You have to determin the
+# timeframe, after which a user is not visible any more on the irc side and
+# set that timeframe in this script as `--since` option.
+
 from __future__ import print_function
 import argparse
 from datetime import datetime
@@ -89,8 +100,8 @@ if __name__ == "__main__":
     parser.add_argument("-a", "--alias", help="The alias of the room eg '#freenode_#matrix-dev:matrix.org'", required=False)
     parser.add_argument("-r", "--room", help="Optional. The room ID instead of the alias eg '!curBafw45738:matrix.org'", required=False)
     parser.add_argument("-H", "--homeserver", help="Base homeserver URL eg 'https://matrix.org'", required=True)
-    parser.add_argument("-s", "--since", type=int, help="Days since idle users have been offline for eg '30'", required=True)
-    parser.add_argument("-p", "--prefix", help="User prefix to determine whether a user should be kicked. E.g. @freenode_", required=True)
+    parser.add_argument("-s", "--since", type=int, help="Days since idle Matrix users have been offline for eg '30'", required=True)
+    parser.add_argument("-p", "--prefix", help="User prefix of bridged IRC users, that should not be kicked. E.g. @freenode_", required=True)
     parser.add_argument("-u", "--user", help="The user ID of the AS bot. E.g '@appservice-irc:matrix.org'", required=True)
     args = parser.parse_args()
     if not args.token or not args.homeserver or not args.user or (not args.alias and not args.room):


### PR DESCRIPTION

I added a Readme to the scripts folder and enhanced the comments in `remove-idle-users.py` and some more options:

## changes in `remove-idle-users.py`:

- Add description in comment and clarify help
- Add simulate and verbose option
- added some more validation to give the right error message, if an argument is wrong.

Signed-off-by: Ruben Barkow <github@r.z11.de>