### PR TITLE
Remove warnings about deprecated config values

### DIFF
--- a/changelog.d/849.removal
+++ b/changelog.d/849.removal
@@ -1,0 +1,1 @@
+Remove warnings/hacks around `config.appservice`. Users should have upgraded to the new format by now.

--- a/src/bridge/IrcBridge.ts
+++ b/src/bridge/IrcBridge.ts
@@ -400,7 +400,7 @@ export class IrcBridge {
             const completeConfig = extend(
                 true, {}, IrcServer.DEFAULT_CONFIG, this.config.ircService.servers[domain]
             );
-            const appServiceserver = new IrcServer(
+            const server = new IrcServer(
                 domain, completeConfig, this.config.homeserver.domain,
                 this.config.homeserver.dropMatrixMessagesAfterSecs
             );

--- a/src/bridge/IrcBridge.ts
+++ b/src/bridge/IrcBridge.ts
@@ -400,7 +400,7 @@ export class IrcBridge {
             const completeConfig = extend(
                 true, {}, IrcServer.DEFAULT_CONFIG, this.config.ircService.servers[domain]
             );
-            const server = new IrcServer(
+            const appServiceserver = new IrcServer(
                 domain, completeConfig, this.config.homeserver.domain,
                 this.config.homeserver.dropMatrixMessagesAfterSecs
             );

--- a/src/main.ts
+++ b/src/main.ts
@@ -26,13 +26,6 @@ process.on("unhandledRejection", (reason?: Error) => {
 
 const _toServer = (domain: string, serverConfig: any, homeserverDomain: string) => {
     // set server config defaults
-    if (serverConfig.dynamicChannels.visibility) {
-        throw new Error(
-            `[DEPRECATED] Use of the config field dynamicChannels.visibility
-            is deprecated. Use dynamicChannels.published, dynamicChannels.joinRule
-            and dynamicChannels.createAlias instead.`
-        );
-    }
     return new IrcServer(
         domain, extend(true, IrcServer.DEFAULT_CONFIG, serverConfig), homeserverDomain
     );


### PR DESCRIPTION
These were added a long time ago (before I took over the project) and I'm going to make the broad assumption that users are no longer using the ancient format. Regardless, we will be making a breaking release anyway so let's remove these.