### PR TITLE
Tweak counter for leaving users

### DIFF
--- a/changelog.d/855.bugfix
+++ b/changelog.d/855.bugfix
@@ -1,0 +1,1 @@
+Fix counter for leaving users.

--- a/src/bridge/MemberListSyncer.ts
+++ b/src/bridge/MemberListSyncer.ts
@@ -406,6 +406,7 @@ export class MemberListSyncer {
 
         // If a userId is in remoteJoinedUsers, but not ircUserIds, intend on leaving roomId
         const promises: Promise<unknown>[] = [];
+        let totalLeavingUsers = 0;
         roomsForChannel.forEach((matrixRoom) => {
             const roomId = matrixRoom.getId();
             const roomInfo = this.memberLists.matrix[roomId];
@@ -421,8 +422,10 @@ export class MemberListSyncer {
                     return !ircUserIds.includes(userId);
                 }
             );
-
-            this.usersToLeave += usersToLeave.length;
+            if (usersToLeave.length > 0) {
+                return;
+            }
+            totalLeavingUsers += usersToLeave.length;
             // ID is the complete mapping of roomID/channel which will be unique
             promises.push(this.leaveQueuePool.enqueue(roomId + " " + channel, {
                 roomId: roomId,
@@ -430,8 +433,9 @@ export class MemberListSyncer {
             }));
         });
         log.info(
-            `updateIrcMemberList: Leaving ${promises.length} users as they are not in ${channel}.`
+            `updateIrcMemberList: Leaving ${totalLeavingUsers} users as they are not in ${channel}.`
         );
+        this.usersToLeave += totalLeavingUsers;
         await Promise.all(promises);
     }
 

--- a/src/bridge/MemberListSyncer.ts
+++ b/src/bridge/MemberListSyncer.ts
@@ -422,7 +422,7 @@ export class MemberListSyncer {
                     return !ircUserIds.includes(userId);
                 }
             );
-            if (usersToLeave.length > 0) {
+            if (usersToLeave.length < 1) {
                 return;
             }
             totalLeavingUsers += usersToLeave.length;


### PR DESCRIPTION
**depends on #845**

This change makes it so that we do not queue a leave operation if there are no users to leave. In addition, we no longer count the number of queued promises as the number of leaving users.