### PR TITLE
Powerlevel handling refactor

### DIFF
--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -107,6 +107,7 @@ ircService:
       # been given multiple modes, the one that maps to the highest power level will be used.
       modePowerMap:
         o: 50
+        v: 1
 
       botConfig:
         # Enable the presence of the bot in IRC channels. The bot serves as the entity

--- a/lib/bridge/IrcBridge.js
+++ b/lib/bridge/IrcBridge.js
@@ -607,14 +607,14 @@ IrcBridge.prototype.onEvent = function(request, context) {
 };
 
 IrcBridge.prototype._onEvent = Promise.coroutine(function*(baseRequest, context) {
-    var event = baseRequest.getData();
+    const event = baseRequest.getData();
     if (event.sender && this.activityTracker) {
         this.activityTracker.bumpLastActiveTime(event.sender);
     }
-    var request = new BridgeRequest(baseRequest, false);
+    const request = new BridgeRequest(baseRequest, false);
     if (event.type === "m.room.message") {
         if (event.origin_server_ts && this.config.homeserver.dropMatrixMessagesAfterSecs) {
-            let now = Date.now();
+            const now = Date.now();
             if ((now - event.origin_server_ts) >
                     (1000 * this.config.homeserver.dropMatrixMessagesAfterSecs)) {
                 log.info(
@@ -634,8 +634,8 @@ IrcBridge.prototype._onEvent = Promise.coroutine(function*(baseRequest, context)
             return BridgeRequest.ERR_NOT_MAPPED;
         }
         this.ircHandler.onMatrixMemberEvent(event);
-        var target = new MatrixUser(event.state_key);
-        var sender = new MatrixUser(event.user_id);
+        const target = new MatrixUser(event.state_key);
+        const sender = new MatrixUser(event.user_id);
         if (event.content.membership === "invite") {
             yield this.matrixHandler.onInvite(request, event, sender, target);
         }
@@ -655,7 +655,7 @@ IrcBridge.prototype._onEvent = Promise.coroutine(function*(baseRequest, context)
             }
         }
     }
-    else if (event.type === "m.room.power_levels") {
+    else if (event.type === "m.room.power_levels" && event.state_key === "") {
         this.ircHandler.powerlevelSyncer.onMatrixPowerlevelEvent(event);
     }
     return undefined;

--- a/lib/bridge/IrcBridge.js
+++ b/lib/bridge/IrcBridge.js
@@ -655,6 +655,9 @@ IrcBridge.prototype._onEvent = Promise.coroutine(function*(baseRequest, context)
             }
         }
     }
+    else if (event.type === "m.room.power_levels") {
+        this.ircHandler.powerlevelSyncer.onMatrixPowerlevelEvent(event);
+    }
     return undefined;
 });
 

--- a/lib/bridge/IrcBridge.js
+++ b/lib/bridge/IrcBridge.js
@@ -656,7 +656,7 @@ IrcBridge.prototype._onEvent = Promise.coroutine(function*(baseRequest, context)
         }
     }
     else if (event.type === "m.room.power_levels" && event.state_key === "") {
-        this.ircHandler.powerlevelSyncer.onMatrixPowerlevelEvent(event);
+        this.ircHandler.roomAccessSyncer.onMatrixPowerlevelEvent(event);
     }
     return undefined;
 });

--- a/lib/bridge/IrcHandler.js
+++ b/lib/bridge/IrcHandler.js
@@ -65,6 +65,7 @@ function IrcHandler(ircBridge, config) {
     //    kickReason: string,
     //    retry: boolean,
     //    req: Request,
+    //    deop: boolean,
     //}
     this._leaveQueue = new QueuePool(
         config.leaveConcurrency || LEAVE_CONCURRENCY,
@@ -746,6 +747,7 @@ IrcHandler.prototype.onKick = Promise.coroutine(function*(req, server,
             shouldKick: false,
             retry: true,
             req,
+            deop: true, // deop real irc users, likereal irc.
         });
     }
 });
@@ -820,6 +822,7 @@ IrcHandler.prototype.onPart = Promise.coroutine(function*(req, server, leavingUs
         req,
         kickReason: "Client PARTed from channel", // this will only be used if shouldKick is true
         retry: true, // We must retry these so that membership isn't leaked.
+        deop: !leavingUser.isVirtual, // deop real irc users, likereal irc.
     });
     stats.membership(true, "part");
     yield promise;
