### PR TITLE
Test !nick when the user already has the nick

### DIFF
--- a/changelog.d/1020.misc
+++ b/changelog.d/1020.misc
@@ -1,0 +1,1 @@
+Test !nick when the user already has the nick


### PR DESCRIPTION
In preparation of #1018 I want the CI to ring an alarm, if changing the nick to your current nick causes a different notice to appear in Matrix.