### PR TITLE
Store pending nicks and use them to filter out new joiners

### DIFF
--- a/lib/irc/ClientPool.js
+++ b/lib/irc/ClientPool.js
@@ -56,6 +56,7 @@ class ClientPool {
         if (this.getBridgedClientByNick(server, nick)) {
             return true;
         }
+        
         // The client may not have signalled to us that it's connected, but it is connect*ing*.
         const pending = Object.keys(this._virtualClients[server.domain].pending || {});
         return pending.includes(nick);
@@ -365,7 +366,9 @@ ClientPool.prototype._onClientDisconnected = function(bridgedClient) {
     this._sendConnectionMetric(bridgedClient.server);
 
     // remove the pending nick we had set for this user
-    delete this._virtualClients[bridgedClient.nick].pending[oldNick];
+    if (this._virtualClients[bridgedClient.server]) {
+        delete this._virtualClients[bridgedClient.server].pending[bridgedClient.nick];
+    }
 
     if (bridgedClient.disconnectReason === "banned") {
         const req = new BridgeRequest(this._ircBridge._bridge.getRequestFactory().newRequest());

--- a/lib/irc/ClientPool.js
+++ b/lib/irc/ClientPool.js
@@ -56,7 +56,7 @@ class ClientPool {
         if (this.getBridgedClientByNick(server, nick)) {
             return true;
         }
-        
+
         // The client may not have signalled to us that it's connected, but it is connect*ing*.
         const pending = Object.keys(this._virtualClients[server.domain].pending || {});
         return pending.includes(nick);

--- a/lib/irc/ClientPool.js
+++ b/lib/irc/ClientPool.js
@@ -10,23 +10,44 @@ const Promise = require("bluebird");
 const QueuePool = require("../util/QueuePool");
 const BridgeRequest = require("../models/BridgeRequest");
 
-function ClientPool(ircBridge) {
-    this._ircBridge = ircBridge;
-    // The list of bot clients on servers (not specific users)
-    this._botClients = {
-        // server_domain: BridgedClient
-    };
+class ClientPool {
+    constructor(ircBridge) {
+        this._ircBridge = ircBridge;
+        // The list of bot clients on servers (not specific users)
+        this._botClients = {
+            // server_domain: BridgedClient
+        };
 
-    // list of virtual users on servers
-    this._virtualClients = {
-        // server_domain: {
-        //    nicks: {
-        //      <nickname>: BridgedClient
-        //    },
-        //    userIds: {
-        //      <user_id>: BridgedClient
-        //    }
-        // }
+        // list of virtual users on servers
+        this._virtualClients = {
+            // server_domain: {
+            //    nicks: {
+            //      <nickname>: BridgedClient
+            //    },
+            //    userIds: {
+            //      <user_id>: BridgedClient
+            //    }
+            //    These users are in the process of being
+            //    connected with an *assumed* nick.
+            //    pending: {
+            //
+            //    }
+            // }
+        }
+
+        // map of numbers of connected clients on each server
+        // Counting these is quite expensive because we have to
+        // ignore entries where the value is undefined. Instead,
+        // just keep track of how many we have.
+        this._virtualClientCounts = {
+            // server_domain: number
+        };
+
+        this._reconnectQueues = {
+            // server_domain: QueuePool
+        };
+    }
+
     }
     // map of numbers of connected clients on each server
     // Counting these is quite expensive because we have to

--- a/lib/irc/ClientPool.js
+++ b/lib/irc/ClientPool.js
@@ -124,13 +124,22 @@ ClientPool.prototype.createIrcClient = function(ircClientConfig, matrixUser, isB
     if (this._virtualClients[server.domain] === undefined) {
         this._virtualClients[server.domain] = {
             nicks: Object.create(null),
-            userIds: Object.create(null)
+            userIds: Object.create(null),
+            pending: {},
         };
         this._virtualClientCounts[server.domain] = 0;
     }
     if (isBot) {
         this._botClients[server.domain] = bridgedClient;
     }
+
+    // `pending` is used to ensure that we know if a nick belongs to a userId
+    // before they have been connected. It's impossible to know for sure
+    // what nick they will be assigned before being connected, but this
+    // should catch most cases. Knowing the nick is important, because
+    // slow clients may not send a 'client-connected' signal before a join is
+    // emitted, which means ghost users may join with their nickname into matrix.
+    this._virtualClients[server.domain].pending[bridgedClient.nick] = bridgedClient.userId;
 
     // add event listeners
     bridgedClient.on("client-connected", this._onClientConnected.bind(this));
@@ -338,6 +347,9 @@ ClientPool.prototype._onClientConnected = function(bridgedClient) {
     var oldNick = bridgedClient.nick;
     var actualNick = bridgedClient.unsafeClient.nick;
 
+    // remove the pending nick we had set for this user
+    delete this._virtualClients[server.domain].pending[oldNick];
+
     // assign a nick to this client
     this._virtualClients[server.domain].nicks[actualNick] = bridgedClient;
 
@@ -351,6 +363,9 @@ ClientPool.prototype._onClientConnected = function(bridgedClient) {
 ClientPool.prototype._onClientDisconnected = function(bridgedClient) {
     this._removeBridgedClient(bridgedClient);
     this._sendConnectionMetric(bridgedClient.server);
+
+    // remove the pending nick we had set for this user
+    delete this._virtualClients[bridgedClient.nick].pending[oldNick];
 
     if (bridgedClient.disconnectReason === "banned") {
         const req = new BridgeRequest(this._ircBridge._bridge.getRequestFactory().newRequest());

--- a/lib/irc/ClientPool.js
+++ b/lib/irc/ClientPool.js
@@ -48,18 +48,18 @@ class ClientPool {
         };
     }
 
-    }
-    // map of numbers of connected clients on each server
-    // Counting these is quite expensive because we have to
-    // ignore entries where the value is undefined. Instead,
-    // just keep track of how many we have.
-    this._virtualClientCounts = {
-        // server_domain: number
-    };
+    nickIsVirtual(server, nick) {
+        if (!this._virtualClients[server.domain]) {
+            return false;
+        }
 
-    this._reconnectQueues = {
-        // server_domain: QueuePool
-    };
+        if (this.getBridgedClientByNick(server, nick)) {
+            return true;
+        }
+        // The client may not have signalled to us that it's connected, but it is connect*ing*.
+        const pending = Object.keys(this._virtualClients[server.domain].pending || {});
+        return pending.includes(nick);
+    }
 }
 
 ClientPool.prototype.killAllClients = function() {

--- a/lib/irc/IrcEventBroker.js
+++ b/lib/irc/IrcEventBroker.js
@@ -249,7 +249,7 @@ IrcEventBroker.prototype.addHooks = function(client, connInst) {
     var createUser = (nick) => {
         return new IrcUser(
             server, nick,
-            this._pool.getBridgedClientByNick(server, nick) !== undefined
+            this._pool.nickIsVirtual(server, nick)
         );
     };
 


### PR DESCRIPTION
This fixes the bug where Matrix users get replicated back into matrix with a `nick[m]` user. The problem was a race where it's possible for the account to join channels, and have the join reflected over the IRC connection before the `BridgedClient` has been stored in an object to map it against he `user_id`. The bridge would check this map when the join occurs, and wouldn't find the BridgedClient, and therefore decide the user must be a real IRC user.

This fix introduces a pending object, where we store the *expected* nickname of the user and will filter out new joins against that until the real client is stored appropriately.