### PR TITLE
Disable !join when dynamic channels are off

### DIFF
--- a/src/bridge/AdminRoomHandler.ts
+++ b/src/bridge/AdminRoomHandler.ts
@@ -169,7 +169,7 @@ export class AdminRoomHandler {
         if (!ircChannel || ircChannel.indexOf("#") !== 0) {
             errText = "Format: '!join irc.example.com #channel [key]'";
         }
-        else if (server.hasInviteRooms() && !server.isInWhitelist(sender)) {
+        else if (!server.canJoinRooms(sender)) {
             errText = "You are not authorised to join channels on this server.";
         }
 

--- a/src/irc/IrcServer.ts
+++ b/src/irc/IrcServer.ts
@@ -289,9 +289,10 @@ export class IrcServer {
         });
     }
 
-    public hasInviteRooms() {
+    public canJoinRooms(userId: string) {
         return (
-            this.config.dynamicChannels.enabled && this.getJoinRule() === "invite"
+            this.config.dynamicChannels.enabled &&
+            (this.getJoinRule() === "public" || this.isInWhitelist(userId))
         );
     }
 


### PR DESCRIPTION
AFAICT this may lead to private, statically configured channels getting exposed to the public, as `hasInviteRooms` is `false` when `dynamicChannels.enabled` is off, thus the user is considered always "authorised to join channels".

I haven't tested if this is actually the case; I just sleep better when the `!join` command is immediately denied when `dynamicChannels.enabled` is off.