### PR TITLE
Perform membership operations linearly

### DIFF
--- a/changelog.d/905.misc
+++ b/changelog.d/905.misc
@@ -1,0 +1,1 @@
+Ensure that joins and leaves are performed linearly per-room.

--- a/src/bridge/IrcBridge.ts
+++ b/src/bridge/IrcBridge.ts
@@ -79,7 +79,6 @@ export class IrcBridge {
         }
         // Dependency graph
         this.matrixHandler = new MatrixHandler(this, this.config.matrixHandler);
-        this.ircHandler = new IrcHandler(this, this.config.ircHandler);
         if (!this.config.database && this.config.ircService.databaseUri) {
             log.warn("ircService.databaseUri is a deprecated config option." +
                      "Please use the database configuration block");
@@ -157,6 +156,7 @@ export class IrcBridge {
             },
             membershipCache: this.membershipCache,
         });
+        this.ircHandler = new IrcHandler(this, this.config.ircHandler);
 
         // By default the bridge will escape mxids, but the irc bridge isn't ready for this yet.
         MatrixUser.ESCAPE_DEFAULT = false;

--- a/src/util/MembershipQueue.ts
+++ b/src/util/MembershipQueue.ts
@@ -56,9 +56,8 @@ export class MembershipQueue {
     }
 
     public async queueMembership(item: QueueUserItem) {
-        const queueNumber = this.hashRoomId(item.roomId);
         try {
-            return await this.queuePool.enqueue("", item, queueNumber);
+            return await this.queuePool.enqueue("", item, this.hashRoomId(item.roomId));
         }
         catch (ex) {
             log.error(`Failed to handle membership: ${ex}`);

--- a/src/util/MembershipQueue.ts
+++ b/src/util/MembershipQueue.ts
@@ -82,7 +82,7 @@ export class MembershipQueue {
                 await intent.join(roomId);
             }
             else {
-                await intent.kick(roomId, userId, reason);
+                await intent[kickUser ? "kick" : "leave"](roomId, userId, reason);
             }
         }
         catch (ex) {
@@ -101,18 +101,10 @@ export class MembershipQueue {
     }
 
     private shouldRetry(ex: {code: string; errcode: string; httpStatus: number}, attempts: number): boolean {
-        if (attempts === ATTEMPTS_LIMIT) {
-            return false;
-        }
-        if (ex.code === "ECONNREFUSED") {
-            return true;
-        }
-        if (ex.errcode === "M_FORBIDDEN" || ex.httpStatus === 403) {
-            return false;
-        }
-        if (ex.errcode === "M_LIMIT_EXCEEDED" || ex.errcode === "M_UNKNOWN") {
-            return true;
-        }
-        return true;
+        return !(
+            attempts === ATTEMPTS_LIMIT ||
+            ex.errcode === "M_FORBIDDEN" ||
+            ex.httpStatus === 403
+        );
     }
 }

--- a/src/util/MembershipQueue.ts
+++ b/src/util/MembershipQueue.ts
@@ -1,0 +1,103 @@
+import { Bridge } from "matrix-appservice-bridge";
+import { BridgeRequest } from "../models/BridgeRequest";
+import getLogger from "../logging";
+import { QueuePool } from "./QueuePool";
+import QuickLRU from "quick-lru";
+
+const log = getLogger("MembershipQueue");
+
+/**
+ * This class processes membership changes in a queue.
+ */
+
+const CONCURRENT_ROOM_LIMIT = 8;
+const ATTEMPTS_LIMIT = 10;
+const JOIN_DELAY_MS = 250;
+const JOIN_DELAY_CAP_MS = 30 * 60 * 1000; // 30 mins
+const ROOM_QUEUE_CACHE_SIZE = 500;
+
+interface QueueUserItem {
+    type: "join"|"leave";
+    kickUser?: string;
+    reason?: string;
+    attempts: number;
+    roomId: string;
+    userId: string;
+    retry: boolean;
+    req: BridgeRequest;
+}
+
+export class MembershipQueue {
+    private roomIdIndexes: QuickLRU<string, number> = new QuickLRU({ maxSize: ROOM_QUEUE_CACHE_SIZE });
+    private queuePool: QueuePool<QueueUserItem> = new QueuePool(CONCURRENT_ROOM_LIMIT, this.serviceQueue.bind(this));
+
+    constructor(private bridge: Bridge) { }
+
+    public async join(roomId: string, userId: string, req: BridgeRequest, retry = true) {
+        return this.queueMembership({
+            roomId,
+            userId,
+            retry,
+            req,
+            attempts: 0,
+            type: "join",
+        });
+    }
+
+    public async leave(roomId: string, userId: string, req: BridgeRequest, retry = true, reason?: string, kickUser?: string) {
+        return this.queueMembership({
+            roomId,
+            userId,
+            retry,
+            req,
+            attempts: 0,
+            reason,
+            kickUser,
+            type: "leave",
+        })
+    }
+
+    public async queueMembership(item: QueueUserItem) {
+        const queueNumber = this.roomIdIndexes.get(item.roomId) || Math.ceil(Math.random() * CONCURRENT_ROOM_LIMIT -1);
+        this.roomIdIndexes.set(item.roomId, queueNumber);
+        log.debug(`${item.roomId} is assigned to ${queueNumber}`);
+        try {
+            return await this.queuePool.enqueue("", item, queueNumber);
+        } catch (ex) {
+            log.error(`Failed to handle membership: ${ex}`);
+            throw ex;
+        }
+    }
+
+    private async serviceQueue(item: QueueUserItem): Promise<void> {
+        log.debug(`${item.userId}@${item.roomId} -> ${item.type}`);
+        const { req, roomId, userId, reason, kickUser, attempts } = item;
+        const intent = this.bridge.getIntent(kickUser || userId);
+        try {
+            if (item.type === "join") {
+                await intent.join(roomId);
+            } else {
+                await intent.kick(roomId, userId, reason);
+            }
+        } catch (ex) {
+            if (!this.shouldRetry(ex, attempts)) {
+                return;
+            }
+            const delay = Math.min(
+                (JOIN_DELAY_MS * attempts) + (Math.random() * 500),
+                JOIN_DELAY_CAP_MS
+            );
+            req.log.warn(`Failed to join ${roomId}, delaying for ${delay}ms`);
+            req.log.debug(`Failed with: ${ex.errcode} ${ex.message}`);
+            await new Promise((r) => setTimeout(r, delay));
+            this.queueMembership(item);
+        }
+    }
+
+    private shouldRetry(ex: {errcode: string, message: string}, attempts: number): boolean {
+        if (attempts === ATTEMPTS_LIMIT) {
+            return false;
+        }
+        return true;
+    }
+}

--- a/src/util/MembershipQueue.ts
+++ b/src/util/MembershipQueue.ts
@@ -2,16 +2,12 @@ import { Bridge } from "matrix-appservice-bridge";
 import { BridgeRequest } from "../models/BridgeRequest";
 import getLogger from "../logging";
 import { QueuePool } from "./QueuePool";
-import QuickLRU from "quick-lru";
-
 const log = getLogger("MembershipQueue");
-
 
 const CONCURRENT_ROOM_LIMIT = 8;
 const ATTEMPTS_LIMIT = 10;
 const JOIN_DELAY_MS = 250;
 const JOIN_DELAY_CAP_MS = 30 * 60 * 1000; // 30 mins
-const ROOM_QUEUE_CACHE_SIZE = 500;
 
 interface QueueUserItem {
     type: "join"|"leave";

--- a/src/util/MembershipQueue.ts
+++ b/src/util/MembershipQueue.ts
@@ -100,7 +100,7 @@ export class MembershipQueue {
         }
     }
 
-    private shouldRetry(ex: {code: string; errcode: string, httpStatus: number}, attempts: number): boolean {
+    private shouldRetry(ex: {code: string; errcode: string; httpStatus: number}, attempts: number): boolean {
         if (attempts === ATTEMPTS_LIMIT) {
             return false;
         }


### PR DESCRIPTION
Fixes #883 

This splits out the queue behavior to a new utility class, which should hopefully be more readable.