### PR TITLE
Add the ability to deactivate users to prevent them from ever being bridged

### DIFF
--- a/spec/integ/irc-connections.spec.js
+++ b/spec/integ/irc-connections.spec.js
@@ -563,14 +563,13 @@ describe("IRC connections", function() {
     it("should not bridge matrix users who are deactivated", async function() {
         const deactivatedUserId = "@deactivated:hs";
         const nick = "M-deactivated";
-        
+
         const store = env.ircBridge.getStore();
         await store.deactivateUser(deactivatedUserId);
         expect(await store.isUserDeactivated(deactivatedUserId)).toBe(true);
 
         env.ircMock._whenClient(roomMapping.server, nick, "connect",
         function() {
-            console.log(nick);
             throw Error("Client should not be saying anything")
         });
         try {

--- a/spec/integ/irc-connections.spec.js
+++ b/spec/integ/irc-connections.spec.js
@@ -230,11 +230,10 @@ describe("IRC connections", function() {
     });
 
     it("should be made once per client, regardless of how many messages are " +
-    "to be sent to IRC", function(done) {
+    "to be sent to IRC", async function() {
         let connectCount = 0;
 
-        env.ircMock._whenClient(roomMapping.server, testUser.nick, "connect",
-        function(client, cb) {
+        env.ircMock._whenClient(roomMapping.server, testUser.nick, "connect", (client, cb) => {
             connectCount += 1;
             // add an artificially long delay to make sure it isn't connecting
             // twice
@@ -243,7 +242,7 @@ describe("IRC connections", function() {
             }, 500);
         });
 
-        let promises = [];
+        const promises = [];
 
         promises.push(env.mockAppService._trigger("type:m.room.message", {
             content: {
@@ -264,11 +263,8 @@ describe("IRC connections", function() {
             room_id: roomMapping.roomId,
             type: "m.room.message"
         }));
-
-        Promise.all(promises).done(function() {
-            expect(connectCount).toBe(1);
-            done();
-        });
+        await Promise.all(promises);
+        expect(connectCount).toBe(1);
     });
 
     // BOTS-41
@@ -558,6 +554,39 @@ describe("IRC connections", function() {
         catch (ex) {
             expect(ex.message).toBe(
                 "Cannot create bridged client - user is excluded from bridging"
+            );
+            return;
+        }
+        throw Error("Should have thrown");
+    });
+
+    it("should not bridge matrix users who are deactivated", async function() {
+        const deactivatedUserId = "@deactivated:hs";
+        const nick = "M-deactivated";
+        
+        const store = env.ircBridge.getStore();
+        await store.deactivateUser(deactivatedUserId);
+        expect(await store.isUserDeactivated(deactivatedUserId)).toBe(true);
+
+        env.ircMock._whenClient(roomMapping.server, nick, "connect",
+        function() {
+            console.log(nick);
+            throw Error("Client should not be saying anything")
+        });
+        try {
+            await env.mockAppService._trigger("type:m.room.message", {
+                content: {
+                    body: "Text that should never be sent",
+                    msgtype: "m.text"
+                },
+                user_id: deactivatedUserId,
+                room_id: roomMapping.roomId,
+                type: "m.room.message"
+            });
+        }
+        catch (ex) {
+            expect(ex.message).toBe(
+                "Cannot create bridged client - user has been deactivated"
             );
             return;
         }

--- a/src/DebugApi.ts
+++ b/src/DebugApi.ts
@@ -170,7 +170,7 @@ export class DebugApi {
                     promise = Promise.reject(new Error("Need user_id and reason"));
                 }
                 else {
-                    promise = this.killUser(body.user_id, body.reason);
+                    promise = this.killUser(body.user_id, body.reason, body.deactivate);
                 }
             }
             catch (err) {
@@ -232,8 +232,11 @@ export class DebugApi {
         return inspect(client, { colors:true, depth:7 });
     }
 
-    private killUser(userId: string, reason: string) {
+    private async killUser(userId: string, reason: string, deactivate: boolean) {
         const req = new BridgeRequest(this.ircBridge.getAppServiceBridge().getRequestFactory().newRequest());
+        if (deactivate) {
+            await this.ircBridge.getStore().deactivateUser(userId);
+        }
         const clients = this.pool.getBridgedClientsForUserId(userId);
         return this.ircBridge.matrixHandler.quitUser(req, userId, clients, null, reason);
     }

--- a/src/datastore/DataStore.ts
+++ b/src/datastore/DataStore.ts
@@ -172,5 +172,9 @@ export interface DataStore {
 
     setRoomVisibility(roomId: string, vis: "public"|"private"): Promise<void>;
 
+    isUserDeactivated(userId: string): Promise<boolean>;
+
+    deactivateUser(userId: string): Promise<void>;
+
     destroy(): Promise<void>;
 }

--- a/src/datastore/NedbDataStore.ts
+++ b/src/datastore/NedbDataStore.ts
@@ -653,6 +653,20 @@ export class NeDBDataStore implements DataStore {
         await this.roomStore.setMatrixRoom(room);
     }
 
+    public async deactivateUser(userId: string) {
+        let user = await this.userStore.getMatrixUser(userId);
+        if (!user) {
+            user = new MatrixUser(userId);
+        }
+        user.set("deactivated", true);
+        await this.userStore.setMatrixUser(user);
+    }
+
+    public async isUserDeactivated(userId: string) {
+        const user = await this.userStore.getMatrixUser(userId);
+        return user?.get("deactivated") === true;
+    }
+
     public async roomUpgradeOnRoomMigrated(oldRoomId: string, newRoomId: string) {
         const ircRooms = await this.getIrcChannelsForRoomId(oldRoomId);
         for (const ircRoom of ircRooms) {

--- a/src/datastore/postgres/PgDataStore.ts
+++ b/src/datastore/postgres/PgDataStore.ts
@@ -566,7 +566,7 @@ export class PgDataStore implements DataStore {
     }
 
     public async deactivateUser(userId: string) {
-        this.pgPool.query("INSERT INTO deactivated_users VALUES ($1)", [userId]);
+        this.pgPool.query("INSERT INTO deactivated_users VALUES ($1, $2)", [userId, Date.now()]);
     }
 
     public async ensureSchema() {

--- a/src/datastore/postgres/PgDataStore.ts
+++ b/src/datastore/postgres/PgDataStore.ts
@@ -561,7 +561,7 @@ export class PgDataStore implements DataStore {
     }
 
     public async isUserDeactivated(userId: string): Promise<boolean> {
-        const res = await this.pgPool.query(`SELECT user_id FROM deactivated_users WHERE userId = $1`, [userId]);
+        const res = await this.pgPool.query(`SELECT user_id FROM deactivated_users WHERE user_id = $1`, [userId]);
         return res.rowCount > 0;
     }
 

--- a/src/datastore/postgres/PgDataStore.ts
+++ b/src/datastore/postgres/PgDataStore.ts
@@ -33,7 +33,7 @@ const log = getLogger("PgDatastore");
 export class PgDataStore implements DataStore {
     private serverMappings: {[domain: string]: IrcServer} = {};
 
-    public static readonly LATEST_SCHEMA = 3;
+    public static readonly LATEST_SCHEMA = 4;
     private pgPool: Pool;
     private hasEnded = false;
     private cryptoStore?: StringCrypto;
@@ -558,6 +558,15 @@ export class PgDataStore implements DataStore {
         ]);
         await this.pgPool.query(statement, [roomId, visibility === "public"]);
         log.info(`setRoomVisibility ${roomId} => ${visibility}`);
+    }
+
+    public async isUserDeactivated(userId: string): Promise<boolean> {
+        const res = await this.pgPool.query(`SELECT user_id FROM deactivated_users WHERE userId = $1`, [userId]);
+        return res.rowCount > 0;
+    }
+
+    public async deactivateUser(userId: string) {
+        this.pgPool.query("INSERT INTO deactivated_users VALUES ($1)", [userId]);
     }
 
     public async ensureSchema() {

--- a/src/datastore/postgres/schema/v4.ts
+++ b/src/datastore/postgres/schema/v4.ts
@@ -5,6 +5,7 @@ export async function runSchema(connection: PoolClient) {
     await connection.query(`
     CREATE TABLE deactivated_users (
         user_id	TEXT UNIQUE NOT NULL,
+        ts BIGINT NOT NULL
     );
     `);
 }

--- a/src/datastore/postgres/schema/v4.ts
+++ b/src/datastore/postgres/schema/v4.ts
@@ -1,0 +1,10 @@
+import { PoolClient } from "pg";
+
+export async function runSchema(connection: PoolClient) {
+    // Create schema
+    await connection.query(`
+    CREATE TABLE deactivated_users (
+        user_id	TEXT UNIQUE NOT NULL,
+    );
+    `);
+}

--- a/src/irc/ClientPool.ts
+++ b/src/irc/ClientPool.ts
@@ -208,6 +208,10 @@ export class ClientPool {
             return bridgedClient;
         }
 
+        if (userId && await this.ircBridge.getStore().isUserDeactivated(userId)) {
+            throw Error("Cannot create bridged client - user has been deactivated");
+        }
+
         const mxUser = new MatrixUser(userId);
         if (displayName) {
             mxUser.setDisplayName(displayName);


### PR DESCRIPTION
A few users have noted that they are re-bridged even after deactivating their account. The bridge will always reconnect users if they join an IRC bridged room. However, due to *state resets* (a bug where older v1-2 version rooms could revert their state to a previous point in time) these users may end up reappearing in the room. I can't seem to find an actual issue that describes the 'state reset bug', but there you go.

If the user reappears in the room, they may get reconnected even if they have since deleted their account. The IRC bridge should therefore keep track of users who have deactivated their accounts. In the future. [MSC2438](https://github.com/matrix-org/matrix-doc/pull/2438) will allow us to listen for these deactivation requests, but for now this offers us a manual way to do it.