### PR TITLE
Replace some calls to .roomState()

### DIFF
--- a/changelog.d/865.bugfix
+++ b/changelog.d/865.bugfix
@@ -1,0 +1,1 @@
+Replace calls to /state with more efficent calls, where possible.

--- a/changelog.d/865.bugfix
+++ b/changelog.d/865.bugfix
@@ -1,1 +1,1 @@
-Replace calls to /state with more efficent calls, where possible.
+Replace calls to `/state` with more efficient calls, where possible.

--- a/spec/util/client-sdk-mock.js
+++ b/spec/util/client-sdk-mock.js
@@ -27,7 +27,7 @@ function MockClient(config) {
     this.sendEvent = jasmine.createSpy("sdk.sendEvent(roomId,type,content)");
     this.invite = jasmine.createSpy("sdk.invite(roomId, userId)");
     this.leave = jasmine.createSpy("sdk.leave(roomId)");
-    this.kick = jasmine.createSpy("sdk.kick(roomId, target)");
+    this.kick = jasmine.createSpy("sdk.kick(roomId, target, reason)");
     this.createAlias = jasmine.createSpy("sdk.createAlias(alias, roomId)");
     this.mxcUrlToHttp = jasmine.createSpy("sdk.mxcUrlToHttp(mxc, w, h, method)");
     this.getHomeserverUrl = jasmine.createSpy("sdk.getHomeserverUrl()");
@@ -48,6 +48,8 @@ function MockClient(config) {
     });
 
     this.getJoinedRooms.and.returnValue(Promise.resolve([]));
+
+    this.getJoinedRoomMembers.and.returnValue(Promise.resolve([]));
 
     // mock up sendStateEvent
     this.sendStateEvent.and.callFake(function() {

--- a/src/bridge/IrcHandler.ts
+++ b/src/bridge/IrcHandler.ts
@@ -155,14 +155,7 @@ export class IrcHandler {
             // query room state to see if the user is actually joined.
             log.info("Querying PM room state (%s) between %s and %s",
                 roomId, userId, virtUserId);
-            const stateEvents = await intent.roomState(roomId);
-            for (let i = 0; i < stateEvents.length; i++) {
-                if (stateEvents[i].type === "m.room.member" &&
-                        stateEvents[i].state_key === userId) {
-                    priv.membership = stateEvents[i].content.membership;
-                    break;
-                }
-            }
+            priv = (await intent.getStateEvent(roomId, "m.room.member", userId));
         }
 
         // we should have the latest membership state now for this user (either we just

--- a/src/bridge/MatrixHandler.ts
+++ b/src/bridge/MatrixHandler.ts
@@ -211,17 +211,7 @@ export class MatrixHandler {
             return;
         }
         req.log.error("This room isn't a 1:1 chat!");
-        // whine that you don't do group chats and leave.
-        const notice = new MatrixAction("notice",
-            "Group chat not supported."
-        );
-        try {
-            await this.ircBridge.sendMatrixAction(mxRoom, invitedUser, notice);
-        }
-        catch (err) {
-            // ignore, we want to leave the room regardless.
-        }
-        await intent.leave(event.room_id);
+        await intent.kick(event.room_id, invitedUser.getId(), "Group chat not supported.");
     }
 
     // === Admin room handling ===
@@ -944,7 +934,7 @@ export class MatrixHandler {
             if (this.ircBridge.getAppServiceUserId() === event.sender) {
                 await this.handleInviteFromBot(req, event, ircUser); // case [2]
             }
-            else if (event.content.is_direct) {
+            else { // We check if this is an invite inside the func.
                 await this.handleInviteFromUser(req, event, ircUser); // case [1]
             }
         }

--- a/src/bridge/MatrixHandler.ts
+++ b/src/bridge/MatrixHandler.ts
@@ -147,8 +147,7 @@ export class MatrixHandler {
         await this.ircBridge.getAppServiceBridge().getIntent(mxUser.getId()).join(event.room_id);
     }
 
-    private async handleInviteFromUser(req: BridgeRequest, event: {room_id: string; sender: string; state_key: string},
-        invited: IrcUser) {
+    private async handleInviteFromUser(req: BridgeRequest, event: MatrixEventInvite, invited: IrcUser) {
         req.log.info("Handling invite from user directed at %s on %s",
         invited.server.domain, invited.nick);
         const invitedUser = await this.ircBridge.getMatrixUser(invited);
@@ -193,13 +192,15 @@ export class MatrixHandler {
         req.log.info("Joined %s to room %s", invitedUser.getId(), event.room_id);
 
         // check if this room is a PM room or not.
-        const roomState = await intent.roomState(event.room_id);
-        const joinedMembers = roomState.filter((ev) =>
-            ev.type === "m.room.member" && ev.content.membership === "join"
-        ).map((ev) => ev.state_key);
-        const isPmRoom = (
-            joinedMembers.length === 2 && joinedMembers.includes(event.sender)
-        );
+
+        let isPmRoom = event.content.is_direct === true;
+        if (isPmRoom !== true) {
+            // Legacy check
+            const joinedMembers = Object.keys(
+                await this.ircBridge.getAppServiceBridge().getBot().getJoinedMembers(event.room_id)
+            );
+            isPmRoom = joinedMembers.length === 2 && joinedMembers.includes(event.sender);
+        }
 
         if (isPmRoom) {
             // nick is the channel


### PR DESCRIPTION
There are a few places when handling invites where we call roomState, and then use it to find the state of one user. This change removes those and uses more sensible alternatives. This change is intended to improve the performance of the bridge for matrix.org, where /state calls are costly.