### PR TITLE
Add snapcraft packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ passkey.pem
 *.tsbuildinfo
 *.map
 lib/
+
+#snap
+*.snap

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ To install all dependencies and add a binary `matrix-appservice-irc`:
 Alternatively, `git clone` this repository on the `master` branch, then run `npm install`. If
 you use this method, the bridge can be run via `node app.js`.
 
+This repository also contains snapcraft packaging information. Until the snap is published on the snapcraft store, the snap can be built by
+running `snapcraft` in the top level of this repository, and the resulting `.snap` installed with `snap install --devmode <filename>.snap`.
 
 ### Requirements
  - Node.js **v10.16.0** or above.

--- a/changelog.d/807.feature
+++ b/changelog.d/807.feature
@@ -1,0 +1,1 @@
+Added snapcraft packaging information so this package can be built as a snap

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,63 @@
+name: matrix-appservice-irc
+base: core18
+version: git
+summary: Node.js Matrix bridge for IRC
+description: |
+  A bridge between Matrix and IRC. Currently the bridge is in Beta.
+
+grade: stable
+confinement: strict
+
+apps:
+  matrix-appservice-irc:
+    command: 'bin/node $SNAP/app.js -c $SNAP_COMMON/config.yaml -f $SNAP_COMMON/registration.yaml -p 9999'
+    plugs: [network-bind, network]
+    daemon: simple
+
+parts:
+  nodejs-lts:
+    plugin: nil
+    override-build: |
+      NODE_VERSION=12.16.1
+      case $SNAPCRAFT_ARCH_TRIPLET in
+      x86_64-*)
+        NODE_ARCH="x64"
+        ;;
+      aarch64-*)
+        NODE_ARCH="arm64"
+        ;;
+      arm-linux-gnueabihf)
+        NODE_ARCH="armv7l"
+        ;;
+      powerpc64le-*)
+        NODE_ARCH="ppc64le"
+        ;;
+      s390x-*)
+        NODE_ARCH="s390x"
+        ;;
+      esac
+      echo "Fetching node $NODE_VERSION for $NODE_ARCH"
+      wget "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-$NODE_ARCH.tar.xz" -O /tmp/nodejs.tar.xz
+      tar Jxf /tmp/nodejs.tar.xz -C $SNAPCRAFT_PART_INSTALL/ --strip 1
+      rm $SNAPCRAFT_PART_INSTALL/README.md
+      rm $SNAPCRAFT_PART_INSTALL/CHANGELOG.md
+      rm $SNAPCRAFT_PART_INSTALL/LICENSE
+      snapcraftctl build
+  matrix-appservice-irc:
+    source: .
+    plugin: dump
+    build-packages:
+      - make
+      - gcc
+      - g++
+      - binutils
+      - python
+      - git
+      - libicu-dev
+    stage-packages:
+      - sipcalc
+      - iproute2
+      - openssl
+      - libicu60
+      - libatm1
+    after: [nodejs-lts]


### PR DESCRIPTION
This merge adds a wrapper, snapcraft.yaml and relevant ignores to .gitignore to be able to build this appserver as a snap.

Once/if this is merged, I would be happy to handle publishing this snap to the snap store, or ideally providing guidance on how to enable automatic snap builds from GitHub.

Signed-off-by: James Hebden <james@ec0.io>