### PR TITLE
Ignore the bot user when connection reaping.

### DIFF
--- a/changelog.d/1046.bugfix
+++ b/changelog.d/1046.bugfix
@@ -1,0 +1,1 @@
+Ensure we don't kick the bot user on connectionReap

--- a/src/bridge/IrcBridge.ts
+++ b/src/bridge/IrcBridge.ts
@@ -1078,7 +1078,7 @@ export class IrcBridge {
         log.warn(`Running connection reaper for ${serverName} dryrun=${dry}`);
         const req = new BridgeRequest(this.bridge.getRequestFactory().newRequest());
         logCb(`Connection reaping for ${serverName}`);
-        const users: string[] = this.clientPool.getConnectedMatrixUsersForServer(server);
+        const users: (string|null)[] = this.clientPool.getConnectedMatrixUsersForServer(server);
         logCb(`Found ${users.length} real users for ${serverName}`);
         const exclude = excludeRegex ? new RegExp(excludeRegex) : null;
         let offlineCount = 0;

--- a/src/bridge/IrcBridge.ts
+++ b/src/bridge/IrcBridge.ts
@@ -1083,6 +1083,10 @@ export class IrcBridge {
         const exclude = excludeRegex ? new RegExp(excludeRegex) : null;
         let offlineCount = 0;
         for (const userId of users) {
+            if (!userId) {
+                // The bot user has a userId of null, ignore it.
+                continue;
+            }
             const status = await this.activityTracker.isUserOnline(userId, maxIdleTime, defaultOnline);
             if (status.online) {
                 continue;

--- a/src/irc/ClientPool.ts
+++ b/src/irc/ClientPool.ts
@@ -486,7 +486,7 @@ export class ClientPool {
         return nickUserIdMap;
     }
 
-    public getConnectedMatrixUsersForServer(server: IrcServer): string[] {
+    public getConnectedMatrixUsersForServer(server: IrcServer): (string|null)[] {
         const users = this.virtualClients[server.domain];
         if (!users) {
             throw Error("Cannot get users for unknown server");


### PR DESCRIPTION
Fixes:
```
Connection reaping for chat.freenode.net
Found 25486 real users for chat.freenode.net
TypeError: Cannot read property 'split' of null
```