### PR TITLE
Soft buffer messages for I->M

### DIFF
--- a/changelog.d/953.misc
+++ b/changelog.d/953.misc
@@ -1,0 +1,1 @@
+Queue IRC messages inbound to Matrix for a maximum of 5 seconds.

--- a/src/bridge/IrcHandler.ts
+++ b/src/bridge/IrcHandler.ts
@@ -931,10 +931,6 @@ export class IrcHandler {
         return true;
     }
 
-    private invalidateNickUserIdMap(server: IrcServer, channel: string) {
-        this.nickUserIdMapCache.delete(`${server.domain}:${channel}`);
-    }
-
     public incrementMetric(metric: MetricNames) {
         if (!this.callCountMetrics) { return; /* for TS-safety, but this shouldn't happen */ }
         if (this.callCountMetrics[metric] === undefined) {
@@ -957,6 +953,10 @@ export class IrcHandler {
             "mode": 0,
         };
         return metrics;
+    }
+
+    private invalidateNickUserIdMap(server: IrcServer, channel: string) {
+        this.nickUserIdMapCache.delete(`${server.domain}:${channel}`);
     }
 }
 

--- a/src/bridge/IrcHandler.ts
+++ b/src/bridge/IrcHandler.ts
@@ -17,7 +17,6 @@ import QuickLRU from "quick-lru";
 import { MembershipQueue } from "../util/MembershipQueue";
 
 const NICK_USERID_CACHE_MAX = 512;
-const ROOM_BUFFER_TIMEOUT = 5000; // 5 seconds.
 
 type MatrixMembership = "join"|"invite"|"leave"|"ban";
 
@@ -79,8 +78,6 @@ export class IrcHandler {
         [key in MetricNames]: number;
     };
     private registeredNicks: {[userId: string]: boolean} = {};
-
-    private roomPromiseBuffer: {[roomId: string]: Promise<unknown>} = {};
 
     constructor (
         private readonly ircBridge: IrcBridge,
@@ -601,11 +598,7 @@ export class IrcHandler {
                 "Relaying in room %s", room.getId()
             );
             promises.push(
-                this.bufferRequestToRoom(
-                    room.getId(), () =>
-                    this.ircBridge.sendMatrixAction(room, virtualMatrixUser, mxAction),
-                    req
-                ),
+                this.ircBridge.sendMatrixAction(room, virtualMatrixUser, mxAction)
             );
         }
         await Promise.all(promises);
@@ -967,49 +960,6 @@ export class IrcHandler {
 
     private invalidateNickUserIdMap(server: IrcServer, channel: string) {
         this.nickUserIdMapCache.delete(`${server.domain}:${channel}`);
-    }
-
-    /**
-     * This function "soft" queues functions acting on a single room. This means
-     * that messages will be processed in order, unless they take longer than `ROOM_BUFFER_TIMEOUT`
-     * milliseconds, in which case they will "jump" the queue. This ensures that messages will be
-     * hopefully ordered correctly, but will not arrive too late if the IRC bridge or the homeserver
-     * is running slow.
-     * @param roomId The roomId to key the queue on.
-     * @param req The request function
-     * @param request The request object for logging to.
-     */
-    private async bufferRequestToRoom(roomId: string, req: () => Promise<unknown>, request: BridgeRequest) {
-        this.roomPromiseBuffer[roomId] = (async () => {
-            // Get the existing promise.
-            const existing = this.roomPromiseBuffer[roomId] || Promise.resolve();
-            try {
-                // Wait ROOM_BUFFER_TIMEOUT ms for the promise to complete.
-                await new Promise((res, rej) => {
-                    const t = setTimeout(() => {
-                        rej(new Error("Timed out waiting"))
-                    }, ROOM_BUFFER_TIMEOUT);
-                    existing.then((data) => {
-                        res(data);
-                    }).catch((data) => {
-                        rej(data);
-                    }).finally(() => {
-                        clearTimeout(t);
-                    });
-                });
-                // If the promise didn't complete in time, continue with the next promise anyway.
-            }
-            catch (ex) {
-                if (ex.message === "Timed out waiting") {
-                    request.log.warn(`Request took >${ROOM_BUFFER_TIMEOUT} to complete.`);
-                }
-                else {
-                    request.log.error(ex.message);
-                }
-                // Fall through.
-            }
-            await req();
-        })();
     }
 }
 

--- a/src/irc/IrcEventBroker.ts
+++ b/src/irc/IrcEventBroker.ts
@@ -461,7 +461,6 @@ export class IrcEventBroker {
                     req, server, createUser(from), to, new IrcAction("notice", text)
                 ));
             }, req);
-                
         });
         this.hookIfClaimed(client, connInst, "topic", function(channel: string, topic: string, nick: string) {
             if (channel.indexOf("#") !== 0) { return; }
@@ -489,15 +488,15 @@ export class IrcEventBroker {
      * milliseconds, in which case they will "jump" the queue. This ensures that messages will be
      * hopefully ordered correctly, but will not arrive too late if the IRC bridge or the homeserver
      * is running slow.
-     * 
+     *
      * @param channel The channel to key the queue on.
      * @param req The request function
      * @param request The request object for logging to.
      */
-    private async bufferRequestToChannel(roomId: string, req: () => Promise<unknown>, request: BridgeRequest) {
-        this.channelReqBuffer[roomId] = (async () => {
+    private async bufferRequestToChannel(channel: string, req: () => Promise<unknown>, request: BridgeRequest) {
+        this.channelReqBuffer[channel] = (async () => {
             // Get the existing promise.
-            const existing = this.channelReqBuffer[roomId] || Promise.resolve();
+            const existing = this.channelReqBuffer[channel] || Promise.resolve();
             try {
                 // Wait ROOM_BUFFER_TIMEOUT ms for the promise to complete.
                 await new Promise((res, rej) => {


### PR DESCRIPTION
This is an attempt to fix #628.

Currently, we process messages asynchronously which is all fine and dandy except if someone tries to send about 10 lines at once (NickServ) then the ordering is extremely out of whack.

This PR tries to queue the messages in order at the earliest point so that small time fluctuations do not affect message ordering, while serious outages do not stop messages arriving at all. 