### PR TITLE
fix startup without sentry config

### DIFF
--- a/changelog.d/921.bugfix
+++ b/changelog.d/921.bugfix
@@ -1,0 +1,1 @@
+Stop trying to use sentry when config.sentry.enabled is false

--- a/src/main.ts
+++ b/src/main.ts
@@ -68,7 +68,7 @@ export function generateRegistration(reg: AppServiceRegistration, config: Bridge
 }
 
 export async function runBridge(port: number, config: BridgeConfig, reg: AppServiceRegistration, isDBInMemory = false) {
-    if (config.sentry && config.sentry.dsn) {
+    if (config.sentry && config.sentry.enabled && config.sentry.dsn) {
         log.info("Sentry ENABLED");
         Sentry.init({
             dsn: config.sentry.dsn,


### PR DESCRIPTION
This actually respects config.sentry.enabled and thus makes the
bridge usable without configuring sentry.

https://matrix.to/#/!BAXLHOFjvDKUeLafmO:matrix.org/$afPi3kvwcVUp6zc3Th5fEVans8SqOFx+xPo9HQUbk/Q?via=matrix.org&via=chat.weho.st&via=privacytools.io

Signed-off-by: Simon Koerner <git@lubiland.de>