### PR TITLE
Store room visibility cache in the DB

### DIFF
--- a/changelog.d/882.misc
+++ b/changelog.d/882.misc
@@ -1,0 +1,1 @@
+Store room visibility in the datastore to avoid making wasted HTTP calls

--- a/changelog.d/882.misc
+++ b/changelog.d/882.misc
@@ -1,1 +1,1 @@
-Store room visibility in the datastore to avoid making wasted HTTP calls
+Room directory visibility state for bridged rooms is now cached in the database

--- a/src/bridge/PublicitySyncer.ts
+++ b/src/bridge/PublicitySyncer.ts
@@ -200,10 +200,19 @@ export class PublicitySyncer {
         }
 
         const cli = this.ircBridge.getAppServiceBridge().getBot().getClient();
-
         // Update rooms to correct visibilities
+        let currentStates: {[roomId: string]: string} = {};
+
+        // Assume private by default
+        roomIds.forEach((r) => currentStates[r] = "private"); 
+
+        currentStates = {
+            ...currentStates,
+            ...await this.ircBridge.getStore().getRoomsVisibility(roomIds),
+        };
+         
         const promises = roomIds.map(async (roomId) => {
-            const currentState = await this.ircBridge.getStore().getRoomVisibility(roomId);
+            const currentState = currentStates[roomId];
             const correctState: "private"|"public" = shouldBePrivate(roomId, []) ? 'private' : 'public';
 
             // Use the server network ID of the first mapping

--- a/src/bridge/PublicitySyncer.ts
+++ b/src/bridge/PublicitySyncer.ts
@@ -216,7 +216,8 @@ export class PublicitySyncer {
                     await this.ircBridge.getStore().setRoomVisibility(roomId, correctState);
                     // Update cache
                     this.visibilityMap.roomVisibilities[roomId] = correctState;
-                } catch (ex) {
+                }
+                catch (ex) {
                     log.error(`Failed to setRoomDirectoryVisibility (${ex.message})`);
                 }
             }

--- a/src/bridge/PublicitySyncer.ts
+++ b/src/bridge/PublicitySyncer.ts
@@ -204,13 +204,13 @@ export class PublicitySyncer {
         let currentStates: {[roomId: string]: string} = {};
 
         // Assume private by default
-        roomIds.forEach((r) => currentStates[r] = "private"); 
+        roomIds.forEach((r) => { currentStates[r] = "private" });
 
         currentStates = {
             ...currentStates,
             ...await this.ircBridge.getStore().getRoomsVisibility(roomIds),
         };
-         
+
         const promises = roomIds.map(async (roomId) => {
             const currentState = currentStates[roomId];
             const correctState: "private"|"public" = shouldBePrivate(roomId, []) ? 'private' : 'public';

--- a/src/bridge/RoomAccessSyncer.ts
+++ b/src/bridge/RoomAccessSyncer.ts
@@ -334,6 +334,8 @@ export class RoomAccessSyncer {
                     // only from the beginning.
                     enabled = server.getJoinRule() === "invite";
                     return this.setMatrixRoomAsInviteOnly(room, enabled);
+                case "s":
+                    break; // Handled above.
                 default:
                     // Not reachable, but warn anyway in case of future additions
                     req.log.warn(`onMode: Unhandled channel mode ${mode}`);

--- a/src/bridge/RoomAccessSyncer.ts
+++ b/src/bridge/RoomAccessSyncer.ts
@@ -319,7 +319,7 @@ export class RoomAccessSyncer {
             this.ircBridge.getStore().setModeForRoom(room.getId(), mode, enabled)
         ));
 
-        const promises = matrixRooms.map((room) => {
+        const promises = matrixRooms.map(async (room) => {
             switch (mode) {
                 case "k":
                 case "i":
@@ -328,18 +328,20 @@ export class RoomAccessSyncer {
                         room.getId()
                     );
                     if (enabled) {
-                        return this.setMatrixRoomAsInviteOnly(room, true);
+                        await this.setMatrixRoomAsInviteOnly(room, true);
                     }
-                    // don't "unlock"; the room may have been invite
-                    // only from the beginning.
-                    enabled = server.getJoinRule() === "invite";
-                    return this.setMatrixRoomAsInviteOnly(room, enabled);
+                    else {
+                        // don't "unlock"; the room may have been invite
+                        // only from the beginning.
+                        enabled = server.getJoinRule() === "invite";
+                        await this.setMatrixRoomAsInviteOnly(room, enabled);
+                    }
+                    break;
                 case "s":
                     break; // Handled above.
                 default:
                     // Not reachable, but warn anyway in case of future additions
                     req.log.warn(`onMode: Unhandled channel mode ${mode}`);
-                    return Promise.resolve();
             }
         });
 

--- a/src/datastore/DataStore.ts
+++ b/src/datastore/DataStore.ts
@@ -166,5 +166,9 @@ export interface DataStore {
 
     getAllUserIds(): Promise<string[]>;
 
+    getRoomVisibility(roomId: string): Promise<"public"|"private">;
+
+    setRoomVisibility(roomId: string, vis: "public"|"private"): Promise<void>;
+
     destroy(): Promise<void>;
 }

--- a/src/datastore/DataStore.ts
+++ b/src/datastore/DataStore.ts
@@ -166,7 +166,7 @@ export interface DataStore {
 
     getAllUserIds(): Promise<string[]>;
 
-    getRoomVisibility(roomId: string): Promise<"public"|"private">;
+    getRoomsVisibility(roomIds: string[]): Promise<{[roomId: string]: "public"|"private"}>;
 
     setRoomVisibility(roomId: string, vis: "public"|"private"): Promise<void>;
 

--- a/src/datastore/NedbDataStore.ts
+++ b/src/datastore/NedbDataStore.ts
@@ -623,6 +623,22 @@ export class NeDBDataStore implements DataStore {
         return docs.map((e: {id: string}) => e.id);
     }
 
+    public async getRoomVisibility(roomId: string) {
+        const room = await this.roomStore.getMatrixRoom(roomId);
+        if (!room) {
+            return "private";
+        }
+        return room.get("visibility") as "public"|"private";
+    }
+    public async setRoomVisibility(roomId: string, visibility: "public"|"private") {
+        let room = await this.roomStore.getMatrixRoom(roomId);
+        if (!room) {
+            room = new MatrixRoom(roomId);
+        }
+        room.set("visibility", visibility);
+        await this.roomStore.setMatrixRoom(room);
+    }
+
     public async roomUpgradeOnRoomMigrated() {
         // this can no-op, because the matrix-appservice-bridge library will take care of it.
     }

--- a/src/datastore/NedbDataStore.ts
+++ b/src/datastore/NedbDataStore.ts
@@ -630,6 +630,15 @@ export class NeDBDataStore implements DataStore {
         }
         return room.get("visibility") as "public"|"private";
     }
+
+    public async getRoomsVisibility(roomIds: string[]) {
+        const map: {[roomId: string]: "public"|"private"} = {};
+        for (const roomId of roomIds) {
+            map[roomId] = await this.getRoomVisibility(roomId);
+        }
+        return map;
+    }
+
     public async setRoomVisibility(roomId: string, visibility: "public"|"private") {
         let room = await this.roomStore.getMatrixRoom(roomId);
         if (!room) {

--- a/src/datastore/postgres/schema/v3.ts
+++ b/src/datastore/postgres/schema/v3.ts
@@ -1,0 +1,11 @@
+import { PoolClient } from "pg";
+
+export async function runSchema(connection: PoolClient) {
+    // Create schema
+    await connection.query(`
+    CREATE TABLE room_visibility (
+        room_id	TEXT UNIQUE NOT NULL,
+        visibility BOOLEAN NOT NULL
+    );
+    `);
+}


### PR DESCRIPTION
Soft dependency on #881 

Fixes #880 

This is a simple change which caches the room directory visibility in the database rather than just in memory, so that restarts do not spam the homeserver with requests.