### PR TITLE
Reconnect to the correct domain on passsword changes

### DIFF
--- a/changelog.d/1000.bugfix
+++ b/changelog.d/1000.bugfix
@@ -1,0 +1,1 @@
+Reconnect to the correct domain on passsword changes. Thanks to @palmer-dabbelt

--- a/src/bridge/AdminRoomHandler.ts
+++ b/src/bridge/AdminRoomHandler.ts
@@ -134,7 +134,7 @@ export class AdminRoomHandler {
                 await this.handleWhois(req, args, ircServer, adminRoom, event.sender);
                 break;
             case "!storepass":
-                await this.handleStorePass(req, args, ircServer, adminRoom, event.sender, clientList[0]);
+                await this.handleStorePass(req, args, ircServer, adminRoom, event.sender, clientList);
                 break;
             case "!removepass":
                 await this.handleRemovePass(ircServer, adminRoom, event.sender);
@@ -400,7 +400,7 @@ export class AdminRoomHandler {
     }
 
     private async handleStorePass(req: BridgeRequest, args: string[], server: IrcServer,
-        room: MatrixRoom, userId: string, client: BridgedClient) {
+        room: MatrixRoom, userId: string, clientList: BridgedClient[]) {
         const domain = server.domain;
         let notice;
 
@@ -419,8 +419,10 @@ export class AdminRoomHandler {
                 notice = new MatrixAction(
                     "notice", `Successfully stored password for ${domain}. You will now be reconnected to IRC.`
                 );
-                if (client) {
-                    await client.disconnect("iwantoreconnect", "authenticating", false);
+                for (let i = 0; i < clientList.length; i++) {
+                  if (clientList[i].server === server) {
+                      await clientList[i].disconnect("iwantoreconnect", "authenticating", false);
+                  }
                 }
             }
         }


### PR DESCRIPTION
The appservice triggers a reconnect when handling "!storepass" commands, but
rather than reconnecting to the domain for which the password was changed the
appservice just always reconnects to the first domain.  This causes an issue
for my setup, which has multiple domains in a singe appservice.

I've tested this by running it on my instance, which is connected to two
networks, and changing my password.

Signed-off-by: Palmer Dabbelt <palmerdabbelt@google.com>