@@ -940,6 +943,15 @@ IrcHandler.prototype._handleLeaveQueue = async function(item) {
             }
             else {
                 await bridge.getIntent(item.userId).leave(roomId);
+            }
+            if (item.deop) {
+                try {
+                    await this.powerlevelSyncer.removePowerLevels(roomId, [item.userId]);
+                }
+                catch (ex) {
+                    // This is non-critical but annoying.
+                    item.req.log.warn("Failed to remove power levels for leaving user.");
+                }
             }
         }
         catch (ex) {

--- a/lib/bridge/IrcHandler.js
+++ b/lib/bridge/IrcHandler.js
@@ -825,6 +825,14 @@ IrcHandler.prototype.onPart = Promise.coroutine(function*(req, server, leavingUs
     yield promise;
 });
 
+/**
+ * Called when a user sets a mode in a channel.
+ * @param {Request} req The metadata request
+ * @param {IrcServer} server : The sending IRC server.
+ * @param {string} channel The channel that has the given mode.
+ * @param {string} mode The mode that the channel is in, e.g. +sabcdef
+ * @return {Promise} which is resolved/rejected when the request finishes.
+ */
 IrcHandler.prototype.onMode = Promise.coroutine(function*(req, server, channel, by,
                                                 mode, enabled, arg) {
     this.incrementMetric("mode");
@@ -834,31 +842,6 @@ IrcHandler.prototype.onMode = Promise.coroutine(function*(req, server, channel, 
         channel, by, arg
     );
     yield this.powerlevelSyncer.onMode(req, server, channel, by, mode, enabled, arg);
-});
-
-IrcHandler.prototype._onModeratedChannelToggle = Promise.coroutine(function*(req, server, channel,
-                                                by, enabled, arg) {
-    let matrixRooms = yield this.ircBridge.getStore().getMatrixRoomsForChannel(server, channel);
-    // modify power levels for all mapped rooms to set events_default to something >0 so by default
-    // people CANNOT speak into it (unless they are a mod or have voice, both of which need to be
-    // configured correctly in the config file).
-    const botClient = this.ircBridge.getAppServiceBridge().getIntent().getClient();
-    for (let i = 0; i < matrixRooms.length; i++) {
-        const roomId = matrixRooms[i].getId();
-        try {
-            const plContent = yield botClient.getStateEvent(roomId, "m.room.power_levels", "");
-            plContent.events_default = enabled ? 1 : 0;
-            yield botClient.sendStateEvent(roomId, "m.room.power_levels", plContent, "");
-            req.log.info(
-                "onModeratedChannelToggle: (channel=%s,enabled=%s) power levels updated in room %s",
-                channel, enabled, roomId
-            );
-            this.ircBridge.getStore().setModeForRoom(roomId, "m", enabled);
-        }
-        catch (err) {
-            req.log.error("Failed to alter power level in room %s : %s", roomId, err);
-        }
-    }
 });
 
 /**

--- a/lib/bridge/IrcHandler.js
+++ b/lib/bridge/IrcHandler.js
@@ -10,7 +10,7 @@ const MatrixAction = require("../models/MatrixAction");
 const Queue = require("../util/Queue.js");
 const QueuePool = require("../util/QueuePool.js");
 const QuitDebouncer = require("./QuitDebouncer.js");
-const PowerlevelSyncer = require("./PowerlevelSyncer.js");
+const RoomAccessSyncer = require("./RoomAccessSyncer.js");
 
 const JOIN_DELAY_MS = 250;
 const JOIN_DELAY_CAP_MS = 30 * 60 * 1000; // 30 mins
@@ -80,7 +80,7 @@ function IrcHandler(ircBridge, config) {
     */
     this._mentionMode = config.mapIrcMentionsToMatrix || "on";
 
-    this.powerlevelSyncer = new PowerlevelSyncer(ircBridge);
+    this.roomAccessSyncer = new RoomAccessSyncer(ircBridge);
 
     this.getMetrics();
 }
@@ -844,7 +844,7 @@ IrcHandler.prototype.onMode = Promise.coroutine(function*(req, server, channel, 
         (enabled ? ("+" + mode) : ("-" + mode)),
         channel, by, arg
     );
-    yield this.powerlevelSyncer.onMode(req, server, channel, by, mode, enabled, arg);
+    yield this.roomAccessSyncer.onMode(req, server, channel, by, mode, enabled, arg);
 });
 
 /**
@@ -857,7 +857,7 @@ IrcHandler.prototype.onMode = Promise.coroutine(function*(req, server, channel, 
  */
 IrcHandler.prototype.onModeIs = Promise.coroutine(function*(req, server, channel, mode) {
     req.log.info(`onModeIs for ${channel} = ${mode}.`);
-    yield this.powerlevelSyncer.onModeIs(req, server, channel, mode);
+    yield this.roomAccessSyncer.onModeIs(req, server, channel, mode);
 });
 
 /**
@@ -946,7 +946,7 @@ IrcHandler.prototype._handleLeaveQueue = async function(item) {
             }
             if (item.deop) {
                 try {
-                    await this.powerlevelSyncer.removePowerLevels(roomId, [item.userId]);
+                    await this.roomAccessSyncer.removePowerLevels(roomId, [item.userId]);
                 }
                 catch (ex) {
                     // This is non-critical but annoying.

--- a/lib/bridge/IrcHandler.js
+++ b/lib/bridge/IrcHandler.js
@@ -1,27 +1,20 @@
 /*eslint no-invalid-this: 0 consistent-return: 0*/
-"use strict";
-const Promise = require("bluebird");
 
+const Promise = require("bluebird");
 const stats = require("../config/stats");
 const BridgeRequest = require("../models/BridgeRequest");
 const IrcRoom = require("../models/IrcRoom");
 const MatrixRoom = require("matrix-appservice-bridge").MatrixRoom;
 const MatrixUser = require("matrix-appservice-bridge").MatrixUser;
 const MatrixAction = require("../models/MatrixAction");
-
 const Queue = require("../util/Queue.js");
 const QueuePool = require("../util/QueuePool.js");
-
 const QuitDebouncer = require("./QuitDebouncer.js");
+const PowerlevelSyncer = require("./PowerlevelSyncer.js");
 
 const JOIN_DELAY_MS = 250;
 const JOIN_DELAY_CAP_MS = 30 * 60 * 1000; // 30 mins
-const MODES_TO_WATCH = [
-    "m", // We want to ensure we do not miss rooms that get unmoderated.
-    "k",
-    "i",
-    "s"
-];
+
 
 const NICK_USERID_CACHE_MAX = 512;
 const LEAVE_CONCURRENCY = 10;
@@ -85,6 +78,8 @@ function IrcHandler(ircBridge, config) {
     "force-off" - Disabled, cannot be enabled.
     */
     this._mentionMode = config.mapIrcMentionsToMatrix || "on";
+
+    this.powerlevelSyncer = new PowerlevelSyncer(ircBridge);
 
     this.getMetrics();
 }
