### PR TITLE
When changing irc nick, hide events from the new nick

### DIFF
--- a/changelog.d/996.bugfix
+++ b/changelog.d/996.bugfix
@@ -1,0 +1,1 @@
+Matrix users who change nicks will no longer cause ghosts to appear in rooms with their new nick.

--- a/src/irc/BridgedClient.ts
+++ b/src/irc/BridgedClient.ts
@@ -337,6 +337,7 @@ export class BridgedClient extends EventEmitter {
                 if (nickErrListener) {
                     client.removeListener("error", nickErrListener);
                 }
+                this.emit("pending-nick.remove", validNick);
                 reject(new Error("Timed out waiting for a response to change nick."));
             }, NICK_DELAY_TIMER_MS);
             nickListener = (old, n) => {
@@ -344,6 +345,7 @@ export class BridgedClient extends EventEmitter {
                 if (nickErrListener) {
                     client.removeListener("error", nickErrListener);
                 }
+                this.emit("pending-nick.remove", validNick);
                 resolve("Nick changed from '" + old + "' to '" + n + "'.");
             }
             nickErrListener = (err) => {
@@ -361,9 +363,11 @@ export class BridgedClient extends EventEmitter {
                     }
                     reject(new Error("Failed to change nick: " + err.command));
                 }
+                this.emit("pending-nick.remove", validNick);
             }
             client.once("nick", nickListener);
             client.once("error", nickErrListener);
+            this.emit("pending-nick.add", validNick);
             client.send("NICK", validNick);
         });
     }


### PR DESCRIPTION
A nick change can race, so that new messages from the new nick can hit the IRC server before it's aware that the nick change has completed. Therefore, we hack around this slightly by storing a temporary nick.