### PR TITLE
Reconnect the IRC user on !storepass

### DIFF
--- a/changelog.d/864.feature
+++ b/changelog.d/864.feature
@@ -1,0 +1,1 @@
+When !storepass is called, reconnect the user to ensure the password is set.

--- a/src/bridge/AdminRoomHandler.ts
+++ b/src/bridge/AdminRoomHandler.ts
@@ -122,7 +122,7 @@ export class AdminRoomHandler {
                 await this.handleWhois(req, args, ircServer, adminRoom, event.sender);
                 break;
             case "!storepass":
-                await this.handleStorePass(req, args, ircServer, adminRoom, event.sender);
+                await this.handleStorePass(req, args, ircServer, adminRoom, event.sender, clientList[0]);
                 break;
             case "!removepass":
                 await this.handleRemovePass(ircServer, adminRoom, event.sender);
@@ -390,33 +390,28 @@ export class AdminRoomHandler {
     }
 
     private async handleStorePass(req: BridgeRequest, args: string[], server: IrcServer,
-        room: MatrixRoom, userId: string) {
+        room: MatrixRoom, userId: string, client: BridgedClient) {
         const domain = server.domain;
         let notice;
 
         try {
             // Allow passwords with spaces
             const pass = args.join(' ');
-            const explanation = `When you next reconnect to ${domain}, this password ` +
-                `will be automatically sent in a PASS command which most ` +
-                `IRC networks will use as your NickServ password. This ` +
-                `means you will not need to talk to NickServ. This does ` +
-                `NOT apply to your currently active connection: you still ` +
-                `need to talk to NickServ one last time to authenticate ` +
-                `your current connection if you haven't already.`;
-
             if (pass.length === 0) {
                 notice = new MatrixAction(
                     "notice",
                     "Format: '!storepass password' " +
-                    "or '!storepass irc.server.name password'\n" + explanation
+                    "or '!storepass irc.server.name password'\n"
                 );
             }
             else {
                 await this.ircBridge.getStore().storePass(userId, domain, pass);
                 notice = new MatrixAction(
-                    "notice", `Successfully stored password for ${domain}. ` + explanation
+                    "notice", `Successfully stored password for ${domain}. You will now be reconnected to IRC.`
                 );
+            }
+            if (client) {
+                await client.disconnect("iwantoreconnect", "authenticating", false);
             }
         }
         catch (err) {

--- a/src/irc/BridgedClient.ts
+++ b/src/irc/BridgedClient.ts
@@ -284,8 +284,8 @@ export class BridgedClient extends EventEmitter {
         this.log.info("Rejoined channels");
     }
 
-    public disconnect(reason: InstanceDisconnectReason, textReason?: string) {
-        this._explicitDisconnect = true;
+    public disconnect(reason: InstanceDisconnectReason, textReason?: string, explicit = true) {
+        this._explicitDisconnect = explicit;
         if (!this.inst || this.inst.dead) {
             return Promise.resolve();
         }

--- a/src/irc/ConnectionInstance.ts
+++ b/src/irc/ConnectionInstance.ts
@@ -77,7 +77,8 @@ export interface ConnectionOpts {
 }
 
 export type InstanceDisconnectReason = "throttled"|"irc_error"|"net_error"|"timeout"|"raw_error"|
-                                       "toomanyconns"|"banned"|"killed"|"idle"|"limit_reached";
+                                       "toomanyconns"|"banned"|"killed"|"idle"|"limit_reached"|
+                                       "iwantoreconnect";
 
 export class ConnectionInstance {
     public dead = false;


### PR DESCRIPTION
**depends on #863**

Fixes #724

This is a simple solution to fix the problem where users will not have their password applied when calling `!storepass`. Clients are automatically reconnected unless the explicit flag is given, so this should just work.