### PR TITLE
Reconnect after !storepass, even if the user isn't in any channels.

### DIFF
--- a/changelog.d/1024.bugfix
+++ b/changelog.d/1024.bugfix
@@ -1,0 +1,1 @@
+Fix issue where users who used !storepass are never reconnected and cannot send messages through the bridge.

--- a/src/bridge/AdminRoomHandler.ts
+++ b/src/bridge/AdminRoomHandler.ts
@@ -420,7 +420,7 @@ export class AdminRoomHandler {
                     "notice", `Successfully stored password for ${domain}. You will now be reconnected to IRC.`
                 );
                 if (client) {
-                    await client.disconnect("iwantoreconnect", "authenticating", false);
+                    await client.disconnect("iwanttoreconnect", "authenticating", false);
                 }
             }
         }

--- a/src/irc/ClientPool.ts
+++ b/src/irc/ClientPool.ts
@@ -220,7 +220,8 @@ export class ClientPool {
         if (storedConfig) {
             log.debug("Configuring IRC user from store => " + storedConfig);
             ircClientConfig = storedConfig;
-        } else {
+        }
+        else {
             ircClientConfig = IrcClientConfig.newConfig(
                 mxUser, server.domain
             );
@@ -581,7 +582,9 @@ export class ClientPool {
 
         if (chanList.length === 0 && !isBot && bridgedClient.disconnectReason !== "iwanttoreconnect") {
             // Never drop the bot, or users that really want to reconnect.
-            log.info(`Dropping ${bridgedClient.id} (${bridgedClient.nick}) because they are not joined to any channels`);
+            log.info(
+                `Dropping ${bridgedClient.id} (${bridgedClient.nick}) because they are not joined to any channels`
+            );
             return;
         }
 

--- a/src/irc/ClientPool.ts
+++ b/src/irc/ClientPool.ts
@@ -567,6 +567,15 @@ export class ClientPool {
             );
         }
 
+        const isBot = bridgedClient.isBot;
+        const chanList = bridgedClient.chanList;
+
+        if (chanList.length === 0 && !isBot && bridgedClient.disconnectReason !== "iwanttoreconnect") {
+            // Never drop the bot, or users that really want to reconnect.
+            log.info(`Dropping ${bridgedClient.id} (${bridgedClient.nick}) because they are not joined to any channels`);
+            return;
+        }
+
         if (bridgedClient.explicitDisconnect) {
             log.info(`Dropping ${bridgedClient.id} (${bridgedClient.nick}) because explicitDisconnect is true`);
             // don't reconnect users which explicitly disconnected e.g. client
@@ -587,20 +596,13 @@ export class ClientPool {
         }
 
         cliConfig.setDesiredNick(bridgedClient.nick);
-
         const cli = this.createIrcClient(
             cliConfig, bridgedClient.matrixUser || null, bridgedClient.isBot
         );
-        const isBot = bridgedClient.isBot;
-        const chanList = bridgedClient.chanList;
         // remove ref to the disconnected client so it can be GC'd. If we don't do this,
         // the timeout below holds it in a closure, preventing it from being GC'd.
         (bridgedClient as unknown) = undefined;
 
-        if (chanList.length === 0 && !isBot) { // Never drop the bot.
-            log.info(`Dropping ${cli.id} (${cli.nick}) because they are not joined to any channels`);
-            return;
-        }
         const queue = this.getOrCreateReconnectQueue(cli.server);
         if (queue === null) {
             this.reconnectClient({

--- a/src/irc/ConnectionInstance.ts
+++ b/src/irc/ConnectionInstance.ts
@@ -78,7 +78,7 @@ export interface ConnectionOpts {
 
 export type InstanceDisconnectReason = "throttled"|"irc_error"|"net_error"|"timeout"|"raw_error"|
                                        "toomanyconns"|"banned"|"killed"|"idle"|"limit_reached"|
-                                       "iwantoreconnect";
+                                       "iwanttoreconnect";
 
 export class ConnectionInstance {
     public dead = false;


### PR DESCRIPTION
Fixes #946, #1006, #944, #939 and maybe others

The bug occurs when somebody who isn't in any channels but *is* connected will try to set a password with `!storepass`. The bridge will then try to reconnect them, but will drop out early because the user isn't joined to any channels.

However, this is done *after* a new client is assigned to them and so they are left unconnected, but never able to reconnect. 