### PR TITLE
Always use the latest client config when reconnecting

### DIFF
--- a/changelog.d/900.bugfix
+++ b/changelog.d/900.bugfix
@@ -1,0 +1,1 @@
+!storepass command now reconnects you with the new password.

--- a/changelog.d/900.bugfix
+++ b/changelog.d/900.bugfix
@@ -1,1 +1,1 @@
-!storepass command now reconnects you with the new password.
+The !storepass command now reconnects users with their new password.

--- a/spec/integ/admin-rooms.spec.js
+++ b/spec/integ/admin-rooms.spec.js
@@ -1116,6 +1116,39 @@ describe("Admin rooms", function() {
         await connectPromise;
     });
 
+    it("should be able to store a username:password with !storepass", async function() {
+        const password = "mynick:foopassword"
+        const sdk = env.clientMock._client(botUserId);
+
+        const sendPromise = sdk.sendEvent.and.callFake(async (roomId, _, content) => {
+            expect(roomId).toEqual(adminRoomId);
+            expect(content.msgtype).toEqual("m.notice");
+            expect(content.body).toEqual(
+                "Successfully stored password for irc.example. You will now be reconnected to IRC."
+            );
+            return {};
+        });
+        const disconnectPromise = env.ircMock._whenClient(roomMapping.server, userIdNick, "disconnect", () => { });
+        const connectPromise = env.ircMock._whenClient(roomMapping.server, userIdNick, "connect", (client) => {
+            const opts = client.opts;
+            expect(opts.password).toBe(password);
+        });
+
+        await env.mockAppService._trigger("type:m.room.message", {
+            content: {
+                body: `!storepass ${password}`,
+                msgtype: "m.text"
+            },
+            user_id: userId,
+            room_id: adminRoomId,
+            type: "m.room.message"
+        });
+        await sendPromise;
+        await disconnectPromise;
+        await connectPromise;
+    });
+
+
     it("should be able to remove a password with !removepass", async function() {
         const sdk = env.clientMock._client(botUserId);
 

--- a/src/irc/ClientPool.ts
+++ b/src/irc/ClientPool.ts
@@ -569,7 +569,7 @@ export class ClientPool {
         let cliConfig = bridgedClient.getClientConfig();
         if (bridgedClient.userId) {
             // We may have changed something between connections, so use the new config.
-            let newConfig = await this.store.getIrcClientConfig(bridgedClient.userId, bridgedClient.server.domain);
+            const newConfig = await this.store.getIrcClientConfig(bridgedClient.userId, bridgedClient.server.domain);
             if (newConfig) {
                 cliConfig = newConfig;
             }


### PR DESCRIPTION
This also tests that "user:pass" format passwords are correctly set.

The !storepass command now uses the correct password when reconnecting.