### PR TITLE
Make sure a killed BridgedClient is dead, even if connect was never called

### DIFF
--- a/changelog.d/976.bugfix
+++ b/changelog.d/976.bugfix
@@ -1,0 +1,1 @@
+Make sure a killed BridgedClient is dead, even if connect was never called

--- a/src/bridge/AdminRoomHandler.ts
+++ b/src/bridge/AdminRoomHandler.ts
@@ -19,7 +19,7 @@ import { MatrixRoom, MatrixUser } from "matrix-appservice-bridge";
 import { IrcBridge } from "./IrcBridge";
 import { MatrixAction } from "../models/MatrixAction";
 import { IrcServer } from "../irc/IrcServer";
-import { BridgedClient } from "../irc/BridgedClient";
+import { BridgedClient, BridgedClientStatus } from "../irc/BridgedClient";
 import { IrcClientConfig } from "../models/IrcClientConfig";
 import { MatrixHandler } from "./MatrixHandler";
 import logging from "../logging";
@@ -335,11 +335,11 @@ export class AdminRoomHandler {
                 server, sender
             );
 
-            if (!bridgedClient.unsafeClient) {
+            if (bridgedClient.state.status != BridgedClientStatus.CONNECTED) {
                 throw new Error('Possibly disconnected');
             }
 
-            bridgedClient.unsafeClient.send(...sendArgs);
+            bridgedClient.state.client.send(...sendArgs);
         }
         catch (err) {
             const notice = new MatrixAction("notice", `${err}\n` );

--- a/src/bridge/IrcBridge.ts
+++ b/src/bridge/IrcBridge.ts
@@ -6,7 +6,7 @@ import { MatrixHandler } from "./MatrixHandler";
 import { MemberListSyncer } from "./MemberListSyncer";
 import { IrcServer } from "../irc/IrcServer";
 import { ClientPool } from "../irc/ClientPool";
-import { BridgedClient } from "../irc/BridgedClient";
+import { BridgedClient, BridgedClientStatus } from "../irc/BridgedClient";
 import { IrcUser } from "../models/IrcUser";
 import { IrcRoom } from "../models/IrcRoom";
 import { BridgeRequest, BridgeRequestErr } from "../models/BridgeRequest";
@@ -958,7 +958,7 @@ export class IrcBridge {
     public sendIrcAction(ircRoom: IrcRoom, bridgedClient: BridgedClient, action: IrcAction) {
         log.info(
             "Sending IRC message in %s as %s (connected=%s)",
-            ircRoom.channel, bridgedClient.nick, Boolean(bridgedClient.unsafeClient)
+            ircRoom.channel, bridgedClient.nick, Boolean(bridgedClient.state.status == BridgedClientStatus.CONNECTED)
         );
         return bridgedClient.sendAction(ircRoom, action);
     }

--- a/src/bridge/MatrixHandler.ts
+++ b/src/bridge/MatrixHandler.ts
@@ -5,7 +5,7 @@ import { IrcUser } from "../models/IrcUser";
 import { MatrixAction, MatrixMessageEvent } from "../models/MatrixAction";
 import { IrcRoom } from "../models/IrcRoom";
 import logging from "../logging";
-import { BridgedClient } from "../irc/BridgedClient";
+import { BridgedClient, BridgedClientStatus } from "../irc/BridgedClient";
 import { IrcServer } from "../irc/IrcServer";
 import { IrcAction } from "../models/IrcAction";
 import { toIrcLowerCase } from "../irc/formatting";
@@ -908,13 +908,13 @@ export class MatrixHandler {
         }
 
         // Check for the existance of the getSplitMessages method.
-        if (!(ircClient.unsafeClient && ircClient.unsafeClient.getSplitMessages)) {
+        if (!(ircClient.state.status == BridgedClientStatus.CONNECTED && ircClient.state.client.getSplitMessages)) {
             await this.ircBridge.sendIrcAction(ircRoom, ircClient, ircAction);
             return;
         }
 
         // Generate an array of individual messages that would be sent
-        const potentialMessages = ircClient.unsafeClient.getSplitMessages(ircRoom.channel, text);
+        const potentialMessages = ircClient.state.client.getSplitMessages(ircRoom.channel, text);
         const lineLimit = ircRoom.server.getLineLimit();
 
         if (potentialMessages.length <= lineLimit) {

--- a/src/bridge/PublicitySyncer.ts
+++ b/src/bridge/PublicitySyncer.ts
@@ -1,6 +1,7 @@
 import logger from "../logging";
 import { IrcBridge } from "./IrcBridge";
 import { IrcServer } from "../irc/IrcServer";
+import { BridgedClientStatus } from "../irc/BridgedClient";
 
 const log = logger("PublicitySyncer");
 
@@ -49,11 +50,11 @@ export class PublicitySyncer {
     public initModeForChannel(server: IrcServer, chan: string) {
         return this.ircBridge.getBotClient(server).then(
             (client) => {
-                if (!client.unsafeClient) {
+                if (client.state.status != BridgedClientStatus.CONNECTED) {
                     throw Error("Can't request modes, bot client not connected")
                 }
                 log.info(`Bot requesting mode for ${chan} on ${server.domain}`);
-                client.unsafeClient.mode(chan);
+                client.state.client.mode(chan);
             },
             (err) => {
                 log.error(`Could not request mode of ${chan} (${err.message})`);

--- a/src/bridge/RoomAccessSyncer.ts
+++ b/src/bridge/RoomAccessSyncer.ts
@@ -3,6 +3,7 @@ import { IrcBridge } from "./IrcBridge";
 import { BridgeRequest } from "../models/BridgeRequest";
 import { IrcServer } from "../irc/IrcServer";
 import { MatrixRoom } from "matrix-appservice-bridge";
+import { BridgedClientStatus } from "../irc/BridgedClient";
 const log = getLogger("RoomAccessSyncer");
 
 const MODES_TO_WATCH = [
@@ -114,11 +115,11 @@ export class RoomAccessSyncer {
         let userId = null;
         if (nick !== null && bridgedClient) {
             userId = bridgedClient.userId;
-            if (!bridgedClient.unsafeClient) {
+            if (bridgedClient.state.status != BridgedClientStatus.CONNECTED) {
                 req.log.info(`Bridged client for ${nick} has no IRC client.`);
                 return;
             }
-            const client = bridgedClient.unsafeClient;
+            const client = bridgedClient.state.client;
             const chanData = client.chanData(channel);
             if (!(chanData && chanData.users)) {
                 req.log.error(`No channel data for ${channel}`);

--- a/src/irc/BridgedClient.ts
+++ b/src/irc/BridgedClient.ts
@@ -58,16 +58,34 @@ export interface BridgedClientLogger {
 
 export const illegalCharactersRegex = /[^A-Za-z0-9\]\[\^\\\{\}\-`_\|]/g;
 
+export enum BridgedClientStatus {
+    CREATED,
+    CONNECTING,
+    CONNECTED,
+    DEAD,
+    KILLED,
+}
+
+interface NotConnected {
+    status: BridgedClientStatus.CREATED | BridgedClientStatus.CONNECTING |
+        BridgedClientStatus.DEAD | BridgedClientStatus.KILLED;
+}
+
+interface Connected {
+    status: BridgedClientStatus.CONNECTED;
+    client: Client;
+    inst: ConnectionInstance;
+}
+
+type State = Connected | NotConnected
+
 export class BridgedClient extends EventEmitter {
     public readonly userId: string|null;
     public readonly displayName: string|null;
     private _nick: string;
     public readonly id: string;
     private readonly password?: string;
-    private _unsafeClient: Client|null = null;
     private lastActionTs: number;
-    private inst: ConnectionInstance|null = null;
-    private instCreationFailed = false;
     private _explicitDisconnect = false;
     private _disconnectReason: string|null = null;
     private _chanList: Set<string> = new Set();
@@ -76,6 +94,9 @@ export class BridgedClient extends EventEmitter {
     private cachedOperatorNicksInfo: {[channel: string]: GetNicksResponseOperators} = {};
     private idleTimeout: NodeJS.Timer|null = null;
     private whoisPendingNicks: Set<string> = new Set();
+    private _state: State = {
+        status: BridgedClientStatus.CREATED
+    };
     /**
      * Create a new bridged IRC client.
      * @constructor
@@ -150,8 +171,8 @@ export class BridgedClient extends EventEmitter {
         return Array.from(this._chanList);
     }
 
-    public get unsafeClient() {
-        return this._unsafeClient;
+    public get state() {
+        return this._state;
     }
 
     public get nick(): string {
@@ -164,21 +185,19 @@ export class BridgedClient extends EventEmitter {
     }
 
     public kill(reason?: string) {
-        // Nullify so that no further commands can be issued
-        //  via unsafeClient, which should be null checked
-        //  anyway as it is not instantiated until a connection
-        //  has occurred.
-        this._unsafeClient = null;
+        const state = this.state;
+        // so that no further commands can be issued
+        this._state = {
+            status: BridgedClientStatus.KILLED
+        }
+
         // kill connection instance
         log.info('Killing client ', this.nick);
-        return this.disconnect("killed", reason);
+        return this.disconnectWithState(state, "killed", reason);
     }
 
     public isDead() {
-        if (this.instCreationFailed || (this.inst && this.inst.dead)) {
-            return true;
-        }
-        return false;
+        return this.state.status == BridgedClientStatus.DEAD || this.state.status == BridgedClientStatus.KILLED;
     }
 
     public toString() {
@@ -191,6 +210,10 @@ export class BridgedClient extends EventEmitter {
      */
     public async connect(): Promise<ConnectionInstance> {
         let identResolver: (() => void) | undefined;
+
+        this._state = {
+            status: BridgedClientStatus.CONNECTING
+        }
 
         try {
             const nameInfo = await this.identGenerator.getIrcNames(
@@ -228,8 +251,11 @@ export class BridgedClient extends EventEmitter {
                 this.onConnectionCreated(inst, nameInfo, identResolver!);
             });
 
-            this.inst = connInst;
-            this._unsafeClient = connInst.client;
+            this._state = {
+                status: BridgedClientStatus.CONNECTED,
+                inst: connInst,
+                client: connInst.client,
+            }
             this.emit("client-connected", this);
             // we may have been assigned a different nick, so update it from source
             this._nick = connInst.client.nick;
@@ -280,7 +306,9 @@ export class BridgedClient extends EventEmitter {
         }
         catch (err) {
             this.log.debug("Failed to connect.");
-            this.instCreationFailed = true;
+            this._state = {
+                status: BridgedClientStatus.DEAD
+            }
             if (identResolver) {
                 identResolver();
             }
@@ -303,11 +331,15 @@ export class BridgedClient extends EventEmitter {
     }
 
     public disconnect(reason: InstanceDisconnectReason, textReason?: string, explicit = true) {
+        return this.disconnectWithState(this.state, reason, textReason, explicit);
+    }
+
+    private disconnectWithState(state: State, reason: InstanceDisconnectReason, textReason?: string, explicit = true) {
         this._explicitDisconnect = explicit;
-        if (!this.inst || this.inst.dead) {
+        if (state.status != BridgedClientStatus.CONNECTED) {
             return Promise.resolve();
         }
-        return this.inst.disconnect(reason, textReason);
+        return state.inst.disconnect(reason, textReason);
     }
 
     /**
@@ -348,10 +380,11 @@ export class BridgedClient extends EventEmitter {
     }
 
     private async sendNickCommand(nick: string): Promise<string> {
-        if (!this.unsafeClient) {
+        if (this.state.status != BridgedClientStatus.CONNECTED) {
             throw Error("You are not connected to the network.");
         }
-        const client = this.unsafeClient;
+        const client = this.state.client;
+
         return new Promise((resolve, reject) => {
             // These are nullified to prevent the linter from thinking these should be consts.
             let nickListener: ((old: string, n: string) => void) | null = null;
@@ -401,7 +434,7 @@ export class BridgedClient extends EventEmitter {
     }
 
     public leaveChannel(channel: string, reason = "User left") {
-        if (!this.inst || this.inst.dead || !this.unsafeClient) {
+        if (this.state.status != BridgedClientStatus.CONNECTED) {
             return Promise.resolve(); // we were never connected to the network.
         }
         if (channel.indexOf("#") !== 0) {
@@ -413,7 +446,7 @@ export class BridgedClient extends EventEmitter {
         const defer = promiseutil.defer();
         this.removeChannel(channel);
         this.log.debug("Leaving channel %s", channel);
-        this.unsafeClient.part(channel, reason, () => {
+        this.state.client.part(channel, reason, () => {
             this.log.debug("Left channel %s", channel);
             defer.resolve();
         });
@@ -427,10 +460,10 @@ export class BridgedClient extends EventEmitter {
 
     public kick(nick: string, channel: string, reason: string) {
         reason = reason || "User kicked";
-        if (!this.inst || this.inst.dead || !this.unsafeClient) {
+        if (this.state.status != BridgedClientStatus.CONNECTED) {
             return Promise.resolve(); // we were never connected to the network.
         }
-        if (Object.keys(this.unsafeClient.chans).indexOf(channel) === -1) {
+        if (Object.keys(this.state.client.chans).indexOf(channel) === -1) {
             // we were never joined to it. We need to be joined to it to kick people.
             return Promise.resolve();
         }
@@ -438,7 +471,7 @@ export class BridgedClient extends EventEmitter {
             return Promise.resolve(); // PM room
         }
 
-        const c = this.unsafeClient;
+        const c = this.state.client;
 
         return new Promise((resolve) => {
             this.log.debug("Kicking %s from channel %s", nick, channel);
@@ -476,10 +509,10 @@ export class BridgedClient extends EventEmitter {
      * @param {string} nick : The nick to call /whois on
      */
     public async whois(nick: string): Promise<{ server: IrcServer; nick: string; msg: string}|null> {
-        if (!this.unsafeClient) {
+        if (this.state.status != BridgedClientStatus.CONNECTED) {
             throw Error("unsafeClient not ready yet");
         }
-        const client = this.unsafeClient;
+        const client = this.state.client;
         let timeout: NodeJS.Timeout|null = null;
         let errorHandler!: (msg: IrcMessage) => void;
         try {
@@ -585,11 +618,10 @@ export class BridgedClient extends EventEmitter {
                 if (prefix === "@") {
                     return true;
                 }
-                const cli = this.unsafeClient;
-                if (!cli) {
+                if (this.state.status != BridgedClientStatus.CONNECTED) {
                     throw new Error("Missing client");
                 }
-                if (cli.isUserPrefixMorePowerfulThan(prefix, "@")) {
+                if (this.state.client.isUserPrefixMorePowerfulThan(prefix, "@")) {
                     return true;
                 }
             }
@@ -618,11 +650,11 @@ export class BridgedClient extends EventEmitter {
      */
     public getNicks(channel: string): Bluebird<GetNicksResponse> {
         return new Bluebird((resolve, reject) => {
-            if (!this.unsafeClient) {
+            if (this.state.status != BridgedClientStatus.CONNECTED) {
                 reject(Error("unsafeClient not ready yet"));
                 return;
             }
-            this.unsafeClient.names(channel, (channelName: string, names: {[nick: string]: string}) => {
+            this.state.client.names(channel, (channelName: string, names: {[nick: string]: string}) => {
                 // names maps nicks to chan op status, where '@' indicates chan op
                 // names = {'nick1' : '', 'nick2' : '@', ...}
                 resolve({
@@ -679,12 +711,12 @@ export class BridgedClient extends EventEmitter {
             n = "M" + n;
         }
 
-        if (this.unsafeClient) {
+        if (this.state.status == BridgedClientStatus.CONNECTED) {
             // nicks can't be too long
             let maxNickLen = 9; // RFC 1459 default
-            if (this.unsafeClient.supported &&
-                    typeof this.unsafeClient.supported.nicklength == "number") {
-                maxNickLen = this.unsafeClient.supported.nicklength;
+            if (this.state.client.supported &&
+                    typeof this.state.client.supported.nicklength == "number") {
+                maxNickLen = this.state.client.supported.nicklength;
             }
             if (n.length > maxNickLen) {
                 if (throwOnInvalid) {
@@ -762,6 +794,14 @@ export class BridgedClient extends EventEmitter {
                 // If we've been banned, this is intentional.
                 this._explicitDisconnect = true;
             }
+
+            // make sure a killed connection stays killed
+            if (this.state.status != BridgedClientStatus.KILLED) {
+                this._state = {
+                    status: BridgedClientStatus.DEAD,
+                }
+            }
+
             this.emit("client-disconnected", this);
             this.eventBroker.sendMetadata(this,
                 "Your connection to the IRC network '" + this.server.domain +
@@ -777,13 +817,13 @@ export class BridgedClient extends EventEmitter {
     }
 
     private async setTopic(room: IrcRoom, topic: string): Promise<void> {
-        if (!this.unsafeClient) {
+        if (this.state.status != BridgedClientStatus.CONNECTED) {
             throw Error("unsafeClient not ready yet");
         }
         // join the room if we haven't already
         await this.joinChannel(room.channel)
         this.log.info("Setting topic to %s in channel %s", topic, room.channel);
-        return this.unsafeClient.send("TOPIC", room.channel, topic);
+        return this.state.client.send("TOPIC", room.channel, topic);
     }
 
     private async sendMessage(room: IrcRoom, msgType: string, text: string, expiryTs: number) {
@@ -800,18 +840,18 @@ export class BridgedClient extends EventEmitter {
                 return;
             }
 
-            if (!this.unsafeClient) {
+            if (this.state.status != BridgedClientStatus.CONNECTED) {
                 return;
             }
 
             if (msgType == "action") {
-                await this.unsafeClient.action(room.channel, text);
+                await this.state.client.action(room.channel, text);
             }
             else if (msgType == "notice") {
-                await this.unsafeClient.notice(room.channel, text);
+                await this.state.client.notice(room.channel, text);
             }
             else if (msgType == "message") {
-                await this.unsafeClient.say(room.channel, text);
+                await this.state.client.say(room.channel, text);
             }
             defer.resolve();
         }
@@ -823,7 +863,7 @@ export class BridgedClient extends EventEmitter {
     }
 
     public joinChannel(channel: string, key?: string, attemptCount = 1): Bluebird<IrcRoom> {
-        if (!this.unsafeClient) {
+        if (this.state.status != BridgedClientStatus.CONNECTED) {
             // we may be trying to join before we've connected, so check and wait
             if (this.connectDefer && this.connectDefer.promise.isPending()) {
                 return this.connectDefer.promise.then(() => {
@@ -832,7 +872,7 @@ export class BridgedClient extends EventEmitter {
             }
             return Bluebird.reject(new Error("No client"));
         }
-        if (Object.keys(this.unsafeClient.chans).indexOf(channel) !== -1) {
+        if (Object.keys(this.state.client.chans).indexOf(channel) !== -1) {
             return Bluebird.resolve(new IrcRoom(this.server, channel));
         }
         if (channel.indexOf("#") !== 0) {
@@ -845,7 +885,7 @@ export class BridgedClient extends EventEmitter {
         const defer = promiseutil.defer() as promiseutil.Defer<IrcRoom>;
         this.log.debug("Joining channel %s", channel);
         this.addChannel(channel);
-        const client = this.unsafeClient;
+        const client = this.state.client;
         // listen for failures to join a channel (e.g. +i, +k)
         const failFn = (err: IrcMessage) => {
             if (!err || !err.args) { return; }
@@ -869,7 +909,7 @@ export class BridgedClient extends EventEmitter {
 
         // add a timeout to try joining again
         setTimeout(() => {
-            if (!this.unsafeClient) {
+            if (this.state.status != BridgedClientStatus.CONNECTED) {
                 log.error(
                     `Could not try to join: no client for ${this.nick}, channel = ${channel}`
                 );
@@ -878,7 +918,7 @@ export class BridgedClient extends EventEmitter {
             // promise isn't resolved yet and we still want to join this channel
             if (defer.promise.isPending() && this._chanList.has(channel)) {
                 // we may have joined but didn't get the callback so check the client
-                if (Object.keys(this.unsafeClient.chans).indexOf(channel) !== -1) {
+                if (Object.keys(this.state.client.chans).indexOf(channel) !== -1) {
                     // we're joined
                     this.log.debug("Timed out joining %s - didn't get callback but " +
                         "are now joined. Resolving.", channel);
@@ -908,7 +948,7 @@ export class BridgedClient extends EventEmitter {
         }
 
         // send the JOIN with a key if it was specified.
-        this.unsafeClient.join(channel + (key ? " " + key : ""), () => {
+        this.state.client.join(channel + (key ? " " + key : ""), () => {
             this.log.debug("Joined channel %s", channel);
             client.removeListener("error", failFn);
             const room = new IrcRoom(this.server, channel);

--- a/src/irc/ClientPool.ts
+++ b/src/irc/ClientPool.ts
@@ -21,7 +21,7 @@ import { BridgeRequest } from "../models/BridgeRequest";
 import { IrcClientConfig } from "../models/IrcClientConfig";
 import { IrcServer } from "../irc/IrcServer";
 import { PrometheusMetrics, MatrixUser, MatrixRoom } from "matrix-appservice-bridge";
-import { BridgedClient } from "./BridgedClient";
+import { BridgedClient, BridgedClientStatus } from "./BridgedClient";
 import { IrcBridge } from "../bridge/IrcBridge";
 import { IdentGenerator } from "./IdentGenerator";
 import { Ipv6Generator } from "./Ipv6Generator";
@@ -514,10 +514,10 @@ export class ClientPool {
     private onClientConnected(bridgedClient: BridgedClient): void {
         const server = bridgedClient.server;
         const oldNick = bridgedClient.nick;
-        if (!bridgedClient.unsafeClient) {
+        if (bridgedClient.state.status != BridgedClientStatus.CONNECTED) {
             return;
         }
-        const actualNick = bridgedClient.unsafeClient.nick;
+        const actualNick = bridgedClient.state.client.nick;
 
         // remove the pending nick we had set for this user
         this.virtualClients[server.domain].pending.delete(oldNick);

--- a/src/irc/IrcEventBroker.ts
+++ b/src/irc/IrcEventBroker.ts
@@ -88,7 +88,7 @@ import { ProcessedDict } from "../util/ProcessedDict";
 import { getLogger } from "../logging";
 import { Bridge } from "matrix-appservice-bridge";
 import { ClientPool } from "./ClientPool";
-import { BridgedClient } from "./BridgedClient";
+import { BridgedClient, BridgedClientStatus } from "./BridgedClient";
 import { IrcMessage, ConnectionInstance } from "./ConnectionInstance";
 import { IrcHandler } from "../bridge/IrcHandler";
 
@@ -354,7 +354,7 @@ export class IrcEventBroker {
             }
             // chain off an onMode after the onJoin has been processed.
             return promise.then(() => {
-                if (!client.unsafeClient) {
+                if (client.state.status != BridgedClientStatus.CONNECTED) {
                     req.log.error("No client exists to set onMode for " + name.nick);
                     return null;
                 }
@@ -370,14 +370,14 @@ export class IrcEventBroker {
                         prefixLetter = prefix;
                         continue;
                     }
-                    if (client.unsafeClient.isUserPrefixMorePowerfulThan(prefixLetter, prefix)) {
+                    if (client.state.client.isUserPrefixMorePowerfulThan(prefixLetter, prefix)) {
                         prefixLetter = prefix;
                     }
                 }
                 if (!prefixLetter) {
                     return null;
                 }
-                const modeLetter = client.unsafeClient.modeForPrefix[prefixLetter];
+                const modeLetter = client.state.client.modeForPrefix[prefixLetter];
                 if (!modeLetter) {
                     return null;
                 }

--- a/src/provisioning/Provisioner.ts
+++ b/src/provisioning/Provisioner.ts
@@ -12,7 +12,7 @@ import * as promiseutil from "../promiseutil";
 import * as express from "express";
 import { IrcServer } from "../irc/IrcServer";
 import { IrcUser } from "../models/IrcUser";
-import { BridgedClient, GetNicksResponseOperators } from "../irc/BridgedClient";
+import { BridgedClient, GetNicksResponseOperators, BridgedClientStatus } from "../irc/BridgedClient";
 import { BridgeStateSyncer } from "../bridge/BridgeStateSyncer";
 
 const log = logging("Provisioner");
@@ -1101,10 +1101,10 @@ export class Provisioner {
 
     // Using ISUPPORT rules supported by MatrixBridge bot, case map ircChannel
     private static caseFold(cli: BridgedClient, channel: string) {
-        if (!cli.unsafeClient) {
+        if (cli.state.status != BridgedClientStatus.CONNECTED) {
             log.warn(`Could not case map ${channel} - BridgedClient has no IRC client`);
             return channel;
         }
-        return cli.unsafeClient._toLowerCase(channel);
+        return cli.state.client._toLowerCase(channel);
     }
 }


### PR DESCRIPTION
If for some reason `connect()` gets never called on a `BridgedClient` you will end up in a situation described in #944. The problem is that there is no way to solve this currently.
You can use the `!quit` command which calls `kill()` on `BridgedClient`, but that does not change the state of `isDead()`. This undying `BridgedClient` will remain around until the bridge gets restarted.

Fix #944
