### PR TITLE
Shortcircuit keepalives

### DIFF
--- a/changelog.d/844.misc
+++ b/changelog.d/844.misc
@@ -1,0 +1,1 @@
+Do not call keepalive() callbacks if the user doesn't need to be kept alive.

--- a/src/irc/BridgedClient.ts
+++ b/src/irc/BridgedClient.ts
@@ -656,6 +656,7 @@ export class BridgedClient extends EventEmitter {
             }, (1000 * idleTimeout));
         }
     }
+
     private removeChannel(channel: string) {
         const i = this.chanList.indexOf(channel);
         if (i === -1) {

--- a/src/irc/BridgedClient.ts
+++ b/src/irc/BridgedClient.ts
@@ -628,6 +628,12 @@ export class BridgedClient extends EventEmitter {
 
     private keepAlive() {
         this.lastActionTs = Date.now();
+        if (this.server.shouldSyncMembershipToIrc("initial") || 
+            this.isBot) {
+                // If we are mirroring matrix membership OR
+                // we are a bot, do not disconnect.
+            return;
+        }
         const idleTimeout = this.server.getIdleTimeout();
         if (idleTimeout > 0) {
             if (this.idleTimeout) {
@@ -640,17 +646,6 @@ export class BridgedClient extends EventEmitter {
             // restart the timeout
             this.idleTimeout = setTimeout(() => {
                 this.log.info("Idle timeout has expired");
-                if (this.server.shouldSyncMembershipToIrc("initial")) {
-                    this.log.info(
-                        "Not disconnecting because %s is mirroring matrix membership lists",
-                        this.server.domain
-                    );
-                    return;
-                }
-                if (this.isBot) {
-                    this.log.info("Not disconnecting because this is the bot");
-                    return;
-                }
                 this.disconnect(
                     "idle", `Idle timeout reached: ${idleTimeout}s`
                 ).then(() => {

--- a/src/irc/BridgedClient.ts
+++ b/src/irc/BridgedClient.ts
@@ -628,7 +628,7 @@ export class BridgedClient extends EventEmitter {
 
     private keepAlive() {
         this.lastActionTs = Date.now();
-        if (this.server.shouldSyncMembershipToIrc("initial") || 
+        if (this.server.shouldSyncMembershipToIrc("initial") ||
             this.isBot) {
                 // If we are mirroring matrix membership OR
                 // we are a bot, do not disconnect.


### PR DESCRIPTION
This just saves us a bit of memory and event loop time, but it's also an easy one so let's do it. We do lose the logging that tells us that users are being kept alive, but that can also be inferred from the configuration file.