### PR TITLE
Generic connection options for node-irc

### DIFF
--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -62,10 +62,19 @@ ircService:
       # Whether to use SSL or not. Default: false.
       ssl: true
       # Object to merge with node-irc's connectionOpts
-      # Can be used to override keys like 'ciphers'
+      # Can be used to override keys like ca and ciphers
       # valid options in https://nodejs.org/api/tls.html#tls_tls_connect_options_callback
       # and https://nodejs.org/api/tls.html#tls_tls_createsecurecontext_options
-      connectionOpts: {}
+      #connectionOpts: 
+        # A specific CA to trust instead of the default CAs. Optional.
+        #ca: |
+        #  -----BEGIN CERTIFICATE-----
+        #  ...
+        #  -----END CERTIFICATE-----
+        # If your CA cert has a weak signature digest "CA signature digest algorithm too weak"
+        # You can append @SECLEVEL=0 to nodejs' default cipherlist:
+        #ciphers: "TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384:DHE-RSA-AES256-SHA384:ECDHE-RSA-AES256-SHA256:DHE-RSA-AES256-SHA256:HIGH:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!SRP:!CAMELLIA:@SECLEVEL=0"
+
       # Whether or not IRC server is using a self-signed cert or not providing CA Chain
       sslselfsign: false
       # Should the connection attempt to identify via SASL (if a server or user password is given)
@@ -74,11 +83,6 @@ ircService:
       # Whether to allow expired certs when connecting to the IRC server.
       # Usually this should be off. Default: false.
       allowExpiredCerts: false
-      # A specific CA to trust instead of the default CAs. Optional.
-      #ca: |
-      #  -----BEGIN CERTIFICATE-----
-      #  ...
-      #  -----END CERTIFICATE-----
 
       #
       # The connection password to send for all clients as a PASS (or SASL, if enabled above) command. Optional.

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -61,6 +61,11 @@ ircService:
       port: 6697
       # Whether to use SSL or not. Default: false.
       ssl: true
+      # Object to merge with node-irc's connectionOpts
+      # Can be used to override keys like 'ciphers'
+      # valid options in https://nodejs.org/api/tls.html#tls_tls_connect_options_callback
+      # and https://nodejs.org/api/tls.html#tls_tls_createsecurecontext_options
+      connectionOpts: {}
       # Whether or not IRC server is using a self-signed cert or not providing CA Chain
       sslselfsign: false
       # Should the connection attempt to identify via SASL (if a server or user password is given)

--- a/lib/config/schema.yml
+++ b/lib/config/schema.yml
@@ -125,6 +125,8 @@ properties:
                             type: "boolean"
                         allowExpiredCerts:
                             type: "boolean"
+                        connectionOpts:
+                            type: "object"
                         password:
                             type: "string"
                         sendConnectionMessages:

--- a/lib/irc/ConnectionInstance.js
+++ b/lib/irc/ConnectionInstance.js
@@ -323,17 +323,15 @@ ConnectionInstance.create = Promise.coroutine(function*(server, opts, onCreatedC
         floodProtection: true,
         floodProtectionDelay: FLOOD_PROTECTION_DELAY_MS,
         port: server.getPort(),
+        secure: server.useSsl(),
         selfSigned: server.useSslSelfSigned(),
         certExpired: server.allowExpiredCerts(),
+        customConnectionOpts: server.getCustomConnectionOpts() || null,
         retryCount: 0,
         family: server.getIpv6Prefix() || server.getIpv6Only() ? 6 : null,
         bustRfc3484: true,
         sasl: opts.password ? server.useSasl() : false,
     };
-
-    if (server.useSsl()) {
-        connectionOpts.secure = { ca: server.getCA() };
-    }
 
     // Returns: A promise which resolves to a ConnectionInstance
     let retryConnection = () => {

--- a/lib/irc/IrcServer.js
+++ b/lib/irc/IrcServer.js
@@ -193,9 +193,9 @@ IrcServer.prototype.isInWhitelist = function(userId) {
     return this.config.dynamicChannels.whitelist.indexOf(userId) !== -1;
 };
 
-IrcServer.prototype.getCA = function() {
-    return this.config.ca;
-};
+// IrcServer.prototype.getCA = function() {
+//     return this.config.ca;
+// };
 
 IrcServer.prototype.useSsl = function() {
     return Boolean(this.config.ssl);
@@ -208,6 +208,10 @@ IrcServer.prototype.useSslSelfSigned = function() {
 IrcServer.prototype.useSasl = function() {
     return Boolean(this.config.sasl);
 };
+
+IrcServer.prototype.getCustomConnectionOpts = function() {
+    return this.config.connectionOpts;
+}
 
 IrcServer.prototype.allowExpiredCerts = function() {
     return Boolean(this.config.allowExpiredCerts);


### PR DESCRIPTION
This fixes #840
It moves the `ca` option to a more generic `connectionOpts` object, which can be used to directly pass options to the `tls.connect()` in node-irc. There's also an example in `config.sample.yaml` to use this for fixing the "CA signature digest algorithm too weak" error

Will need a version bump in node-irc, merged with this PR: https://github.com/matrix-org/node-irc/pull/39