### PR TITLE
Add .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,5 @@
+.vscode
+.nyc_output
+data
+tsconfig.tsbuildinfo
+*.log

--- a/changelog.d/991.misc
+++ b/changelog.d/991.misc
@@ -1,0 +1,1 @@
+Add `.npmignore`


### PR DESCRIPTION
Because this is needed to avoid all the files we do not want to package.