### PR TITLE
Reconnect users to channels synchronously

### DIFF
--- a/changelog.d/995.bugfix
+++ b/changelog.d/995.bugfix
@@ -1,0 +1,1 @@
+Fix a bug where users with high numbers of channels would flood the ircd and be stuck trying to connect forever.

--- a/src/irc/BridgedClient.ts
+++ b/src/irc/BridgedClient.ts
@@ -286,9 +286,10 @@ export class BridgedClient extends EventEmitter {
             "Reconnected %s@%s", this.nick, this.server.domain
         );
         this.log.info("Rejoining %s channels", this.chanList.length);
-        await Promise.all(this.chanList.map((c: string) => {
-            return this.joinChannel(c);
-        }));
+        // This needs to be synchronous
+        for (const channel of this.chanList) {
+            await this.joinChannel(channel);
+        }
         this.log.info("Rejoined channels");
     }
 


### PR DESCRIPTION
Trying to join all the channels at once leads to `Excess Flood` errors from the ircd.