### PR TITLE
Added ability to set fallback encoding for non-UTF-8 strings. Implements #580.

### DIFF
--- a/changelog.d/580.feature
+++ b/changelog.d/580.feature
@@ -1,0 +1,1 @@
+Add ability to set fallback text encoding for non-UTF-8 messages.

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -383,6 +383,10 @@ ircService:
     # Default: 0.0.0.0
     address: "::"
 
+  # Encoding fallback - which text encoding to try if text is not UTF-8. Default: not set.
+  # List of supported encodings: https://www.npmjs.com/package/iconv#supported-encodings
+  # encodingFallback: "ISO-8859-15"
+
   # Configuration for logging. Optional. Default: console debug level logging
   # only.
   logging:

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "extend": "^2.0.0",
     "he": "^1.1.1",
     "iconv": "^2.3.4",
-    "irc": "matrix-org/node-irc#matrix-irc-bridge",
+    "irc": "matrix-org/node-irc#7feccae6c168c2c08527daace0c6fe5af56c6560",
     "js-yaml": "^3.2.7",
     "logform": "^2.1.2",
     "matrix-appservice": "^0.4.1",

--- a/src/bridge/IrcBridge.ts
+++ b/src/bridge/IrcBridge.ts
@@ -98,7 +98,6 @@ export class IrcBridge {
                 triggerEndpoint: provisioning.enableReload
             };
         }
-
         let bridgeStoreConfig = {};
 
         if (this.config.database.engine === "nedb") {

--- a/src/config/BridgeConfig.ts
+++ b/src/config/BridgeConfig.ts
@@ -49,6 +49,7 @@ export interface BridgeConfig {
             enabled: boolean;
             initial: boolean;
         };
+        encodingFallback: string;
     };
     sentry?: {
         enabled: boolean;

--- a/src/irc/BridgedClient.ts
+++ b/src/irc/BridgedClient.ts
@@ -94,7 +94,8 @@ export class BridgedClient extends EventEmitter {
         public readonly isBot: boolean,
         private readonly eventBroker: IrcEventBroker,
         private readonly identGenerator: IdentGenerator,
-        private readonly ipv6Generator: Ipv6Generator) {
+        private readonly ipv6Generator: Ipv6Generator,
+        private readonly encodingFallback: string) {
         super();
         this.userId = matrixUser ? matrixUser.getId() : null;
         this.displayName = matrixUser ? matrixUser.getDisplayName() : null;
@@ -220,7 +221,8 @@ export class BridgedClient extends EventEmitter {
                 // won't be able to turn off IPv6!
                 localAddress: (
                     this.server.getIpv6Prefix() ? this.clientConfig.getIpv6Address() : undefined
-                )
+                ),
+                encodingFallback: this.encodingFallback,
             }, (inst: ConnectionInstance) => {
                 // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                 this.onConnectionCreated(inst, nameInfo, identResolver!);

--- a/src/irc/ClientPool.ts
+++ b/src/irc/ClientPool.ts
@@ -289,7 +289,8 @@ export class ClientPool {
 
         return new BridgedClient(
             server, ircClientConfig, matrixUser || undefined, isBot,
-            this.ircEventBroker, this.identGenerator, this.ipv6Generator
+            this.ircEventBroker, this.identGenerator, this.ipv6Generator,
+            this.ircBridge.config.ircService.encodingFallback
         );
     }
 

--- a/src/irc/ConnectionInstance.ts
+++ b/src/irc/ConnectionInstance.ts
@@ -74,6 +74,7 @@ export interface ConnectionOpts {
     secure?: {
         ca?: string;
     };
+    encodingFallback: string;
 }
 
 export type InstanceDisconnectReason = "throttled"|"irc_error"|"net_error"|"timeout"|"raw_error"|
@@ -383,6 +384,7 @@ export class ConnectionInstance {
             bustRfc3484: true,
             sasl: opts.password ? server.useSasl() : false,
             secure: server.useSsl() ? { ca: server.getCA() } : undefined,
+            encodingFallback: opts.encodingFallback
         };
 
         // Returns: A promise which resolves to a ConnectionInstance


### PR DESCRIPTION
Note: To actually work this requires node-irc with this PR merged https://github.com/matrix-org/node-irc/pull/43

I haven't written much NodeJS so please review the changes properly and let me know if any changes are needed.

Signed-off-by: Ville Ranki <ville.ranki@iki.fi>