### PR TITLE
Fix topics echoing after setting it on Matrix

### DIFF
--- a/changelog.d/866.bugfix
+++ b/changelog.d/866.bugfix
@@ -1,0 +1,1 @@
+Topic changes from Matrix no longer cause a ghost user to join the room.

--- a/src/bridge/IrcHandler.ts
+++ b/src/bridge/IrcHandler.ts
@@ -504,6 +504,11 @@ export class IrcHandler {
             server.domain, fromUser, channel, JSON.stringify(action).substring(0, 80)
         );
 
+        if (fromUser.isVirtual) {
+            // Don't echo our topics back.
+            return BridgeRequestErr.ERR_VIRTUAL_USER;
+        }
+
         const ALLOWED_ORIGINS: RoomOrigin[] = ["join", "alias"];
         const topic = action.text;
 
@@ -518,7 +523,7 @@ export class IrcHandler {
                 channel,
                 ALLOWED_ORIGINS
             );
-            return;
+            return BridgeRequestErr.ERR_NOT_MAPPED;
         }
 
         req.log.info(

--- a/src/bridge/IrcHandler.ts
+++ b/src/bridge/IrcHandler.ts
@@ -543,6 +543,7 @@ export class IrcHandler {
             server.domain + " " + channel + " " + topic,
             {req: req, matrixRooms, topic: topic, matrixUser}
         );
+        return undefined;
     }
 
     /**


### PR DESCRIPTION
Fixes #817 

The bug worked as follows:
- A matrix user send a m.room.topic update.
- The IRC bridge sends a topic update to IRC.
- The IRC bridge hears a topic update from a virtual IRC user.
- The IRC bridge sets the topic on Matrix which is identical to the new topic (except perhaps if the topic gets cut off).
- Because we use the actual irc user's ghost to set topics now, the real Matrix user's virtual irc ghost will appear in the room and try to set the topic.