### PR TITLE
Don't escape the user_ids incoming from matrix

### DIFF
--- a/lib/DataStore.js
+++ b/lib/DataStore.js
@@ -528,7 +528,7 @@ DataStore.prototype.getIrcClientConfig = function(userId, domain) {
 DataStore.prototype.storeIrcClientConfig = function(config) {
     return this._userStore.getMatrixUser(config.getUserId()).then((user) => {
         if (!user) {
-            user = new MatrixUser(config.getUserId());
+            user = new MatrixUser(config.getUserId(), undefined, false);
         }
         var userConfig = user.get("client_config") || {};
         if (config.getPassword()) {
@@ -560,7 +560,7 @@ DataStore.prototype.getUserFeatures = function(userId) {
 DataStore.prototype.storeUserFeatures = function(userId, features) {
     return this._userStore.getMatrixUser(userId).then((matrixUser) => {
         if (!matrixUser) {
-            matrixUser = new MatrixUser(userId);
+            matrixUser = new MatrixUser(userId, undefined, false);
         }
         matrixUser.set("features", features);
         return this._userStore.setMatrixUser(matrixUser);

--- a/lib/bridge/IrcBridge.js
+++ b/lib/bridge/IrcBridge.js
@@ -100,6 +100,7 @@ function IrcBridge(config, registration) {
                 enablePresence: this.config.homeserver.enablePresence,
             }
         },
+        escapeUserIds: false,
         roomLinkValidation,
         roomUpgradeOpts: {
             consumeEvent: true,

--- a/lib/bridge/IrcBridge.js
+++ b/lib/bridge/IrcBridge.js
@@ -617,8 +617,8 @@ IrcBridge.prototype._onEvent = Promise.coroutine(function*(baseRequest, context)
             return BridgeRequest.ERR_NOT_MAPPED;
         }
         this.ircHandler.onMatrixMemberEvent(event);
-        var target = new MatrixUser(event.state_key);
-        var sender = new MatrixUser(event.user_id);
+        var target = new MatrixUser(event.state_key, undefined, false);
+        var sender = new MatrixUser(event.user_id, undefined, false);
         if (event.content.membership === "invite") {
             yield this.matrixHandler.onInvite(request, event, sender, target);
         }
@@ -938,7 +938,7 @@ IrcBridge.prototype.getBridgedClient = Promise.coroutine(function*(server, userI
         return bridgedClient;
     }
 
-    let mxUser = new MatrixUser(userId);
+    let mxUser = new MatrixUser(userId, undefined, false);
     mxUser.setDisplayName(displayName);
 
     // check the database for stored config information for this irc client

--- a/lib/bridge/MatrixHandler.js
+++ b/lib/bridge/MatrixHandler.js
@@ -183,7 +183,7 @@ MatrixHandler.prototype._handleInviteFromUser = Promise.coroutine(function*(req,
 MatrixHandler.prototype._onAdminMessage = Promise.coroutine(function*(req, event, adminRoom) {
     req.log.info("Received admin message from %s", event.user_id);
 
-    let botUser = new MatrixUser(this.ircBridge.getAppServiceUserId());
+    let botUser = new MatrixUser(this.ircBridge.getAppServiceUserId(), undefined, false);
 
     // If an admin room has more than 2 people in it, kick the bot out
     let members = [];

--- a/lib/provisioning/Provisioner.js
+++ b/lib/provisioning/Provisioner.js
@@ -793,7 +793,7 @@ Provisioner.prototype._doLink = Promise.coroutine(
             var bridgeReq = new BridgeRequest(
                 this._ircBridge._bridge.getRequestFactory().newRequest(), false
             );
-            var target = new MatrixUser(userId);
+            var target = new MatrixUser(userId, undefined, false);
             // inject a fake join event which will do M->I connections and
             // therefore sync the member list
             yield this._ircBridge.matrixHandler.onJoin(bridgeReq, {


### PR DESCRIPTION
Fixes #744

This is a problem because the bridge recently started escaping users (https://github.com/matrix-org/matrix-appservice-bridge/pull/84) which meant that the bridge was escaping genuine userids from Matrix. 