### PR TITLE
IrcServer: substitute $SERVER when generating a room alias from channel

### DIFF
--- a/changelog.d/958.bugfix
+++ b/changelog.d/958.bugfix
@@ -1,0 +1,3 @@
+Substitute `$SERVER` in `ircService.servers.*.dynamicChannels.aliasTemplate`
+when generating a room alias from channel (fixes thirdparty lookups and joining
+by IRC channel name from Riot).

--- a/src/irc/IrcServer.ts
+++ b/src/irc/IrcServer.ts
@@ -459,7 +459,9 @@ export class IrcServer {
 
     public getAliasFromChannel(channel: string) {
         const template = this.config.dynamicChannels.aliasTemplate;
-        return template.replace(/\$CHANNEL/, channel) + ":" + this.homeserverDomain;
+        let alias = template.replace(/\$CHANNEL/g, channel);
+        alias = alias.replace(/\$SERVER/g, this.domain);
+        return alias + ":" + this.homeserverDomain;
     }
 
     public getNick(userId: string, displayName?: string) {


### PR DESCRIPTION
Consider this configuration:
```
ircService:
  servers:
    irc.domain.tld:
      dynamicChannels:
        aliasTemplate: "#irc_$SERVER_$CHANNEL"
```
When Riot is then used to join #example on this network (using the network picker) the appservice offers to join `#irc_$SERVER_#example:homeserver.tld`.