### PR TITLE
Changed docker port numbers to be consistent

### DIFF
--- a/Dockerfile.README.md
+++ b/Dockerfile.README.md
@@ -24,7 +24,7 @@ namespaces:
   aliases:
     - exclusive: true
       regex: '#irc_.*:localhost' # localhost should be your homeserver's server_name
-url: 'http://localhost:9995'
+url: 'http://localhost:9999'
 sender_localpart: irc_bot
 rate_limited: false
 protocols:
@@ -39,4 +39,4 @@ If you are storing passwords for users, you should also run:
 openssl genpkey -out ./dockerdata/passkey.pem -outform PEM -algorithm RSA -pkeyopt rsa_keygen_bits:2048
 ```
 
-You can now run your shiny new image using `docker run -p 9995:1234 -v $PWD/dockerdata:/app/data`.
+You can now run your shiny new image using `docker run -p 9999:9999 -v $PWD/dockerdata:/app/data`.

--- a/changelog.d/1048.doc
+++ b/changelog.d/1048.doc
@@ -1,0 +1,1 @@
+Corrects tutorial port numbers for docker so that copying/pasting will properly run with default port numbers.


### PR DESCRIPTION
The tutorial uses 9995 externally, but all other documentation uses 9999 externally. The internal port is set to 1234, but this is also wrong as it will assume 9999 internally by default.