### PR TITLE
Fix uploaded long message URL's not sent to IRC side

### DIFF
--- a/changelog.d/889.bugfix
+++ b/changelog.d/889.bugfix
@@ -1,0 +1,1 @@
+Fix uploaded long message URL's not sent to IRC side.

--- a/src/bridge/IrcBridge.ts
+++ b/src/bridge/IrcBridge.ts
@@ -602,13 +602,15 @@ export class IrcBridge {
     }
 
     public uploadTextFile(fileName: string, plaintext: string) {
-        return this.bridge.getIntent().getClient().uploadContent({
-            stream: new Buffer(plaintext),
-            name: fileName,
-            type: "text/plain; charset=utf-8",
-            rawResponse: false,
-            onlyContentUri: true,
-        });
+        return this.bridge.getIntent().getClient().uploadContent(
+            new Buffer(plaintext),
+            {
+                name: fileName,
+                type: "text/plain; charset=utf-8",
+                rawResponse: false,
+                onlyContentUri: true,
+            },
+        );
     }
 
     public async getMatrixUser(ircUser: IrcUser) {

--- a/types/matrix-appservice-bridge/index.d.ts
+++ b/types/matrix-appservice-bridge/index.d.ts
@@ -227,12 +227,11 @@ declare module 'matrix-appservice-bridge' {
         };
         deleteAlias(alias: string): Promise<void>;
         roomState(roomId: string): Promise<any[]>;
-        uploadContent(opts: {
-            stream: Buffer
+        uploadContent(file: Buffer, opts: {
             name: string,
             type: string,
-            rawResponse: false,
-            onlyContentUri: true,
+            rawResponse: boolean,
+            onlyContentUri: boolean,
         }): Promise<string>;
     }
 


### PR DESCRIPTION
The call was changed in #845 to instead of getting the raw response back, to get just the content
uri back. Due to wrong type definition of the uploadContent
method, the change actually made the raw response still get back
due to legacy defaults in uploadContent.

Refactor the call to pass the buffer as first argument and opts
as second. This has been preferred in matrix-js-sdk since 2016.

Refs: #887
Signed-off-by: Jason Robinson <jasonr@matrix.org>