@@ -838,89 +833,7 @@ IrcHandler.prototype.onMode = Promise.coroutine(function*(req, server, channel, 
         (enabled ? ("+" + mode) : ("-" + mode)),
         channel, by, arg
     );
-
-    const privateModes = ["k", "i", "s"];
-    if (privateModes.indexOf(mode) !== -1) {
-        yield this._onPrivateMode(req, server, channel, by, mode, enabled, arg);
-        return;
-    }
-
-    if (mode === "m") {
-        yield this._onModeratedChannelToggle(req, server, channel, by, enabled, arg);
-        return;
-    }
-
-    // Bridge usermodes to power levels
-    let modeToPower = server.getModePowerMap();
-    if (Object.keys(modeToPower).indexOf(mode) === -1) {
-        // Not an operator power mode
-        return;
-    }
-
-    const nick = arg;
-    const matrixRooms = yield this.ircBridge.getStore().getMatrixRoomsForChannel(server, channel);
-    if (matrixRooms.length === 0) {
-        req.log.info("No mapped matrix rooms for IRC channel %s", channel);
-        return;
-    }
-
-    // Work out what power levels to give
-    const userPowers = [];
-    if (modeToPower[mode] && enabled) { // only give this power if it's +, not -
-        userPowers.push(modeToPower[mode]);
-    }
-
-    // Try to also add in other modes for this client connection
-    const bridgedClient = this.ircBridge.getClientPool().getBridgedClientByNick(
-        server, nick
-    );
-    let userId = null;
-    if (bridgedClient) {
-        userId = bridgedClient.userId;
-        if (!bridgedClient.unsafeClient) {
-            req.log.info(`Bridged client for ${nick} has no IRC client.`);
-            return;
-        }
-        const chanData = bridgedClient.unsafeClient.chanData(channel);
-        if (!(chanData && chanData.users)) {
-            req.log.error(`No channel data for ${channel}`);
-            return;
-        }
-        const userPrefixes = chanData.users[nick];
-
-        userPrefixes.split('').forEach(
-            prefix => {
-                const m = bridgedClient.unsafeClient.modeForPrefix[prefix];
-                if (modeToPower[m] !== undefined) {
-                    userPowers.push(modeToPower[m]);
-                }
-            }
-        );
-    }
-    else {
-        // real IRC user, work out their user ID
-        userId = server.getUserIdFromNick(nick);
-    }
-
-    // By default, unset the user's power level. This will be treated
-    // as the users_default defined in the power levels (or 0 otherwise).
-    let level = undefined;
-    // Sort the userPowers for this user in descending order
-    // and grab the highest value at the start of the array.
-    if (userPowers.length > 0) {
-        level = userPowers.sort((a, b) => b - a)[0];
-    }
-
-    req.log.info(
-        `onMode: Mode ${mode} received for ${nick} - granting level of ${level} to ${userId}`
-    );
-
-    const promises = matrixRooms.map((room) => {
-        return this.ircBridge.getAppServiceBridge().getIntent()
-            .setPowerLevel(room.getId(), userId, level);
-    });
-
-    yield Promise.all(promises);
+    yield this.powerlevelSyncer.onMode(req, server, channel, by, mode, enabled, arg);
 });
 
 IrcHandler.prototype._onModeratedChannelToggle = Promise.coroutine(function*(req, server, channel,
@@ -948,72 +861,6 @@ IrcHandler.prototype._onModeratedChannelToggle = Promise.coroutine(function*(req
     }
 });
 
-IrcHandler.prototype._onPrivateMode = Promise.coroutine(function*(req, server, channel, by,
-                                                mode, enabled, arg) {
-    // 'k' = Channel requires 'keyword' to join.
-    // 'i' = Channel is invite-only.
-    // 's' = Channel is secret
-
-    // For k and i, we currently want to flip the join_rules to be
-    // 'invite' to prevent new people who are not in the room from
-    // joining.
-
-    // For s, we just want to control the room directory visibility
-    // accordingly. (+s = 'private', -s = 'public')
-
-    // TODO: Add support for specifying the correct 'keyword' and
-    // support for sending INVITEs for virtual IRC users.
-    let matrixRooms = yield this.ircBridge.getStore().getMatrixRoomsForChannel(server, channel);
-    if (matrixRooms.length === 0) {
-        req.log.info("No mapped matrix rooms for IRC channel %s", channel);
-        return;
-    }
-
-    if (mode === "s") {
-        if (!server.shouldPublishRooms()) {
-            req.log.info("Not syncing publicity: shouldPublishRooms is false");
-            return Promise.resolve();
-        }
-        const key = this.ircBridge.publicitySyncer.getIRCVisMapKey(server.getNetworkId(), channel);
-
-        matrixRooms.map((room) => {
-            this.ircBridge.getStore().setModeForRoom(room.getId(), "s", enabled);
-        });
-        // Update the visibility for all rooms connected to this channel
-        return this.ircBridge.publicitySyncer.updateVisibilityMap(
-            true, key, enabled
-        );
-    }
-    // "k" and "i"
-    matrixRooms.map((room) => {
-        this.ircBridge.getStore().setModeForRoom(room.getId(), mode, enabled);
-    });
-
-    var promises = matrixRooms.map((room) => {
-        switch (mode) {
-            case "k":
-            case "i":
-                req.log.info((enabled ? "Locking room %s" :
-                    "Reverting %s back to default join_rule"),
-                    room.getId()
-                );
-                if (enabled) {
-                    return this._setMatrixRoomAsInviteOnly(room, true);
-                }
-                // don't "unlock"; the room may have been invite
-                // only from the beginning.
-                enabled = server.getJoinRule() === "invite";
-                return this._setMatrixRoomAsInviteOnly(room, enabled);
-            default:
-                // Not reachable, but warn anyway in case of future additions
-                req.log.warn(`onMode: Unhandled channel mode ${mode}`);
-                return Promise.resolve();
-        }
-    });
-
-    yield Promise.all(promises);
-});
-
 /**
  * Called when channel mode information is received
  * @param {Request} req The metadata request
@@ -1024,38 +871,7 @@ IrcHandler.prototype._onPrivateMode = Promise.coroutine(function*(req, server, c
  */
 IrcHandler.prototype.onModeIs = Promise.coroutine(function*(req, server, channel, mode) {
     req.log.info(`onModeIs for ${channel} = ${mode}.`);
-
-    // Delegate to this.onMode
-    let promises = mode.split('').map(
-        (modeChar) => {
-            if (modeChar === '+') {
-                return Promise.resolve();
-            }
-            return this.onMode(req, server, channel, 'onModeIs function', modeChar, true);
-        }
-    );
-
-    // We cache modes per room, so extract the set of modes for all these rooms.
-    const roomModeMap = yield this.ircBridge.getStore().getModesForChannel(server, channel);
-    const oldModes = new Set();
-    Object.values(roomModeMap).forEach((roomMode) => {
-        roomMode.forEach((m) => {oldModes.add(m)});
-    });
-    req.log.debug(`Got cached mode for ${channel} ${[...oldModes]}`);
-
-    // For each cached mode we have for the room, that is no longer set: emit a disabled mode.
-    promises.concat([...oldModes].map((oldModeChar) => {
-        if (!MODES_TO_WATCH.includes(oldModeChar)) {
-            return Promise.resolve();
-        }
-        req.log.debug(`${server.domain} ${channel}: Checking if '${oldModeChar}' is still set.`);
-        if (!mode.includes(oldModeChar)) { // If the mode is no longer here.
-            req.log.debug(`${oldModeChar} has been unset, disabling.`);
-            return this.onMode(req, server, channel, 'onModeIs function', oldModeChar, false);
-        }
-    }));
-
-    yield Promise.all(promises);
+    yield this.powerlevelSyncer.onModeIs(req, server, channel, mode);
 });
 
 /**
@@ -1105,13 +921,6 @@ IrcHandler.prototype.onMetadata = Promise.coroutine(function*(req, client, msg, 
     yield this.ircBridge.sendMatrixAction(adminRoom, botUser, notice, req);
 });
 
-IrcHandler.prototype._setMatrixRoomAsInviteOnly = function(room, isInviteOnly) {
-    return this.ircBridge.getAppServiceBridge().getClientFactory().getClientAs().sendStateEvent(
-        room.getId(), "m.room.join_rules", {
-            join_rule: (isInviteOnly ? "invite" : "public")
-        }, ""
-    );
-};
 
 IrcHandler.prototype.invalidateCachingForUserId = function(userId) {
     if (this._mentionMode === "force-off") {

--- a/lib/bridge/MemberListSyncer.js
+++ b/lib/bridge/MemberListSyncer.js
@@ -362,6 +362,8 @@ MemberListSyncer.prototype._leaveUsersInRoom = Promise.coroutine(function*(item)
         q.enqueue(userId, userId)
     ));
 
+    // Make sure to deop any users
+    yield this.ircBridge.ircHandler.powerlevelSyncer.removePowerLevels(item.roomId, item.userIds);
 });
 
 // Update the MemberListSyncer with the IRC NAMES_RPL that has been received for channel.

--- a/lib/bridge/MemberListSyncer.js
+++ b/lib/bridge/MemberListSyncer.js
@@ -363,7 +363,7 @@ MemberListSyncer.prototype._leaveUsersInRoom = Promise.coroutine(function*(item)
     ));
 
     // Make sure to deop any users
-    yield this.ircBridge.ircHandler.powerlevelSyncer.removePowerLevels(item.roomId, item.userIds);
+    yield this.ircBridge.ircHandler.roomAccessSyncer.removePowerLevels(item.roomId, item.userIds);
 });
 
 // Update the MemberListSyncer with the IRC NAMES_RPL that has been received for channel.

--- a/lib/bridge/MemberListSyncer.js
+++ b/lib/bridge/MemberListSyncer.js
@@ -351,16 +351,17 @@ MemberListSyncer.prototype._leaveUsersInRoom = Promise.coroutine(function*(item)
     // We need to queue these up in ANOTHER queue so as not to have
     // 2 in-flight requests at the same time. We return a promise which resolves
     // when this room is completely done.
-    let self = this;
-    let q = new Queue(Promise.coroutine(function*(userId) {
+    const q = new Queue(async (userId) => {
          // Do this here, we might not manage to leave but we won't retry.
-        self._usersToLeave--;
-        yield self.ircBridge.getAppServiceBridge().getIntent(userId).leave(item.roomId);
+        this._usersToLeave--;
+        await this.ircBridge.getAppServiceBridge().getIntent(userId).leave(item.roomId);
         stats.membership(true, "part");
-    }));
-    yield Promise.all(item.userIds.map((userId) => {
-        return q.enqueue(userId, userId);
-    }));
+    });
+
+    yield Promise.all(item.userIds.map((userId) =>
+        q.enqueue(userId, userId)
+    ));
+
 });
 
 // Update the MemberListSyncer with the IRC NAMES_RPL that has been received for channel.
@@ -403,9 +404,10 @@ MemberListSyncer.prototype.updateIrcMemberList = Promise.coroutine(function*(cha
             )) {
                 return;
         }
+
         let usersToLeave = this._memberLists.matrix[roomId].remoteJoinedUsers.filter(
             (userId) => {
-                return ircUserIds.indexOf(userId) === -1;
+                return !ircUserIds.includes(userId);
             }
         );
 

--- a/lib/bridge/PowerlevelSyncer.js
+++ b/lib/bridge/PowerlevelSyncer.js
@@ -155,7 +155,36 @@ class PowerlevelSyncer {
         await Promise.all(promises);
     }
 
-    async _onPrivateMode(req, server, channel, by, mode, enabled, arg) {
+    /**
+     * Bulk remove a set of users permissions from a room. If users is empty
+     * or no changes were made, this will no-op.
+     * @param {string} roomId A roomId
+     * @param {string[]} users A set of userIds
+     */
+    async removePowerLevels(roomId, users) {
+        if (users.length === 0) {
+            return;
+        }
+        log.info(`Removing power levels for ${users.length} user(s) from ${roomId}`);
+        const plContent = await this._getCurrentPowerlevels(roomId);
+        if (!plContent) {
+            log.warn("Could not remove power levels for", roomId, ". Could not fetch power levels.");
+            return;
+        }
+        let modified = 0;
+        for (const userId of users) {
+            if (plContent.users[userId] !== undefined) {
+                delete plContent.users[userId];
+                modified++;
+            }
+        }
+        if (modified === 0) {
+            // We didn't actually change anything, so don't send anything.
+            return;
+        }
+        const botClient = this._ircBridge.getAppServiceBridge().getIntent().getClient();
+        await botClient.sendStateEvent(roomId, "m.room.power_levels", plContent, "");
+    }
         // 'k' = Channel requires 'keyword' to join.
         // 'i' = Channel is invite-only.
         // 's' = Channel is secret

--- a/lib/bridge/PowerlevelSyncer.js
+++ b/lib/bridge/PowerlevelSyncer.js
@@ -160,12 +160,14 @@ class PowerlevelSyncer {
         for (const room of matrixRooms) {
             const powerLevelMap = await (this._getCurrentPowerlevels(room.getId())) || {};
             const users = powerLevelMap.users || {};
-            // If the user's present PL is equal to the level, or is 0|undefined and the mode is disabled.
+            // If the user's present PL is equal to the level,
+            // or is 0|undefined and the mode is disabled.
             if ((users[userId] === level && enabled) || !enabled && !users[userId]) {
                 req.log.debug("Not granting PLs, user already has correct PL");
                 continue;
             }
-            // If we have a PL for the user, and the PL is higher than the level we want to give the user.
+            // If we have a PL for the user, and the PL is higher than
+            // the level we want to give the user.
             if (users[userId] !== undefined && users[userId] > level) {
                 req.log.debug("Not granting PLs, user has a higher existing PL");
                 continue;

--- a/lib/bridge/PowerlevelSyncer.js
+++ b/lib/bridge/PowerlevelSyncer.js
@@ -23,23 +23,63 @@ class PowerlevelSyncer {
 
     constructor(ircBridge) {
         this._ircBridge = ircBridge;
+        // Warning: This cache is currently unbounded.
         this._powerLevelsForRoom = {
             // roomId:PowerLevelObject
         };
     }
 
+    /**
+     * Called when a m.room.power_levels is forwarded to the bridge. This should
+     * happen when a Matrix user or the bridge changes the power levels for a room.
+     * @param {MatrixEvent} event The matrix event.
+     */
     onMatrixPowerlevelEvent(event) {
         this._powerLevelsForRoom[event.room_id] = event.content;
     }
 
+    /**
+     * Useful function to determine current power levels. Will either use
+     * cached value or fetch from the homeserver.
+     * @param {string} roomId The room to fetch the state from.
+     */
+    async _getCurrentPowerlevels(roomId) {
+        if (typeof(roomId) !== "string") {
+            throw Error("RoomId must be a string");
+        }
+        if (this._powerLevelsForRoom[roomId]) {
+            return this._powerLevelsForRoom[roomId];
+        }
+        const intent = this._ircBridge.getAppServiceBridge().getIntent();
+        try {
+            const state = await intent.getStateEvent(roomId, "m.room.power_levels");
+            this._powerLevelsForRoom[roomId] = state;
+            return state;
+        }
+        catch (ex) {
+            log.warn("Failed to get power levels for ", roomId);
+            return null;
+        }
+    }
+
+    /**
+     * Called when an IRC user sets a mode on another user or channel.
+     * @param {BridgeReqeust} req The request tracking the operation.
+     * @param {IrcServer} server The server the channel and users are part of
+     * @param {string} channel Which channel was the mode set in.
+     * @param {string} by Which user set the mode
+     * @param {string} mode The mode string
+     * @param {boolean} enabled Whether the mode was enabled or disabled.
+     * @param {string|null} arg This is usually the affected user, if applicable.
+     */
     async onMode(req, server, channel, by, mode, enabled, arg) {
         if (PRIVATE_MODES.includes(mode)) {
-            await this._onPrivateMode(req, server, channel, by, mode, enabled, arg);
+            await this._onPrivateMode(req, server, channel, mode, enabled);
             return;
         }
 
         if (mode === "m") {
-            await this._onModeratedChannelToggle(req, server, channel, by, enabled, arg);
+            await this._onModeratedChannelToggle(req, server, channel, enabled);
             return;
         }
 
@@ -97,9 +137,14 @@ class PowerlevelSyncer {
             userId = server.getUserIdFromNick(nick);
         }
 
+        if (userId === null) {
+            // Probably the BridgeBot or a user we don't know about, drop it.
+            return;
+        }
+
         // By default, unset the user's power level. This will be treated
         // as the users_default defined in the power levels (or 0 otherwise).
-        let level = undefined;
+        let level;
         // Sort the userPowers for this user in descending order
         // and grab the highest value at the start of the array.
         if (userPowers.length > 0) {
@@ -109,15 +154,31 @@ class PowerlevelSyncer {
         req.log.info(
             `onMode: Mode ${mode} received for ${nick} - granting level of ${level} to ${userId}`
         );
+        const intent = this._ircBridge.getAppServiceBridge().getIntent();
 
-        const promises = matrixRooms.map((room) => {
-            return this._ircBridge.getAppServiceBridge().getIntent()
-                .setPowerLevel(room.getId(), userId, level);
-        });
+        for (const room of matrixRooms) {
+            const powerLevelMap = await (this._getCurrentPowerlevels(room.getId())) || {};
+            const users = powerLevelMap.users || {};
+            if (users[userId] === level) {
+                req.log.debug("Not granting PLs, user already has correct PL");
+                continue;
+            }
+            try {
+                await intent.setPowerLevel(room.getId(), userId, level);
+            }
+            catch (ex) {
+                req.log.warn(`Failed to apply PL${level} to ${userId}`, ex);
+            }
+        }
 
-        await Promise.all(promises);
     }
-
+    /**
+     * Called when an IRC server responds to a mode request.
+     * @param {BridgeReqeust} req The request tracking the operation.
+     * @param {IrcServer} server The server the channel and users are part of
+     * @param {string} channel Which channel was the mode(s) set in.
+     * @param {string} mode The mode string, which may contain many modes.
+     */
     async onModeIs(req, server, channel, mode) {
         // Delegate to this.onMode
         let promises = mode.split('').map(
@@ -185,6 +246,17 @@ class PowerlevelSyncer {
         const botClient = this._ircBridge.getAppServiceBridge().getIntent().getClient();
         await botClient.sendStateEvent(roomId, "m.room.power_levels", plContent, "");
     }
+
+    /**
+     * If a mode given in PRIVATE_MODES is found, change a room's join rules
+     * to match.
+     * @param {BridgeReqeust} req The request tracking the operation.
+     * @param {IrcServer} server The server the channel and users are part of
+     * @param {string} channel Which channel was the mode(s) set in.
+     * @param {string} mode The mode string.
+     * @param {boolean} enabled Was the mode enabled or disabled.
+     */
+    async _onPrivateMode(req, server, channel, mode, enabled) {
         // 'k' = Channel requires 'keyword' to join.
         // 'i' = Channel is invite-only.
         // 's' = Channel is secret
@@ -198,7 +270,9 @@ class PowerlevelSyncer {
 
         // TODO: Add support for specifying the correct 'keyword' and
         // support for sending INVITEs for virtual IRC users.
-        let matrixRooms = await this._ircBridge.getStore().getMatrixRoomsForChannel(server, channel);
+        let matrixRooms = await this._ircBridge.getStore().getMatrixRoomsForChannel(
+            server, channel
+        );
         if (matrixRooms.length === 0) {
             req.log.info("No mapped matrix rooms for IRC channel %s", channel);
             return;
@@ -209,7 +283,9 @@ class PowerlevelSyncer {
                 req.log.info("Not syncing publicity: shouldPublishRooms is false");
                 return;
             }
-            const key = this._ircBridge.publicitySyncer.getIRCVisMapKey(server.getNetworkId(), channel);
+            const key = this._ircBridge.publicitySyncer.getIRCVisMapKey(
+                server.getNetworkId(), channel
+            );
 
             matrixRooms.map((room) => {
                 this._ircBridge.getStore().setModeForRoom(room.getId(), "s", enabled);
@@ -249,23 +325,37 @@ class PowerlevelSyncer {
         await Promise.all(promises);
     }
 
-    async _onModeratedChannelToggle(req, server, channel, by, enabled, arg) {
-        const matrixRooms = await this._ircBridge.getStore().getMatrixRoomsForChannel(server, channel);
-        // modify power levels for all mapped rooms to set events_default to something >0 so by default
-        // people CANNOT speak into it (unless they are a mod or have voice, both of which need to be
-        // configured correctly in the config file).
-        const botClient = this.ircBridge.getAppServiceBridge().getIntent().getClient();
-        for (let i = 0; i < matrixRooms.length; i++) {
-            const roomId = matrixRooms[i].getId();
+    /**
+     * This is called when a "m" mode is toggled in a channel. This will either
+     * enable or disable a users permission to speak unless they are voiced.
+     * @param {BridgeReqeust} req The request tracking the operation.
+     * @param {IrcServer} server The server the channel and users are part of
+     * @param {string} channel Which channel was the mode(s) set in.
+     * @param {boolean} enabled Has moderation been turned on or off.
+     */
+    async _onModeratedChannelToggle(req, server, channel, enabled) {
+        const ircStore = this._ircBridge.getStore();
+        const matrixRooms = await ircStore.getMatrixRoomsForChannel(server, channel);
+        // modify power levels for all mapped rooms to set events_default
+        // to something >0 so by default people CANNOT speak into it (unless they
+        // are a mod or have voice, both of which need to be configured correctly in
+        // the config file).
+        const botClient = this._ircBridge.getAppServiceBridge().getIntent().getClient();
+        for (const room of matrixRooms) {
+            const roomId = room.getId();
             try {
-                const plContent = await botClient.getStateEvent(roomId, "m.room.power_levels", "");
-                plContent.events_default = enabled ? 1 : 0;
+                const plContent = await this._getCurrentPowerlevels(roomId);
+                const eventsDefault = enabled ? 1 : 0;
+                if (plContent.events_default === eventsDefault) {
+                    continue;
+                }
+                plContent.events_default = eventsDefault;
                 await botClient.sendStateEvent(roomId, "m.room.power_levels", plContent, "");
                 req.log.info(
-                    "onModeratedChannelToggle: (channel=%s,enabled=%s) power levels updated in room %s",
-                    channel, enabled, roomId
+                "onModeratedChannelToggle: (channel=%s,enabled=%s) power levels updated in room %s",
+                channel, enabled, roomId
                 );
-                this.ircBridge.getStore().setModeForRoom(roomId, "m", enabled);
+                ircStore.setModeForRoom(roomId, "m", enabled);
             }
             catch (err) {
                 req.log.error("Failed to alter power level in room %s : %s", roomId, err);
@@ -280,17 +370,14 @@ class PowerlevelSyncer {
      *                               make the room public
      */
     async _setMatrixRoomAsInviteOnly(room, isInviteOnly) {
-        return this.ircBridge.getAppServiceBridge().getClientFactory().getClientAs().sendStateEvent(
+        const client = this._ircBridge.getAppServiceBridge().getClientFactory().getClientAs();
+        return client.sendStateEvent(
             room.getId(),
             "m.room.join_rules", {
                 join_rule: (isInviteOnly ? "invite" : "public")
             },
             ""
         );
-    }
-
-    computePowerlevelForUser() {
-
     }
 }
 

--- a/lib/bridge/PowerlevelSyncer.js
+++ b/lib/bridge/PowerlevelSyncer.js
@@ -1,0 +1,268 @@
+const log = require("../logging").get("PowerlevelSyncer");
+
+const MODES_TO_WATCH = [
+    "m", // This channel is "moderated" - only voiced users can speak.
+         // We want to ensure we do not miss rooms that get unmoderated.
+    "k", // keylock - needs a password
+    "i", // invite only
+    "s", // secret - don't show in channel lisitings
+];
+
+const PRIVATE_MODES = [
+    "k",
+    "i",
+    "s",
+]
+
+/**
+ * This class is supplimentary to the IrcHandler class. This
+ * class handles incoming mode changes as well as computing the new
+ * power level state.
+ */
+class PowerlevelSyncer {
+
+    constructor(ircBridge) {
+        this._ircBridge = ircBridge;
+        this._powerLevelsForRoom = {
+            // roomId:PowerLevelObject
+        };
+    }
+
+    onMatrixPowerlevelEvent(event) {
+        this._powerLevelsForRoom[event.room_id] = event.content;
+    }
+
+    async onMode(req, server, channel, by, mode, enabled, arg) {
+        if (PRIVATE_MODES.includes(mode)) {
+            await this._onPrivateMode(req, server, channel, by, mode, enabled, arg);
+            return;
+        }
+
+        if (mode === "m") {
+            await this._onModeratedChannelToggle(req, server, channel, by, enabled, arg);
+            return;
+        }
+
+        // Bridge usermodes to power levels
+        const modeToPower = server.getModePowerMap();
+        if (!Object.keys(modeToPower).includes(mode)) {
+            // Not an operator power mode
+            return;
+        }
+
+        const nick = arg;
+        const matrixRooms = await this._ircBridge.getStore().getMatrixRoomsForChannel(
+            server, channel
+        );
+        if (matrixRooms.length === 0) {
+            req.log.info("No mapped matrix rooms for IRC channel %s", channel);
+            return;
+        }
+
+        // Work out what power levels to give
+        const userPowers = [];
+        if (modeToPower[mode] && enabled) { // only give this power if it's +, not -
+            userPowers.push(modeToPower[mode]);
+        }
+
+        // Try to also add in other modes for this client connection
+        const bridgedClient = this._ircBridge.getClientPool().getBridgedClientByNick(
+            server, nick
+        );
+        let userId = null;
+        if (bridgedClient) {
+            userId = bridgedClient.userId;
+            if (!bridgedClient.unsafeClient) {
+                req.log.info(`Bridged client for ${nick} has no IRC client.`);
+                return;
+            }
+            const chanData = bridgedClient.unsafeClient.chanData(channel);
+            if (!(chanData && chanData.users)) {
+                req.log.error(`No channel data for ${channel}`);
+                return;
+            }
+            const userPrefixes = chanData.users[nick];
+
+            userPrefixes.split('').forEach(
+                prefix => {
+                    const m = bridgedClient.unsafeClient.modeForPrefix[prefix];
+                    if (modeToPower[m] !== undefined) {
+                        userPowers.push(modeToPower[m]);
+                    }
+                }
+            );
+        }
+        else {
+            // real IRC user, work out their user ID
+            userId = server.getUserIdFromNick(nick);
+        }
+
+        // By default, unset the user's power level. This will be treated
+        // as the users_default defined in the power levels (or 0 otherwise).
+        let level = undefined;
+        // Sort the userPowers for this user in descending order
+        // and grab the highest value at the start of the array.
+        if (userPowers.length > 0) {
+            level = userPowers.sort((a, b) => b - a)[0];
+        }
+
+        req.log.info(
+            `onMode: Mode ${mode} received for ${nick} - granting level of ${level} to ${userId}`
+        );
+
+        const promises = matrixRooms.map((room) => {
+            return this._ircBridge.getAppServiceBridge().getIntent()
+                .setPowerLevel(room.getId(), userId, level);
+        });
+
+        await Promise.all(promises);
+    }
+
+    async onModeIs(req, server, channel, mode) {
+        // Delegate to this.onMode
+        let promises = mode.split('').map(
+            (modeChar) => {
+                if (modeChar === '+') {
+                    return Promise.resolve();
+                }
+                return this.onMode(req, server, channel, 'onModeIs function', modeChar, true);
+            }
+        );
+
+        // We cache modes per room, so extract the set of modes for all these rooms.
+        const roomModeMap = await this._ircBridge.getStore().getModesForChannel(server, channel);
+        const oldModes = new Set();
+        Object.values(roomModeMap).forEach((roomMode) => {
+            roomMode.forEach((m) => {oldModes.add(m)});
+        });
+        req.log.debug(`Got cached mode for ${channel} ${[...oldModes]}`);
+
+        // For each cached mode we have for the room, that is no longer set: emit a disabled mode.
+        promises.concat([...oldModes].map((oldModeChar) => {
+            if (!MODES_TO_WATCH.includes(oldModeChar)) {
+                return Promise.resolve();
+            }
+            req.log.debug(
+                `${server.domain} ${channel}: Checking if '${oldModeChar}' is still set.`
+            );
+            if (!mode.includes(oldModeChar)) { // If the mode is no longer here.
+                req.log.debug(`${oldModeChar} has been unset, disabling.`);
+                return this.onMode(req, server, channel, 'onModeIs function', oldModeChar, false);
+            }
+            return Promise.resolve();
+        }));
+
+        await Promise.all(promises);
+    }
+
+    async _onPrivateMode(req, server, channel, by, mode, enabled, arg) {
+        // 'k' = Channel requires 'keyword' to join.
+        // 'i' = Channel is invite-only.
+        // 's' = Channel is secret
+
+        // For k and i, we currently want to flip the join_rules to be
+        // 'invite' to prevent new people who are not in the room from
+        // joining.
+
+        // For s, we just want to control the room directory visibility
+        // accordingly. (+s = 'private', -s = 'public')
+
+        // TODO: Add support for specifying the correct 'keyword' and
+        // support for sending INVITEs for virtual IRC users.
+        let matrixRooms = await this._ircBridge.getStore().getMatrixRoomsForChannel(server, channel);
+        if (matrixRooms.length === 0) {
+            req.log.info("No mapped matrix rooms for IRC channel %s", channel);
+            return;
+        }
+
+        if (mode === "s") {
+            if (!server.shouldPublishRooms()) {
+                req.log.info("Not syncing publicity: shouldPublishRooms is false");
+                return;
+            }
+            const key = this._ircBridge.publicitySyncer.getIRCVisMapKey(server.getNetworkId(), channel);
+
+            matrixRooms.map((room) => {
+                this._ircBridge.getStore().setModeForRoom(room.getId(), "s", enabled);
+            });
+            // Update the visibility for all rooms connected to this channel
+            await this._ircBridge.publicitySyncer.updateVisibilityMap(
+                true, key, enabled
+            );
+        }
+        // "k" and "i"
+        matrixRooms.map((room) => {
+            this._ircBridge.getStore().setModeForRoom(room.getId(), mode, enabled);
+        });
+
+        const promises = matrixRooms.map((room) => {
+            switch (mode) {
+                case "k":
+                case "i":
+                    req.log.info((enabled ? "Locking room %s" :
+                        "Reverting %s back to default join_rule"),
+                        room.getId()
+                    );
+                    if (enabled) {
+                        return this._setMatrixRoomAsInviteOnly(room, true);
+                    }
+                    // don't "unlock"; the room may have been invite
+                    // only from the beginning.
+                    enabled = server.getJoinRule() === "invite";
+                    return this._setMatrixRoomAsInviteOnly(room, enabled);
+                default:
+                    // Not reachable, but warn anyway in case of future additions
+                    req.log.warn(`onMode: Unhandled channel mode ${mode}`);
+                    return Promise.resolve();
+            }
+        });
+
+        await Promise.all(promises);
+    }
+
+    async _onModeratedChannelToggle(req, server, channel, by, enabled, arg) {
+        const matrixRooms = await this._ircBridge.getStore().getMatrixRoomsForChannel(server, channel);
+        // modify power levels for all mapped rooms to set events_default to something >0 so by default
+        // people CANNOT speak into it (unless they are a mod or have voice, both of which need to be
+        // configured correctly in the config file).
+        const botClient = this.ircBridge.getAppServiceBridge().getIntent().getClient();
+        for (let i = 0; i < matrixRooms.length; i++) {
+            const roomId = matrixRooms[i].getId();
+            try {
+                const plContent = await botClient.getStateEvent(roomId, "m.room.power_levels", "");
+                plContent.events_default = enabled ? 1 : 0;
+                await botClient.sendStateEvent(roomId, "m.room.power_levels", plContent, "");
+                req.log.info(
+                    "onModeratedChannelToggle: (channel=%s,enabled=%s) power levels updated in room %s",
+                    channel, enabled, roomId
+                );
+                this.ircBridge.getStore().setModeForRoom(roomId, "m", enabled);
+            }
+            catch (err) {
+                req.log.error("Failed to alter power level in room %s : %s", roomId, err);
+            }
+        }
+    }
+
+    /**
+     * Modify the join rules of a room, setting it either to invite only or public.
+     * @param {MatrixRoom} room The room to set the join_rules for.
+     * @param {boolean} isInviteOnly Set to true to make invite only, set to false to
+     *                               make the room public
+     */
+    async _setMatrixRoomAsInviteOnly(room, isInviteOnly) {
+        return this.ircBridge.getAppServiceBridge().getClientFactory().getClientAs().sendStateEvent(
+            room.getId(),
+            "m.room.join_rules", {
+                join_rule: (isInviteOnly ? "invite" : "public")
+            },
+            ""
+        );
+    }
+
+    computePowerlevelForUser() {
+
+    }
+}
+
+module.exports = PowerlevelSyncer;

--- a/lib/bridge/PowerlevelSyncer.js
+++ b/lib/bridge/PowerlevelSyncer.js
@@ -229,7 +229,7 @@ class PowerlevelSyncer {
         log.info(`Removing power levels for ${users.length} user(s) from ${roomId}`);
         const plContent = await this._getCurrentPowerlevels(roomId);
         if (!plContent) {
-            log.warn("Could not remove power levels for", roomId, ". Could not fetch power levels.");
+            log.warn(`Could not remove power levels for ${roomId} Could not fetch power levels.`);
             return;
         }
         let modified = 0;

--- a/lib/bridge/PowerlevelSyncer.js
+++ b/lib/bridge/PowerlevelSyncer.js
@@ -101,7 +101,7 @@ class PowerlevelSyncer {
 
         // Work out what power levels to give
         const userPowers = [];
-        if (modeToPower[mode] && enabled) { // only give this power if it's +, not -
+        if (modeToPower[mode]) { // only give this power if it's +, not -
             userPowers.push(modeToPower[mode]);
         }
 
@@ -152,16 +152,30 @@ class PowerlevelSyncer {
         }
 
         req.log.info(
-            `onMode: Mode ${mode} received for ${nick} - granting level of ${level} to ${userId}`
+            `onMode: Mode ${mode} received for ${nick}, granting level of ` +
+            `${enabled ? level : 0} to ${userId}`
         );
         const intent = this._ircBridge.getAppServiceBridge().getIntent();
 
         for (const room of matrixRooms) {
             const powerLevelMap = await (this._getCurrentPowerlevels(room.getId())) || {};
             const users = powerLevelMap.users || {};
-            if (users[userId] === level) {
+            // If the user's present PL is equal to the level, or is 0|undefined and the mode is disabled.
+            if ((users[userId] === level && enabled) || !enabled && !users[userId]) {
                 req.log.debug("Not granting PLs, user already has correct PL");
                 continue;
+            }
+            // If we have a PL for the user, and the PL is higher than the level we want to give the user.
+            if (users[userId] !== undefined && users[userId] > level) {
+                req.log.debug("Not granting PLs, user has a higher existing PL");
+                continue;
+            }
+            // If we hit here, then level is higher than our current level.
+            if (!enabled) {
+                // XXX: Annoyingly we don't know if we can pop down to
+                // voiced level after being de-oped, as we aren't told the full
+                // set of modes.
+                level = 0;
             }
             try {
                 await intent.setPowerLevel(room.getId(), userId, level);
@@ -342,11 +356,13 @@ class PowerlevelSyncer {
         // the config file).
         const botClient = this._ircBridge.getAppServiceBridge().getIntent().getClient();
         for (const room of matrixRooms) {
+            req.log.info(`Checking moderated status for ${channel}`);
             const roomId = room.getId();
             try {
                 const plContent = await this._getCurrentPowerlevels(roomId);
                 const eventsDefault = enabled ? 1 : 0;
                 if (plContent.events_default === eventsDefault) {
+                    req.log.debug(`${channel} already has events_default set to ${eventsDefault}`);
                     continue;
                 }
                 plContent.events_default = eventsDefault;

--- a/lib/bridge/RoomAccessSyncer.js
+++ b/lib/bridge/RoomAccessSyncer.js
@@ -1,4 +1,4 @@
-const log = require("../logging").get("PowerlevelSyncer");
+const log = require("../logging").get("RoomAccessSyncer");
 
 const MODES_TO_WATCH = [
     "m", // This channel is "moderated" - only voiced users can speak.
@@ -19,7 +19,7 @@ const PRIVATE_MODES = [
  * class handles incoming mode changes as well as computing the new
  * power level state.
  */
-class PowerlevelSyncer {
+class RoomAccessSyncer {
 
     constructor(ircBridge) {
         this._ircBridge = ircBridge;
@@ -399,4 +399,4 @@ class PowerlevelSyncer {
     }
 }
 
-module.exports = PowerlevelSyncer;
+module.exports = RoomAccessSyncer;

--- a/spec/integ/irc-to-matrix.spec.js
+++ b/spec/integ/irc-to-matrix.spec.js
@@ -494,6 +494,9 @@ describe("IRC-to-Matrix operator modes bridging", function() {
             env.ircMock._findClientAsync(roomMapping.server, roomMapping.botNick).done(
             function(cli) {
                 cli.emit(
+                    "+mode", roomMapping.channel, "op-er", "v", tRealMatrixUserNick, "here you go"
+                );
+                cli.emit(
                     "-mode", roomMapping.channel, "op-er", "o", tRealMatrixUserNick, "here you go"
                 );
             });
@@ -528,6 +531,9 @@ describe("IRC-to-Matrix operator modes bridging", function() {
 
             env.ircMock._findClientAsync(roomMapping.server, roomMapping.botNick).done(
             function(cli) {
+                cli.emit(
+                    "+mode", roomMapping.channel, "op-er", "o", tRealMatrixUserNick, "here you go"
+                );
                 cli.emit(
                     "-mode", roomMapping.channel, "op-er", "v", tRealMatrixUserNick, "here you go"
                 );


### PR DESCRIPTION
This change refactors mode/power level handling to it's own class for convenience, as well as the hope of being able to unit test the class individually to address our most glaring power level desync issues.

This makes the following changes to behaviour:
- IRC users which are left from a room ~on startup~ (https://github.com/matrix-org/matrix-appservice-irc/pull/785/commits/6b7d23e5bf4031dd45c421c08bf870977ad49b93 makes this work for realtime leaves) have their power levels removed, in compliance with IRC standards.
- Power level events are now checked locally before they are sent to ensure a change has actually been made (to avoid needless state spam).
 