### PR TITLE
Add yaml config options to set port and hostname

### DIFF
--- a/app.js
+++ b/app.js
@@ -5,11 +5,11 @@ const main = require("./lib/main");
 const path = require("path");
 
 const REG_PATH = "appservice-registration-irc.yaml";
-
 new Cli({
     registrationPath: REG_PATH,
     enableRegistration: true,
     enableLocalpart: true,
+    port: -1, // Set this here so we know if the port is a default
     bridgeConfig: {
         affectsRegistration: true,
         schema: path.join(__dirname, "config.schema.yml"),
@@ -42,6 +42,9 @@ new Cli({
         });
     },
     run: function(port, config, reg) {
+        if (port === -1) {
+            port = null;
+        }
         main.runBridge(port, config, reg).catch(function(err) {
             log.error("Failed to run bridge.");
             throw err;

--- a/changelog.d/857.feature
+++ b/changelog.d/857.feature
@@ -1,0 +1,1 @@
+Allow admins to specify a bind port and/or hostname in the config.

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -32,6 +32,14 @@ homeserver:
   # Default: true
   enablePresence: true
 
+  # Which port should the appservice bind to. Takes priority over the one provided in the
+  # command line! Optional.
+  # bindPort: 9999
+
+  # Use this option to force the appservice to listen on another hostname for transactions.
+  # This is NOT your synapse hostname. E.g. use 127.0.0.1 to only listen locally. Optional.
+  # bindHostname: 0.0.0.0
+
 # Configuration specific to the IRC service
 ircService:
   servers:

--- a/config.schema.yml
+++ b/config.schema.yml
@@ -28,6 +28,10 @@ properties:
                 type: "integer"
             enablePresence:
                 type: "boolean"
+            bindHostname:
+                type: "string"
+            bindPort:
+                type: "integer"
         required: ["url", "domain"]
     ircService:
         type: "object"

--- a/package-lock.json
+++ b/package-lock.json
@@ -2353,9 +2353,9 @@
       }
     },
     "matrix-appservice": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/matrix-appservice/-/matrix-appservice-0.3.5.tgz",
-      "integrity": "sha512-oQcxlpERcUj90QbGjV7t5Ly5/Aze/sUwB9ZrIt1UMFwuNT+CgEzA7cxLDHAiJkXfgoNzFvjVnKJ3203oIuLONQ==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/matrix-appservice/-/matrix-appservice-0.4.1.tgz",
+      "integrity": "sha512-mxHr9XDOvN/p6OFrfb4kkcEjCPftnXNzMS8Lg9Cz/pDy1arfRWq11vl9pL9bjzBaAouBGLpW1JzmCR2MsW+VKA==",
       "requires": {
         "body-parser": "^1.18.3",
         "express": "^4.16.3",
@@ -2365,16 +2365,16 @@
       }
     },
     "matrix-appservice-bridge": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/matrix-appservice-bridge/-/matrix-appservice-bridge-1.11.0.tgz",
-      "integrity": "sha512-qkFGRlL4tszWRIY2GkOXihuG2TsaMxPuu6doSlOpi3MrYVr2+z/OPP9eUS/AqcRKHnZl849zryOUb41eHxg2qg==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/matrix-appservice-bridge/-/matrix-appservice-bridge-1.11.1.tgz",
+      "integrity": "sha512-xrtjxScBIx33HRkiK/5G6wkUxZ9jxF9GqTiKzM/Fn7CgMZoHVDIms3sTc7ybZKA6RHAqH68bg4Eg4JbGCtUrhw==",
       "requires": {
         "bluebird": "^2.9.34",
         "chalk": "^2.4.1",
         "extend": "^3.0.0",
         "is-my-json-valid": "^2.19.0",
         "js-yaml": "^3.12.0",
-        "matrix-appservice": "0.3.5",
+        "matrix-appservice": "^0.4.1",
         "matrix-js-sdk": "^2.3.0",
         "nedb": "^1.1.3",
         "nopt": "^3.0.3",
@@ -2402,14 +2402,6 @@
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
           "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
-        },
-        "prom-client": {
-          "version": "11.5.3",
-          "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-11.5.3.tgz",
-          "integrity": "sha512-iz22FmTbtkyL2vt0MdDFY+kWof+S9UB/NACxSn2aJcewtw+EERsen0urSkZ2WrHseNdydsvcxCTAnPcSMZZv4Q==",
-          "requires": {
-            "tdigest": "^0.1.1"
-          }
         },
         "winston": {
           "version": "3.2.1",
@@ -3199,7 +3191,6 @@
       "version": "11.5.3",
       "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-11.5.3.tgz",
       "integrity": "sha512-iz22FmTbtkyL2vt0MdDFY+kWof+S9UB/NACxSn2aJcewtw+EERsen0urSkZ2WrHseNdydsvcxCTAnPcSMZZv4Q==",
-      "dev": true,
       "requires": {
         "tdigest": "^0.1.1"
       }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "iconv": "^2.3.4",
     "irc": "matrix-org/node-irc#matrix-irc-bridge",
     "js-yaml": "^3.2.7",
-    "matrix-appservice-bridge": "^1.11.0",
+    "matrix-appservice-bridge": "^1.11.1",
     "matrix-lastactive": "^0.0.8",
     "nedb": "^1.1.2",
     "nopt": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "@typescript-eslint/parser": "^2.2.0",
     "eslint": "^5.16.0",
     "jasmine": "^3.1.0",
+    "matrix-appservice": "^0.4.1",
     "nyc": "^14.1.1",
     "proxyquire": "^1.4.0",
     "typescript": "^3.6.3",

--- a/src/bridge/IrcBridge.ts
+++ b/src/bridge/IrcBridge.ts
@@ -41,6 +41,7 @@ import { BridgeConfig } from "../config/BridgeConfig";
 
 
 const log = getLogger("IrcBridge");
+const DEFAULT_PORT = 8090;
 const DELAY_TIME_MS = 10 * 1000;
 const DELAY_FETCH_ROOM_LIST_MS = 3 * 1000;
 const DEAD_TIME_MS = 5 * 60 * 1000;
@@ -352,9 +353,10 @@ export class IrcBridge {
         );
     }
 
-    public async run(port: number) {
+    public async run(port: number|null) {
         const dbConfig = this.config.database;
-        port = this.config.homeserver.bindPort || port;
+        // cli port, then config port, then default port
+        port = port || this.config.homeserver.bindPort || DEFAULT_PORT;
         const pkeyPath = this.config.ircService.passwordEncryptionKeyPath;
 
         if (this.debugApi) {

--- a/src/bridge/IrcBridge.ts
+++ b/src/bridge/IrcBridge.ts
@@ -354,6 +354,7 @@ export class IrcBridge {
 
     public async run(port: number) {
         const dbConfig = this.config.database;
+        port = this.config.homeserver.bindPort || port;
         const pkeyPath = this.config.ircService.passwordEncryptionKeyPath;
 
         if (this.debugApi) {
@@ -411,7 +412,7 @@ export class IrcBridge {
         }
 
         // run the bridge (needs to be done prior to configure IRC side)
-        await this.bridge.run(port);
+        await this.bridge.run(port, undefined, undefined, this.config.homeserver.bindHostname);
         this.addRequestCallbacks();
         if (!this.registration.getSenderLocalpart() ||
                 !this.registration.getAppServiceToken()) {

--- a/src/bridge/IrcBridge.ts
+++ b/src/bridge/IrcBridge.ts
@@ -23,13 +23,13 @@ import { MatrixActivityTracker } from "matrix-lastactive";
 import Provisioner from "../provisioning/Provisioner.js";
 import { PublicitySyncer } from "./PublicitySyncer";
 import { Histogram } from "prom-client";
+import { AppServiceRegistration } from "matrix-appservice";
 
 import {
     Bridge,
     MatrixUser,
     MatrixRoom,
     Logging,
-    AppServiceRegistration,
     Entry,
     Request,
     PrometheusMetrics,
@@ -80,7 +80,7 @@ export class IrcBridge {
         if (config.ircService.debugApi && config.ircService.debugApi.enabled) {
             this.activityTracker = new MatrixActivityTracker(
                 this.config.homeserver.url,
-                registration.getAppServiceToken(),
+                registration.getAppServiceToken() as string,
                 this.config.homeserver.domain,
                 this.config.homeserver.enablePresence,
                 getLogger("MxActivityTracker"),
@@ -183,7 +183,7 @@ export class IrcBridge {
                 config.ircService.debugApi.port,
                 this.ircServers,
                 this.clientPool,
-                registration.getAppServiceToken()
+                registration.getAppServiceToken() as string
             ) : null
         );
         this.publicitySyncer = new PublicitySyncer(this);

--- a/src/config/BridgeConfig.ts
+++ b/src/config/BridgeConfig.ts
@@ -17,6 +17,8 @@ export interface BridgeConfig {
         domain: string;
         enablePresence?: boolean;
         dropMatrixMessagesAfterSecs?: number;
+        bindHostname: string|undefined;
+        bindPort: number|undefined;
     };
     ircService: {
         servers: {[domain: string]: IrcServerConfig};

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,7 +3,7 @@ import Datastore from "nedb";
 import extend from "extend";
 import http from "http";
 import https from "https";
-import { AppServiceRegistration, RoomBridgeStore, UserBridgeStore } from "matrix-appservice-bridge";
+import { RoomBridgeStore, UserBridgeStore } from "matrix-appservice-bridge";
 import { IrcBridge } from "./bridge/IrcBridge";
 import { IrcServer } from "./irc/IrcServer";
 import stats from "./config/stats";
@@ -11,6 +11,7 @@ import ident from "./irc/Ident";
 import * as logging from "./logging";
 import { LoggerInstance } from "winston";
 import { BridgeConfig } from "./config/BridgeConfig";
+import { AppServiceRegistration } from "matrix-appservice";
 
 const log = logging.get("main");
 
@@ -39,6 +40,7 @@ const _toServer = (domain: string, serverConfig: any, homeserverDomain: string) 
 
 export async function generateRegistration(reg: AppServiceRegistration, config: BridgeConfig) {
     let asToken;
+
 
     if (!reg.getSenderLocalpart()) {
         reg.setSenderLocalpart(IrcBridge.DEFAULT_LOCALPART);

--- a/types/matrix-appservice-bridge/index.d.ts
+++ b/types/matrix-appservice-bridge/index.d.ts
@@ -18,6 +18,7 @@ limitations under the License.
  * This has been borrowed from https://github.com/huan/matrix-appservice-wechaty/blob/master/src/typings/matrix-appservice-bridge.d.ts
  * under the Apache2 licence.
  */
+
 declare module 'matrix-appservice-bridge' {
 
     namespace PrometheusMetrics {
@@ -265,19 +266,6 @@ declare module 'matrix-appservice-bridge' {
         addDefaultResolveCallback(cb: (req: Request, result: unknown) => void): void;
         addDefaultRejectCallback(cb: (req: Request) => void): void;
         addDefaultTimeoutCallback(cb: (req: Request) => void, timeout: number): void;
-    }
-
-    export class AppServiceRegistration {
-        static generateToken(): string;
-        setSenderLocalpart(localpart: string): void;
-        getSenderLocalpart(): string;
-        setId(id: string): void;
-        setHomeserverToken(token: string): void;
-        setAppServiceToken(token: string): void;
-        getAppServiceToken(): string;
-        setRateLimited(limited: boolean): void;
-        setProtocols(protocols: string[]): void;
-        addRegexPattern(type: "rooms"|"aliases"|"users", regex: string, exclusive: boolean): void;
     }
 
     export class Logging {

--- a/types/matrix-appservice-bridge/index.d.ts
+++ b/types/matrix-appservice-bridge/index.d.ts
@@ -249,7 +249,9 @@ declare module 'matrix-appservice-bridge' {
         getPrometheusMetrics(): PrometheusMetrics;
         getIntent(userId?: string): Intent;
         getIntentFromLocalpart(localpart: string): Intent;
-        run(port: number): void;
+
+        // N.B config isn't used by this func, and appservice isn't used by this bridge.
+        run(port: number, config: undefined, appservice: undefined, hostname: string|undefined): void;
         registerBridgeGauges(cb: () => void): void;
         getClientFactory(): ClientFactory;
     }


### PR DESCRIPTION
Fixes #95 
This PR allows admins to specify the port and hostname they want to bind the appservice to in the config file. The port takes priority over the CLI provided value. The hostname has no equivalent in the CLI, but will default to 0.0.0.0 as before if not specified. This PR also bumps us up to 1.11.1.
