### PR TITLE
Changes to make membership handing more efficent.

### DIFF
--- a/changelog.d/881.misc
+++ b/changelog.d/881.misc
@@ -1,0 +1,1 @@
+Use the DB to prefill some membership caches, reducing the number of HTTP calls made and speeding up bridge startup.

--- a/src/bridge/IrcBridge.ts
+++ b/src/bridge/IrcBridge.ts
@@ -426,7 +426,7 @@ export class IrcBridge {
 
         // run the bridge (needs to be done prior to configure IRC side)
         await this.bridge.run(port, undefined, undefined, this.config.homeserver.bindHostname);
-        
+
         this.addRequestCallbacks();
         if (!this.registration.getSenderLocalpart() ||
                 !this.registration.getAppServiceToken()) {

--- a/src/bridge/IrcBridge.ts
+++ b/src/bridge/IrcBridge.ts
@@ -33,6 +33,7 @@ import {
     Entry,
     Request,
     PrometheusMetrics,
+    MembershipCache,
 } from "matrix-appservice-bridge";
 import { IrcAction } from "../models/IrcAction";
 import { DataStore } from "../datastore/DataStore";
@@ -74,6 +75,7 @@ export class IrcBridge {
         matrix_request_seconds: Histogram;
         remote_request_seconds: Histogram;
     }|null = null;
+    private membershipCache: MembershipCache;
     constructor(public readonly config: BridgeConfig, private registration: AppServiceRegistration) {
         // TODO: Don't log this to stdout
         Logging.configure({console: config.ircService.logging.level});
@@ -118,7 +120,7 @@ export class IrcBridge {
                 userStore: `${dirPath}/users.db`,
             };
         }
-
+        this.membershipCache = new MembershipCache();
         this.bridge = new Bridge({
             registration: this.registration,
             homeserverUrl: this.config.homeserver.url,
@@ -165,7 +167,8 @@ export class IrcBridge {
                 migrateGhosts: false,
                 onRoomMigrated: this.onRoomUpgrade.bind(this),
                 migrateEntry: this.roomUpgradeMigrateEntry.bind(this),
-            }
+            },
+            membershipCache: this.membershipCache,
         });
 
         // By default the bridge will escape mxids, but the irc bridge isn't ready for this yet.
@@ -423,6 +426,7 @@ export class IrcBridge {
 
         // run the bridge (needs to be done prior to configure IRC side)
         await this.bridge.run(port, undefined, undefined, this.config.homeserver.bindHostname);
+        
         this.addRequestCallbacks();
         if (!this.registration.getSenderLocalpart() ||
                 !this.registration.getAppServiceToken()) {
@@ -431,10 +435,21 @@ export class IrcBridge {
             );
         }
 
+        // Storing all the users we know about to avoid calling /register on them.
+        const allUsers = await this.dataStore.getAllUserIds();
+        const bot = this.bridge.getBot();
+        allUsers.filter((u) => bot.isRemoteUser(u))
+            .forEach((u) => this.membershipCache.setMemberEntry("", u, "join"));
+
+
         log.info("Fetching Matrix rooms that are already joined to...");
         await this.fetchJoinedRooms();
 
-        // start things going
+        for (const roomId of this.joinedRoomList) {
+            console.log(roomId, this.appServiceUserId);
+            this.membershipCache.setMemberEntry(roomId, this.appServiceUserId, "join");
+        }
+
         log.info("Joining mapped Matrix rooms...");
         await this.joinMappedMatrixRooms();
         log.info("Syncing relevant membership lists...");

--- a/src/bridge/MemberListSyncer.ts
+++ b/src/bridge/MemberListSyncer.ts
@@ -308,6 +308,7 @@ export class MemberListSyncer {
         this.usersToJoin = entries.length;
         // take the first entry and inject a join event
         const joinNextUser = () => {
+            this.usersToJoin--;
             const entry = entries.shift();
             if (!entry) {
                 d.resolve();
@@ -321,7 +322,6 @@ export class MemberListSyncer {
                 "Injecting join event for %s in %s (%s left) is_frontier=%s",
                 entry.userId, entry.roomId, entries.length, entry.frontier
             );
-            this.usersToJoin--;
             Bluebird.cast(injectJoinFn(entry.roomId, entry.userId, entry.displayName, entry.frontier)).timeout(
                 server.getMemberListFloodDelayMs()
             ).then(() => {

--- a/src/datastore/DataStore.ts
+++ b/src/datastore/DataStore.ts
@@ -164,5 +164,7 @@ export interface DataStore {
 
     getLastSeenTimeForUsers(): Promise<{ user_id: string; ts: number }[]>;
 
+    getAllUserIds(): Promise<string[]>;
+
     destroy(): Promise<void>;
 }

--- a/src/datastore/NedbDataStore.ts
+++ b/src/datastore/NedbDataStore.ts
@@ -618,6 +618,10 @@ export class NeDBDataStore implements DataStore {
         }));
     }
 
+    public async getAllUserIds() {
+        return this.userStore.select({ type: "matrix"}, (e) => e.id);
+    }
+
     public async roomUpgradeOnRoomMigrated() {
         // this can no-op, because the matrix-appservice-bridge library will take care of it.
     }

--- a/src/datastore/NedbDataStore.ts
+++ b/src/datastore/NedbDataStore.ts
@@ -619,7 +619,8 @@ export class NeDBDataStore implements DataStore {
     }
 
     public async getAllUserIds() {
-        return this.userStore.select({ type: "matrix"}, (e) => e.id);
+        const docs = await this.userStore.select({ type: "matrix" });
+        return docs.map((e: {id: string}) => e.id);
     }
 
     public async roomUpgradeOnRoomMigrated() {

--- a/src/datastore/postgres/PgDataStore.ts
+++ b/src/datastore/postgres/PgDataStore.ts
@@ -447,7 +447,7 @@ export class PgDataStore implements DataStore {
             return null;
         }
         const row = res.rows[0];
-        return new MatrixUser(row.user_id, row.data);
+        return new MatrixUser(row.user_id, JSON.parse(row.data));
     }
 
     public async getUserFeatures(userId: string): Promise<UserFeatures> {
@@ -521,6 +521,11 @@ export class PgDataStore implements DataStore {
     public async getLastSeenTimeForUsers(): Promise<{ user_id: string, ts: number }[]> {
         const res = await this.pgPool.query(`SELECT * FROM last_seen`);
         return res.rows;
+    }
+
+    public async getAllUserIds() {
+        const res = await this.pgPool.query(`SELECT user_id FROM matrix_users`);
+        return res.rows.map((u) => u.user_id);
     }
 
     public async ensureSchema() {

--- a/types/matrix-appservice-bridge/index.d.ts
+++ b/types/matrix-appservice-bridge/index.d.ts
@@ -133,7 +133,7 @@ declare module 'matrix-appservice-bridge' {
         db: Nedb
         delete (query: any): Promise<void>
         insert (query: any): Promise<void>
-        select (query: any, transformFn?: (item: Entry) => Entry): Promise<any>
+        select (query: any, transformFn?: (item: Entry) => any): Promise<any>
         inspect: () => string;
     }
 
@@ -273,9 +273,14 @@ declare module 'matrix-appservice-bridge' {
     }
 
     export class StateLookup {
-            constructor(opts: {})
-            onEvent(event: unknown): void;
-            trackRoom(roomId: string): Promise<void>;
-            getState(roomId: string, type: string): any[];
+        constructor(opts: {})
+        onEvent(event: unknown): void;
+        trackRoom(roomId: string): Promise<void>;
+        getState(roomId: string, type: string): any[];
+    }
+
+    export class MembershipCache {
+        constructor();
+        setMemberEntry(roomId: string, userId: string, membership: "join"): void;
     }
 }


### PR DESCRIPTION
This change makes use of an exposed MembershipCache object that allows us to cheat and store membership we know about ahead of time. This PR makes two changes:

- We store every room the bot is joined to on startup, so it doesn't attempt to join when fetching state for rooms. While a /join will no-op on the synapse side, 15k of joins is still something we would like to avoid.

- We also check the DB to find all irc virtual users and store them inside the membership under a fake room_id. Doing this means the bridge won't attempt to register those users, as being joined to a room in the membership cache marks you as registered. This is handy, as it reduces our /register calls on startup massively.