### PR TITLE
Actually join !storepass password with spaces

### DIFF
--- a/lib/bridge/MatrixHandler.js
+++ b/lib/bridge/MatrixHandler.js
@@ -536,7 +536,7 @@ MatrixHandler.prototype._onAdminMessage = Promise.coroutine(function*(req, event
 
         try {
             // Allow passwords with spaces
-            let pass = args.join('');
+            let pass = args.join(' ');
             let explanation = `When you next reconnect to ${domain}, this password ` +
                 `will be automatically sent in a PASS command which most ` +
                 `IRC networks will use as your NickServ password. This ` +


### PR DESCRIPTION
There's a comment at `!storepass` about allowing spaces in passwords, but the password doesn't actually get joined with spaces.
~~This might solve #442.~~