### PR TITLE
On name change, inform Matrix users, if their preferred IRC name is taken

### DIFF
--- a/changelog.d/1018.feature
+++ b/changelog.d/1018.feature
@@ -1,0 +1,1 @@
+On name change, inform Matrix users, if their preferred IRC name is taken

--- a/spec/integ/admin-rooms.spec.js
+++ b/spec/integ/admin-rooms.spec.js
@@ -653,8 +653,12 @@ describe("Admin rooms", function() {
         // make sure that the NICK command not is sent
         let sentNickCommand = false;
         env.ircMock._whenClient(roomMapping.server, userIdNick, "send",
-        function() {
-            sentNickCommand = false;
+        function(client, command, arg) {
+            expect(client.nick).toEqual(userIdNick, "use the old nick on /nick");
+            expect(client.addr).toEqual(roomMapping.server);
+            expect(command).toEqual("NICK");
+            expect(arg).toEqual(newNick);
+            sentNickCommand = true;
         });
 
         env.ircMock._whenClient(roomMapping.server, userIdNick, "whois", (client, whoisNick, callback) => {

--- a/src/bridge/AdminRoomHandler.ts
+++ b/src/bridge/AdminRoomHandler.ts
@@ -536,14 +536,6 @@ export class AdminRoomHandler {
             return;
         }
 
-        if (await this.ircBridge.checkNickExists(ircServer, nick)) {
-            const notice = new MatrixAction("notice",
-                `The user name ${nick} is taken on ${ircServer.domain}. Please pick a different name!`
-            );
-            await this.ircBridge.sendMatrixAction(adminRoom, this.botUser, notice);
-            return;
-        }
-
         // change the nick
         const bridgedClient = await this.ircBridge.getBridgedClient(ircServer, sender);
         try {

--- a/src/bridge/AdminRoomHandler.ts
+++ b/src/bridge/AdminRoomHandler.ts
@@ -387,7 +387,7 @@ export class AdminRoomHandler {
         const bridgedClient = await this.ircBridge.getBridgedClient(server, sender);
         try {
             const response = await bridgedClient.whois(whoisNick);
-            const noticeRes = new MatrixAction("notice", response.msg);
+            const noticeRes = new MatrixAction("notice", response?.msg || "User not found");
             await this.ircBridge.sendMatrixAction(room, this.botUser, noticeRes);
         }
         catch (err) {

--- a/src/bridge/AdminRoomHandler.ts
+++ b/src/bridge/AdminRoomHandler.ts
@@ -536,6 +536,14 @@ export class AdminRoomHandler {
             return;
         }
 
+        if (await this.ircBridge.checkNickExists(ircServer, nick)) {
+            const notice = new MatrixAction("notice",
+                `The user name ${nick} is taken on ${ircServer.domain}. Please pick a different name!`
+            );
+            await this.ircBridge.sendMatrixAction(adminRoom, this.botUser, notice);
+            return;
+        }
+
         // change the nick
         const bridgedClient = await this.ircBridge.getBridgedClient(ircServer, sender);
         try {

--- a/src/bridge/IrcBridge.ts
+++ b/src/bridge/IrcBridge.ts
@@ -926,10 +926,21 @@ export class IrcBridge {
         ));
     }
 
+    /**
+     * Determines if a nick name already exists.
+     */
     public async checkNickExists(server: IrcServer, nick: string) {
         log.info("Querying for nick %s on %s", nick, server.domain);
         const client = await this.getBotClient(server);
-        return await client.whois(nick);
+        try {
+            await client.whois(nick);
+            return true;
+        } catch (error) {
+            if (error.message === "Cannot find nick on whois.") {
+                return false;
+            }
+            throw error;
+        }
     }
 
     public async joinBot(ircRoom: IrcRoom) {

--- a/src/bridge/IrcBridge.ts
+++ b/src/bridge/IrcBridge.ts
@@ -932,15 +932,7 @@ export class IrcBridge {
     public async checkNickExists(server: IrcServer, nick: string) {
         log.info("Querying for nick %s on %s", nick, server.domain);
         const client = await this.getBotClient(server);
-        try {
-            await client.whois(nick);
-            return true;
-        } catch (error) {
-            if (error.message === "Cannot find nick on whois.") {
-                return false;
-            }
-            throw error;
-        }
+        return await client.whois(nick) !== null;
     }
 
     public async joinBot(ircRoom: IrcRoom) {

--- a/src/irc/BridgedClient.ts
+++ b/src/irc/BridgedClient.ts
@@ -345,7 +345,7 @@ export class BridgedClient extends EventEmitter {
 
         if (await this.checkNickExists(validNick)) {
             throw Error(
-                `The nickname ${newNick} is taken on ${this.server.domain}. ` +
+                `The nickname ${newNick} is taken on ${this.server.domain}.` +
                 "Please pick a different nick."
             );
         }
@@ -490,7 +490,6 @@ export class BridgedClient extends EventEmitter {
         let errorHandler!: (msg: IrcMessage) => void;
         try {
             this.whoisPendingNicks.add(nick);
-
             const whois: WhoisResponse|null = await new Promise((resolve, reject) => {
                 errorHandler = (msg: IrcMessage) => {
                     if (msg.command !== "err_nosuchnick" || msg.args[1] !== nick) {

--- a/src/irc/BridgedClient.ts
+++ b/src/irc/BridgedClient.ts
@@ -310,11 +310,16 @@ export class BridgedClient extends EventEmitter {
      * @return {Promise<String>} Which resolves to a message to be sent to the user.
      */
     public changeNick(newNick: string, throwOnInvalid: boolean): Promise<string> {
+        this.log.info(`Trying to change nick from ${this.nick} to ${newNick}`);
         let validNick = newNick;
         try {
             validNick = this.getValidNick(newNick, throwOnInvalid);
             if (validNick === this.nick) {
-                return Promise.resolve(`Your nick is already '${validNick}'.`);
+                throw Error(`Your nick is already '${validNick}'.`);
+            }
+            if (validNick !== newNick) {
+                // Don't "suggest" a nick.
+                throw Error("Nickname is not valid");
             }
         }
         catch (err) {

--- a/src/irc/BridgedClient.ts
+++ b/src/irc/BridgedClient.ts
@@ -312,17 +312,9 @@ export class BridgedClient extends EventEmitter {
      * Determines if a nick name already exists.
      */
     public async checkNickExists(nick: string): Promise<boolean> {
-        try {
-            // We don't care about the return value of .whois().
-            // It will return null if the user isn't defined.
-            return (await this.whois(nick)) !== null;
-        }
-        catch (error) {
-            if (error.message === "Cannot find nick on whois.") {
-                return false;
-            }
-            throw error;
-        }
+        // We don't care about the return value of .whois().
+        // It will return null if the user isn't defined.
+        return (await this.whois(nick)) !== null;
     }
 
     /**
@@ -353,9 +345,9 @@ export class BridgedClient extends EventEmitter {
         return await this.sendNickCommand(validNick);
     }
 
-    private sendNickCommand(nick: string): Promise<string> {
+    private async sendNickCommand(nick: string): Promise<string> {
         if (!this.unsafeClient) {
-            throw new Error("You are not connected to the network.");
+            throw Error("You are not connected to the network.");
         }
         const client = this.unsafeClient;
         return new Promise((resolve, reject) => {


### PR DESCRIPTION
When a Matrix user "peter" writes `!nick max` to the IRC Bridge, but the name max is already in use, we used to rename them to `peter1` (or another number at the end.

This PR checks if the new name is available and aborts the change if the name is taken.

![Screenshot_2020-04-03 Riot appservice-irc localhost](https://user-images.githubusercontent.com/10872136/78345261-c98d0900-759d-11ea-8fec-38d71e4e42e1.png)
