### PR TITLE
Do not treat non-direct invites as PMs

### DIFF
--- a/changelog.d/846.bugfix
+++ b/changelog.d/846.bugfix
@@ -1,0 +1,1 @@
+Inviting the bridge bot to an existing bridged room will no longer cause the room to be bridged as an admin room. Invites must also use `is_direct`.

--- a/spec/integ/admin-rooms.spec.js
+++ b/spec/integ/admin-rooms.spec.js
@@ -34,6 +34,7 @@ describe("Creating admin rooms", function() {
         yield env.mockAppService._trigger("type:m.room.member", {
             content: {
                 membership: "invite",
+                is_direct: true,
             },
             state_key: botUserId,
             user_id: "@someone:somewhere",
@@ -41,6 +42,40 @@ describe("Creating admin rooms", function() {
             type: "m.room.member"
         });
         expect(botJoinedRoom).toBe(true);
+    }));
+
+    it("should not create a room for a non is_direct invite",
+    test.coroutine(function*() {
+        let botJoinedRoom = false;
+        let sdk = env.clientMock._client(botUserId);
+        sdk.joinRoom.and.callFake(function(roomId) {
+            expect(roomId).toEqual("!adminroomid:here");
+            botJoinedRoom = true;
+            return Promise.resolve({});
+        });
+
+        yield env.mockAppService._trigger("type:m.room.member", {
+            content: {
+                membership: "invite",
+            },
+            state_key: botUserId,
+            user_id: "@someone:somewhere",
+            room_id: "!adminroomid:here",
+            type: "m.room.member"
+        });
+
+        yield env.mockAppService._trigger("type:m.room.member", {
+            content: {
+                membership: "invite",
+                is_direct: false,
+            },
+            state_key: botUserId,
+            user_id: "@someone:somewhere",
+            room_id: "!adminroomid:here",
+            type: "m.room.member"
+        });
+
+        expect(botJoinedRoom).toBe(false);
     }));
 });
 
@@ -98,7 +133,8 @@ describe("Admin rooms", function() {
             // auto-setup an admin room
             return env.mockAppService._trigger("type:m.room.member", {
                 content: {
-                    membership: "invite"
+                    membership: "invite",
+                    is_direct: true
                 },
                 state_key: botUserId,
                 user_id: userId,

--- a/spec/integ/invite-rooms.spec.js
+++ b/spec/integ/invite-rooms.spec.js
@@ -43,6 +43,7 @@ describe("Invite-only rooms", function() {
         env.mockAppService._trigger("type:m.room.member", {
             content: {
                 membership: "invite",
+                is_direct: true,
             },
             state_key: botUserId,
             user_id: testUser.id,
@@ -54,6 +55,7 @@ describe("Invite-only rooms", function() {
             return env.mockAppService._trigger("type:m.room.member", {
                 content: {
                     membership: "invite",
+                    is_direct: true,
                 },
                 state_key: botUserId,
                 user_id: testUser.id,

--- a/spec/integ/matrix-to-irc.spec.js
+++ b/spec/integ/matrix-to-irc.spec.js
@@ -672,7 +672,8 @@ describe("Matrix-to-Matrix message bridging", function() {
         // Get nick serv into the 2 PM rooms
         yield env.mockAppService._trigger("type:m.room.member", {
             content: {
-                membership: "invite"
+                membership: "invite",
+                is_direct: true
             },
             state_key: nickServUserId,
             user_id: testUser.id,
@@ -681,7 +682,8 @@ describe("Matrix-to-Matrix message bridging", function() {
         });
         yield env.mockAppService._trigger("type:m.room.member", {
             content: {
-                membership: "invite"
+                membership: "invite",
+                is_direct: true
             },
             state_key: nickServUserId,
             user_id: anotherUserId,

--- a/spec/integ/pm.spec.js
+++ b/spec/integ/pm.spec.js
@@ -33,7 +33,8 @@ describe("Matrix-to-IRC PMing", function() {
         // get the ball rolling
         let requestPromise = env.mockAppService._trigger("type:m.room.member", {
             content: {
-                membership: "invite"
+                membership: "invite",
+                is_direct: true,
             },
             state_key: tIrcUserId,
             user_id: tUserId,
@@ -100,7 +101,8 @@ describe("Matrix-to-IRC PMing", function() {
         // get the ball rolling
         let requestPromise = env.mockAppService._trigger("type:m.room.member", {
             content: {
-                membership: "invite"
+                membership: "invite",
+                is_direct: true,
             },
             state_key: tIrcUserId,
             user_id: tUserId,
@@ -223,7 +225,8 @@ describe("Matrix-to-IRC PMing disabled", function() {
         // get the ball rolling
         let requestPromise = env.mockAppService._trigger("type:m.room.member", {
             content: {
-                membership: "invite"
+                membership: "invite",
+                is_direct: true,
             },
             state_key: tIrcUserId,
             user_id: tUserId,
@@ -552,7 +555,8 @@ describe("Matrix-to-IRC PMing over federation disabled", function() {
         // get the ball rolling
         let requestPromise = env.mockAppService._trigger("type:m.room.member", {
             content: {
-                membership: "invite"
+                membership: "invite",
+                is_direct: true,
             },
             state_key: tIrcUserId,
             user_id: tUserId,


### PR DESCRIPTION
There are lots of cases where we assume an invite means a PM, which means if a user invites the bridge bot to a non-PM room then stuff gets leaked across. This PR ensures we make more checks, such as looking for an existing room and checking for the existence of `is_direct`.