### PR TITLE
Replace deprecated new Buffer("a")

### DIFF
--- a/changelog.d/1019.misc
+++ b/changelog.d/1019.misc
@@ -1,0 +1,1 @@
+Replace deprecated new Buffer("a")

--- a/src/bridge/IrcBridge.ts
+++ b/src/bridge/IrcBridge.ts
@@ -619,7 +619,7 @@ export class IrcBridge {
 
     public uploadTextFile(fileName: string, plaintext: string) {
         return this.bridge.getIntent().getClient().uploadContent(
-            new Buffer(plaintext),
+            Buffer.from(plaintext),
             {
                 name: fileName,
                 type: "text/plain; charset=utf-8",

--- a/src/datastore/StringCrypto.ts
+++ b/src/datastore/StringCrypto.ts
@@ -31,7 +31,7 @@ export class StringCrypto {
             try {
                 crypto.publicEncrypt(
                     this.privateKey,
-                    new Buffer("This is a test!")
+                    Buffer.from("This is a test!")
                 );
             }
             catch (err) {
@@ -51,14 +51,14 @@ export class StringCrypto {
         const salt = crypto.randomBytes(16).toString('base64');
         return crypto.publicEncrypt(
             this.privateKey,
-            new Buffer(salt + ' ' + plaintext)
+            Buffer.from(salt + ' ' + plaintext)
         ).toString('base64');
     }
 
     public decrypt(encryptedString: string): string {
         const decryptedPass = crypto.privateDecrypt(
             this.privateKey,
-            new Buffer(encryptedString, 'base64')
+            Buffer.from(encryptedString, 'base64')
         ).toString();
         // Extract the password by removing the prefixed salt and seperating space
         return decryptedPass.split(' ')[1];


### PR DESCRIPTION
Replace new Buffer("a") with Buffer.from("a")


Will eventually make this startup message go away, when all our dependencies have also moved on:
```
(node:324913) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.
```