### PR TITLE
Discard old PM rooms

### DIFF
--- a/changelog.d/919.bugfix
+++ b/changelog.d/919.bugfix
@@ -1,1 +1,1 @@
-If a new PM room is created for a IRC user, discard the old room.
+If a new DM room is created for a IRC user, discard the old room.

--- a/changelog.d/919.bugfix
+++ b/changelog.d/919.bugfix
@@ -1,0 +1,1 @@
+If a new PM room is created for a IRC user, discard the old room.

--- a/src/datastore/postgres/PgDataStore.ts
+++ b/src/datastore/postgres/PgDataStore.ts
@@ -306,7 +306,14 @@ export class PgDataStore implements DataStore {
     }
 
     public async setPmRoom(ircRoom: IrcRoom, matrixRoom: MatrixRoom, userId: string, virtualUserId: string): Promise<void> {
-        await this.pgPool.query("INSERT INTO pm_rooms VALUES ($1, $2, $3, $4, $5)", [
+        await this.pgPool.query(
+            PgDataStore.BuildUpsertStatement("pm_rooms", "ON CONSTRAINT cons_pm_rooms_matrix_irc_unique", [
+            "room_id",
+            "irc_domain",
+            "irc_nick",
+            "matrix_user_id",
+            "virtual_user_id",
+        ]), [
             matrixRoom.getId(),
             ircRoom.getDomain(),
             ircRoom.getChannel(),


### PR DESCRIPTION
Fixes #911 

When a new PM room gets created/assigned, we want to drop the old one.