### PR TITLE
increase CONNECT_TIMEOUT_MS to 60 seconds

### DIFF
--- a/src/irc/ConnectionInstance.ts
+++ b/src/irc/ConnectionInstance.ts
@@ -32,7 +32,7 @@ export interface IrcMessage {
 }
 
 // The time we're willing to wait for a connect callback when connecting to IRC.
-const CONNECT_TIMEOUT_MS = 30 * 1000; // 30s
+const CONNECT_TIMEOUT_MS = 60 * 1000; // 60s
 // The delay between messages when there are >1 messages to send.
 const FLOOD_PROTECTION_DELAY_MS = 700;
 // The max amount of time we should wait for the server to ping us before reconnecting.


### PR DESCRIPTION
Until #311, can we please increase this to 60 seconds and make IRCnet users happy?