### PR TITLE
Disallow invites to PM rooms

### DIFF
--- a/changelog.d/1010.bugfix
+++ b/changelog.d/1010.bugfix
@@ -1,0 +1,1 @@
+Disconnect a PM room from IRC when another user is invited, and disallow invites to PM rooms.

--- a/spec/integ/pm.spec.js
+++ b/spec/integ/pm.spec.js
@@ -280,11 +280,31 @@ describe("IRC-to-Matrix PMing", function() {
     "it receives a PM directed at a virtual user from a real IRC user",
     test.coroutine(function*() {
         // mock create room impl
-        let createRoomPromise = new Promise(function(resolve, reject) {
+        const createRoomPromise = new Promise(function(resolve) {
             sdk.createRoom.and.callFake(function(opts) {
                 expect(opts.visibility).toEqual("private");
                 expect(opts.invite).toEqual([tRealUserId]);
                 expect(opts.creation_content["m.federate"]).toEqual(true);
+                expect(opts.preset).not.toBeDefined();
+                expect(opts.initial_state).toEqual([{
+                    type: "m.room.power_levels",
+                    state_key: "",
+                    content: {
+                        users: {
+                            "@alice:anotherhomeserver": 10,
+                            "@irc.example_bob:some.home.server": 100
+                        },
+                        events: {
+                            "m.room.avatar": 10,
+                            "m.room.name": 10,
+                            "m.room.canonical_alias": 100,
+                            "m.room.history_visibility": 100,
+                            "m.room.power_levels": 100,
+                            "m.room.encryption": 100
+                        },
+                        invite: 100
+                    },
+                }]);
                 resolve();
                 return Promise.resolve({
                     room_id: tCreatedRoomId

--- a/src/bridge/IrcBridge.ts
+++ b/src/bridge/IrcBridge.ts
@@ -542,7 +542,6 @@ export class IrcBridge {
         });
         // FAILURE
         this.bridge.getRequestFactory().addDefaultRejectCallback((req) => {
-            console.log(req);
             logMessage(req, "FAILED");
             this.logMetric(req, "fail");
             BridgeRequest.HandleExceptionForSentry(req, "fail");

--- a/src/bridge/IrcHandler.ts
+++ b/src/bridge/IrcHandler.ts
@@ -148,6 +148,9 @@ export class IrcHandler {
      * @return {Promise} which is resolved when the PM room has been created.
      */
     private async createPmRoom (toUserId: string, fromUserId: string, fromUserNick: string, server: IrcServer) {
+        const users: {[userId: string]: number} = { };
+        users[toUserId] = 10;
+        users[fromUserId] = 100;
         const response = await this.ircBridge.getAppServiceBridge().getIntent(
             fromUserId
         ).createRoom({
@@ -155,12 +158,29 @@ export class IrcHandler {
             options: {
                 name: (fromUserNick + " (PM on " + server.domain + ")"),
                 visibility: "private",
-                preset: "trusted_private_chat",
+                // We deliberately set our own power levels below.
+                // preset: "trusted_private_chat",
                 invite: [toUserId],
                 creation_content: {
                     "m.federate": server.shouldFederatePMs()
                 },
                 is_direct: true,
+                initial_state: [{
+                    content: {
+                        users,
+                        events: {
+                            "m.room.avatar": 10,
+                            "m.room.name": 10,
+                            "m.room.canonical_alias": 100,
+                            "m.room.history_visibility": 100,
+                            "m.room.power_levels": 100,
+                            "m.room.encryption": 100
+                        },
+                        invite: 100,
+                    },
+                    type: "m.room.power_levels",
+                    state_key: "",
+                }],
             }
         });
         const pmRoom = new MatrixRoom(response.room_id);

--- a/src/bridge/IrcHandler.ts
+++ b/src/bridge/IrcHandler.ts
@@ -17,6 +17,8 @@ import { MembershipQueue } from "../util/MembershipQueue";
 import { IrcMessage } from "../irc/ConnectionInstance";
 
 const NICK_USERID_CACHE_MAX = 512;
+const PM_POWERLEVEL_MATRIXUSER = 10;
+const PM_POWERLEVEL_IRCUSER = 100;
 
 type MatrixMembership = "join"|"invite"|"leave"|"ban";
 
@@ -149,8 +151,8 @@ export class IrcHandler {
      */
     private async createPmRoom (toUserId: string, fromUserId: string, fromUserNick: string, server: IrcServer) {
         const users: {[userId: string]: number} = { };
-        users[toUserId] = 10;
-        users[fromUserId] = 100;
+        users[toUserId] = PM_POWERLEVEL_MATRIXUSER;
+        users[fromUserId] = PM_POWERLEVEL_IRCUSER;
         const response = await this.ircBridge.getAppServiceBridge().getIntent(
             fromUserId
         ).createRoom({

--- a/src/bridge/MatrixHandler.ts
+++ b/src/bridge/MatrixHandler.ts
@@ -401,8 +401,6 @@ export class MatrixHandler {
         const inviteeIsVirtual = !!this.ircBridge.getServerForUserId(event.state_key);
         const inviterIsVirtual = !!this.ircBridge.getServerForUserId(event.sender);
 
-        console.log(rooms, event.sender)
-
         // work out which flow we're dealing with and fork off asap
         // is the invitee the bot?
         if (this.ircBridge.appServiceUserId === event.state_key) {

--- a/src/bridge/MatrixHandler.ts
+++ b/src/bridge/MatrixHandler.ts
@@ -401,6 +401,8 @@ export class MatrixHandler {
         const inviteeIsVirtual = !!this.ircBridge.getServerForUserId(event.state_key);
         const inviterIsVirtual = !!this.ircBridge.getServerForUserId(event.sender);
 
+        console.log(rooms, event.sender)
+
         // work out which flow we're dealing with and fork off asap
         // is the invitee the bot?
         if (this.ircBridge.appServiceUserId === event.state_key) {
@@ -412,15 +414,10 @@ export class MatrixHandler {
             // case[6]
             // Drop through so the invite stays active, but do not join the room.
         }
-        else if (!inviterIsVirtual) {
-            // case[7]
-            if (rooms[0]?.getType() === "pm") {
-                // PMs
-                return this.handleInviteToPMRoom(req, event, inviter, invitee);
-            }
-            // Groups just pass through
-            return BridgeRequestErr.ERR_NOT_MAPPED;
-        }
+        else if (!inviterIsVirtual && rooms[0]?.getType() === "pm") {
+            // case[7]-pms
+            return this.handleInviteToPMRoom(req, event, inviter, invitee);
+        } // case[7]-groups falls through.
         // else is the invitee a real matrix user? If they are, there will be no IRC server
         else if (!inviteeIsVirtual) {
             // If this is a PM, we need to disconnect it

--- a/src/bridge/MatrixHandler.ts
+++ b/src/bridge/MatrixHandler.ts
@@ -396,7 +396,7 @@ export class MatrixHandler {
         const hasExistingRoom= rooms.length > 1;
 
         const inviteeIsVirtual = !!this.ircBridge.getServerForUserId(event.state_key);
-        const inviterIsVirtual = !!this.ircBridge.getServerForUserId(event.sender)
+        const inviterIsVirtual = !!this.ircBridge.getServerForUserId(event.sender);
 
         // work out which flow we're dealing with and fork off asap
         // is the invitee the bot?
@@ -411,7 +411,7 @@ export class MatrixHandler {
         }
         else if (!inviterIsVirtual) {
             // case[7]
-            if (rooms.length === 1 && rooms[0].getType() === "pm") {
+            if (rooms[0]?.getType() === "pm") {
                 // PMs
                 return this.handleInviteToPMRoom(req, event, inviter, invitee);
             }

--- a/src/bridge/MatrixHandler.ts
+++ b/src/bridge/MatrixHandler.ts
@@ -343,10 +343,12 @@ export class MatrixHandler {
      * @param {MatrixUser} invitee : The invitee (receiver).
      * @return {Promise} which is resolved/rejected when the request finishes.
      */
-    private async handleInviteToPMRoom(req: BridgeRequest, event: MatrixEventInvite, inviter: MatrixUser, invitee: MatrixUser):
-    Promise<BridgeRequestErr|null> {
+    private async handleInviteToPMRoom(req: BridgeRequest, event: MatrixEventInvite,
+        inviter: MatrixUser, invitee: MatrixUser): Promise<BridgeRequestErr|null> {
         // We don't support this
-        req.log.warn(`User ${inviter.getId()} tried to invite ${invitee.getId()} to a PM room. Disconnecting from room`);
+        req.log.warn(
+            `User ${inviter.getId()} tried to invite ${invitee.getId()} to a PM room. Disconnecting from room`
+        );
         const store = this.ircBridge.getStore();
         const [room] = await store.getIrcChannelsForRoomId(event.room_id);
         await store.removePmRoom(event.room_id);
@@ -354,7 +356,8 @@ export class MatrixHandler {
         const intent = this.ircBridge.getAppServiceBridge().getIntent(userId);
         await intent.sendMessage(event.room_id, {
             msgtype: "m.notice",
-            body: "This room has been disconnected from IRC. You cannot invite new users into a IRC PM. Please create a new PM room.",
+            body: "This room has been disconnected from IRC. You cannot invite new users into a IRC PM. " +
+                  "Please create a new PM room",
         });
         await intent.leave(event.room_id);
         return null;

--- a/src/bridge/MatrixHandler.ts
+++ b/src/bridge/MatrixHandler.ts
@@ -337,6 +337,30 @@ export class MatrixHandler {
     }
 
     /**
+     * Called when a Matrix user tries to invite another user into a PM
+     * @param {Object} event : The Matrix invite event.
+     * @param {MatrixUser} inviter : The inviter (sender).
+     * @param {MatrixUser} invitee : The invitee (receiver).
+     * @return {Promise} which is resolved/rejected when the request finishes.
+     */
+    private async handleInviteToPMRoom(req: BridgeRequest, event: MatrixEventInvite, inviter: MatrixUser, invitee: MatrixUser):
+    Promise<BridgeRequestErr|null> {
+        // We don't support this
+        req.log.warn(`User ${inviter.getId()} tried to invite ${invitee.getId()} to a PM room. Disconnecting from room`);
+        const store = this.ircBridge.getStore();
+        const [room] = await store.getIrcChannelsForRoomId(event.room_id);
+        await store.removePmRoom(event.room_id);
+        const userId = room.server.getUserIdFromNick(room.channel);
+        const intent = this.ircBridge.getAppServiceBridge().getIntent(userId);
+        await intent.sendMessage(event.room_id, {
+            msgtype: "m.notice",
+            body: "This room has been disconnected from IRC. You cannot invite new users into a IRC PM. Please create a new PM room",
+        });
+        await intent.leave(event.room_id);
+        return null;
+    }
+
+    /**
      * Called when the AS receives a new Matrix invite event.
      * @param {Object} event : The Matrix invite event.
      * @param {MatrixUser} inviter : The inviter (sender).
@@ -354,6 +378,7 @@ export class MatrixHandler {
         * [4] bot --invite--> MX   (bot telling real mx user IRC conn state) - Ignore.
         * [5] irc --invite--> MX   (real irc user PMing a Matrix user) - Ignore.
         * [6] MX  --invite--> BOT  (invite to private room to allow bot to bridge) - Ignore.
+        * [7] MX  --invite--> MX   (matrix user inviting another matrix user)
         */
         req.log.info("onInvite: %s", JSON.stringify(event));
         this._onMemberEvent(req, event);
@@ -367,9 +392,11 @@ export class MatrixHandler {
         });
 
         // Check if this room is known to us.
-        const hasExistingRoom = (
-            await this.ircBridge.getStore().getIrcChannelsForRoomId(event.room_id)
-        ).length > 0;
+        const rooms = await this.ircBridge.getStore().getIrcChannelsForRoomId(event.room_id);
+        const hasExistingRoom= rooms.length > 1;
+
+        const inviteeIsVirtual = !!this.ircBridge.getServerForUserId(event.state_key);
+        const inviterIsVirtual = !!this.ircBridge.getServerForUserId(event.sender)
 
         // work out which flow we're dealing with and fork off asap
         // is the invitee the bot?
@@ -382,9 +409,19 @@ export class MatrixHandler {
             // case[6]
             // Drop through so the invite stays active, but do not join the room.
         }
+        else if (!inviterIsVirtual) {
+            // case[7]
+            if (rooms.length === 1 && rooms[0].getType() === "pm") {
+                // PMs
+                return this.handleInviteToPMRoom(req, event, inviter, invitee);
+            }
+            // Groups just pass through
+            return BridgeRequestErr.ERR_NOT_MAPPED;
+        }
         // else is the invitee a real matrix user? If they are, there will be no IRC server
-        else if (!this.ircBridge.getServerForUserId(event.state_key)) {
-            // cases [4] and [5] : We cannot accept on behalf of real matrix users, so nop
+        else if (!inviteeIsVirtual) {
+            // If this is a PM, we need to disconnect it
+            // cases [4], [5]: We cannot accept on behalf of real matrix users, so nop
             return BridgeRequestErr.ERR_NOT_MAPPED;
         }
         else {

--- a/src/datastore/DataStore.ts
+++ b/src/datastore/DataStore.ts
@@ -120,6 +120,8 @@ export interface DataStore {
 
     setPmRoom(ircRoom: IrcRoom, matrixRoom: MatrixRoom, userId: string, virtualUserId: string): Promise<void>;
 
+    removePmRoom(roomId: string): Promise<void>;
+
     getMatrixPmRoom(realUserId: string, virtualUserId: string): Promise<MatrixRoom|null>;
 
     getTrackedChannelsForServer(domain: string): Promise<string[]>;

--- a/src/datastore/NedbDataStore.ts
+++ b/src/datastore/NedbDataStore.ts
@@ -368,6 +368,11 @@ export class NeDBDataStore implements DataStore {
         }, NeDBDataStore.createPmId(userId, virtualUserId));
     }
 
+    public async removePmRoom(roomId: string): Promise<void> {
+        log.debug(`removePmRoom (room_id=${roomId}`);
+        await this.roomStore.removeEntriesByMatrixRoomId(roomId);
+    }
+
     public async getMatrixPmRoom(realUserId: string, virtualUserId: string) {
         const id = NeDBDataStore.createPmId(realUserId, virtualUserId);
         const entry = await this.roomStore.getEntryById(id);

--- a/src/datastore/postgres/PgDataStore.ts
+++ b/src/datastore/postgres/PgDataStore.ts
@@ -324,6 +324,11 @@ export class PgDataStore implements DataStore {
         ]);
     }
 
+    public async removePmRoom(roomId: string): Promise<void> {
+        log.debug(`removePmRoom (room_id=${roomId}`);
+        await this.pgPool.query("DELETE FROM pm_rooms WHERE room_id = $1", [roomId]);
+    }
+
     public async getMatrixPmRoom(realUserId: string, virtualUserId: string): Promise<MatrixRoom|null> {
         log.debug(`getMatrixPmRoom (matrix_user_id=${realUserId}, virtual_user_id=${virtualUserId})`);
         const res = await this.pgPool.query("SELECT room_id FROM pm_rooms WHERE matrix_user_id = $1 AND virtual_user_id = $2", [

--- a/src/models/IrcRoom.ts
+++ b/src/models/IrcRoom.ts
@@ -51,7 +51,7 @@ export class IrcRoom extends RemoteRoom {
     }
 
     getType() {
-        return super.get("type") as string;
+        return super.get("type") as "channel"|"pm";
     }
 
     public static fromRemoteRoom(server: IrcServer, remoteRoom: RemoteRoom) {


### PR DESCRIPTION
Sometimes users will create a PM room with a irc user and then try to invite their friends to the room, which breaks horribly on IRC and causes the irc users to get a new PM channel per matrix user, which looks like a clusterfuck.

This PR forces a IRC user to leave a PM room if a user gets invited to it, and also removes the PM room from the datastore. If a new PM room is created from the IRC side, the matrix user will now lack the permissions to invite users.