### PR TITLE
Remove hooks/

### DIFF
--- a/changelog.d/951.removal
+++ b/changelog.d/951.removal
@@ -1,0 +1,1 @@
+Remove githooks, since they are unused.

--- a/hooks/install.sh
+++ b/hooks/install.sh
@@ -1,5 +1,0 @@
-#! /bin/bash
-
-DOT_GIT="$(dirname $0)/../.git"
-
-ln -s "../../hooks/pre-commit" "$DOT_GIT/hooks/pre-commit"

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,1 +1,0 @@
-./node_modules/.bin/eslint --fix lib spec


### PR DESCRIPTION
Replaces #948 

I've never really used them, and they are out of date at this point. It's easier to encourage people to just use `npm` directly.