### PR TITLE
Fix a typo when moving to typescript that broke nedb support

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -113,7 +113,7 @@ export async function runBridge(port: number, config: BridgeConfig, reg: AppServ
         ircBridge.getAppServiceBridge().opts.roomStore = undefined;
         ircBridge.getAppServiceBridge().opts.userStore = undefined;
     }
-    else if (engine !== "nedb") {
+    else if (engine === "nedb") {
         // do nothing.
     }
     else {


### PR DESCRIPTION
It seems that when migrating to nedb, the comparison made when checking the database type was changed from equal to different, which effectively breaks nedb support.