### PR TITLE
node-irc types and efficency fixes

### DIFF
--- a/changelog.d/848.misc
+++ b/changelog.d/848.misc
@@ -1,0 +1,1 @@
+Swap to using promises over timers for queuing messages on IRC connections.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1847,7 +1847,7 @@
       "integrity": "sha512-M4Sjn6N/+O6/IXSJseKqHoFc+5FdGJ22sXqnjTpdZweHK64MzEPAyQZyEU3R/KRv2GLoa7nNtg/C2Ev6m7z+eA=="
     },
     "irc": {
-      "version": "github:matrix-org/node-irc#e1f7f76afbf5ca06ca050a19551cb35ea0294b20",
+      "version": "github:matrix-org/node-irc#dd7c84a41bdced5ad24371bf56ee376c6c058a03",
       "from": "github:matrix-org/node-irc#matrix-irc-bridge",
       "requires": {
         "detect-character-encoding": "^0.8.0",

--- a/src/DebugApi.ts
+++ b/src/DebugApi.ts
@@ -235,7 +235,8 @@ export class DebugApi {
                 "User " + user + " does not have a client on " + server.domain + "\n"
             );
         }
-        if (!client.unsafeClient) {
+        const connection = client.unsafeClient && client.unsafeClient.conn;
+        if (!client.unsafeClient || !connection) {
             return Bluebird.resolve(
                 "There is no underlying client instance.\n"
             );
@@ -254,7 +255,7 @@ export class DebugApi {
         body = body.replace("\r\n", "\n");
         body.split("\n").forEach((c: string) => {
             // IRC protocol require rn
-            client.unsafeClient.conn.write(c + "\r\n");
+            connection.write(c + "\r\n");
             buffer.push(c);
         });
 

--- a/src/irc/BridgedClient.ts
+++ b/src/irc/BridgedClient.ts
@@ -29,17 +29,13 @@ import { IrcAction } from "../models/IrcAction";
 import { IdentGenerator } from "./IdentGenerator";
 import { Ipv6Generator } from "./Ipv6Generator";
 import { IrcEventBroker } from "./IrcEventBroker";
+import { Client } from "irc";
 
 const log = getLogger("BridgedClient");
 
 // The length of time to wait before trying to join the channel again
 const JOIN_TIMEOUT_MS = 15 * 1000; // 15s
 const NICK_DELAY_TIMER_MS = 10 * 1000; // 10s
-
-// All of these are not defined yet.
-/* eslint-disable @typescript-eslint/no-explicit-any */
-type IrcClient = EventEmitter|any;
-/* eslint-enable @typescript-eslint/no-explicit-any */
 
 interface GetNicksResponse {
     server: IrcServer;

--- a/src/irc/BridgedClient.ts
+++ b/src/irc/BridgedClient.ts
@@ -738,7 +738,7 @@ export class BridgedClient extends EventEmitter {
                 defer.resolve();
                 return;
             }
-            
+
             if (!this.unsafeClient) {
                 return;
             }

--- a/src/irc/ClientPool.ts
+++ b/src/irc/ClientPool.ts
@@ -368,6 +368,9 @@ export class ClientPool {
     private onClientConnected(bridgedClient: BridgedClient): void {
         const server = bridgedClient.server;
         const oldNick = bridgedClient.nick;
+        if (!bridgedClient.unsafeClient) {
+            return;
+        }
         const actualNick = bridgedClient.unsafeClient.nick;
 
         // remove the pending nick we had set for this user

--- a/src/irc/ConnectionInstance.ts
+++ b/src/irc/ConnectionInstance.ts
@@ -14,10 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// We have no types for IRC yet.
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const irc = require("irc");
-
+import { Client } from "irc";
 import * as promiseutil from "../promiseutil";
 import Scheduler from "./Scheduler";
 import * as logging from "../logging";
@@ -33,9 +30,6 @@ export interface IrcMessage {
     rawCommand: string;
     prefix: string;
 }
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type IrcClient = any;
 
 // The time we're willing to wait for a connect callback when connecting to IRC.
 const CONNECT_TIMEOUT_MS = 30 * 1000; // 30s

--- a/src/irc/ConnectionInstance.ts
+++ b/src/irc/ConnectionInstance.ts
@@ -396,7 +396,6 @@ export class ConnectionInstance {
                 return await retryConnection();
             }
             catch (err) {
-                console.log(err);
                 connAttempts += 1;
                 log.error(
                     `ConnectionInstance.connect failed after ${connAttempts} attempts (${err.message})`


### PR DESCRIPTION
This PR makes use of the recently added types to our fork of `node-irc`. This also includes the changes to hopefully make `node-irc` use promise chains for flood control rather than a one second timer. This should hopefully make a difference to large installations where event loop time is at a premium.