### PR TITLE
Add configurable limit to the number of rooms that can be provisioned

### DIFF
--- a/changelog.d/1060.bugfix
+++ b/changelog.d/1060.bugfix
@@ -1,1 +1,1 @@
-Add ability to limit the number of rooms that an instance can be bridged to
+Add ability to limit the number of rooms that an instance can be bridged.

--- a/changelog.d/1060.bugfix
+++ b/changelog.d/1060.bugfix
@@ -1,0 +1,1 @@
+Add ability to limit the number of rooms that an instance can be bridged to

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -450,7 +450,7 @@ ircService:
     # Watch the file for changes, and apply the rules. Default: false
     enableReload: true
     # Number of channels allowed to be bridged
-    channelLimit: 50
+    roomLimit: 50
 
   # WARNING: The bridge needs to send plaintext passwords to the IRC server, it cannot
   # send a password hash. As a result, passwords (NOT hashes) are stored encrypted in

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -449,6 +449,8 @@ ircService:
     ruleFile: "./provisioning.rules.yaml"
     # Watch the file for changes, and apply the rules. Default: false
     enableReload: true
+    # Number of channels allowed to be bridged
+    channelLimit: 50
 
   # WARNING: The bridge needs to send plaintext passwords to the IRC server, it cannot
   # send a password hash. As a result, passwords (NOT hashes) are stored encrypted in

--- a/config.schema.yml
+++ b/config.schema.yml
@@ -105,7 +105,7 @@ properties:
                         type: "string"
                     enableReload:
                         type: "boolean"
-                    channelLimit:
+                    roomLimit:
                         type: "number" 
             passwordEncryptionKeyPath:
                 type: "string"

--- a/config.schema.yml
+++ b/config.schema.yml
@@ -105,6 +105,8 @@ properties:
                         type: "string"
                     enableReload:
                         type: "boolean"
+                    channelLimit:
+                        type: "number" 
             passwordEncryptionKeyPath:
                 type: "string"
             matrixHandler:

--- a/src/bridge/IrcBridge.ts
+++ b/src/bridge/IrcBridge.ts
@@ -1113,7 +1113,7 @@ export class IrcBridge {
     }
 
     public async atBridgedRoomLimit() {
-        const limit = this.config.ircService.provisioning.roomLimit;
+        const limit = this.config.ircService.provisioning?.roomLimit;
         if (!limit) {
             return false;
         }

--- a/src/bridge/IrcBridge.ts
+++ b/src/bridge/IrcBridge.ts
@@ -1113,7 +1113,7 @@ export class IrcBridge {
     }
 
     public async atBridgedRoomLimit() {
-        const limit = this.config.ircService.provisioning.channelLimit;
+        const limit = this.config.ircService.provisioning.roomLimit;
         if (!limit) {
             return false;
         }

--- a/src/bridge/IrcBridge.ts
+++ b/src/bridge/IrcBridge.ts
@@ -1118,6 +1118,6 @@ export class IrcBridge {
             return false;
         }
         const current = await this.dataStore.getRoomCount();
-        return current < limit;
+        return current >= limit;
     }
 }

--- a/src/bridge/IrcBridge.ts
+++ b/src/bridge/IrcBridge.ts
@@ -1111,4 +1111,13 @@ export class IrcBridge {
         }
         logCb(`Quit ${offlineCount}/${users.length}`);
     }
+
+    public async atBridgedRoomLimit() {
+        const limit = this.config.ircService.provisioning.channelLimit;
+        if (!limit) {
+            return false;
+        }
+        const current = await this.dataStore.getRoomCount();
+        return current < limit;
+    }
 }

--- a/src/config/BridgeConfig.ts
+++ b/src/config/BridgeConfig.ts
@@ -27,7 +27,7 @@ export interface BridgeConfig {
             requestTimeoutSeconds: number;
             ruleFile: string;
             enableReload: boolean;
-            channelLimit?: number;
+            roomLimit?: number;
         };
         logging: LoggerConfig;
         debugApi: {

--- a/src/config/BridgeConfig.ts
+++ b/src/config/BridgeConfig.ts
@@ -27,6 +27,7 @@ export interface BridgeConfig {
             requestTimeoutSeconds: number;
             ruleFile: string;
             enableReload: boolean;
+            channelLimit?: number;
         };
         logging: LoggerConfig;
         debugApi: {

--- a/src/datastore/DataStore.ts
+++ b/src/datastore/DataStore.ts
@@ -176,5 +176,7 @@ export interface DataStore {
 
     deactivateUser(userId: string): Promise<void>;
 
+    getRoomCount(): Promise<number>;
+
     destroy(): Promise<void>;
 }

--- a/src/datastore/NedbDataStore.ts
+++ b/src/datastore/NedbDataStore.ts
@@ -667,6 +667,17 @@ export class NeDBDataStore implements DataStore {
         return user?.get("deactivated") === true;
     }
 
+    public async getRoomCount() {
+        const entries = await this.roomStore.select(
+            {
+                matrix_id: {$exists: true},
+                remote_id: {$exists: true},
+                'remote.type': "channel"
+            }
+        );
+        return entries.length;
+    }
+
     public async roomUpgradeOnRoomMigrated(oldRoomId: string, newRoomId: string) {
         const ircRooms = await this.getIrcChannelsForRoomId(oldRoomId);
         for (const ircRoom of ircRooms) {

--- a/src/datastore/postgres/PgDataStore.ts
+++ b/src/datastore/postgres/PgDataStore.ts
@@ -588,6 +588,11 @@ export class PgDataStore implements DataStore {
         log.info(`Database schema is at version v${currentVersion}`);
     }
 
+    public async getRoomCount(): Promise<number> {
+        const res = await this.pgPool.query(`SELECT COUNT(*) FROM rooms`);
+        return res.rows[0];
+    }
+
     public async destroy() {
         log.info("Destroy called");
         if (this.hasEnded) {

--- a/src/provisioning/Provisioner.ts
+++ b/src/provisioning/Provisioner.ts
@@ -1092,7 +1092,7 @@ export class Provisioner {
 
     private getLimits() {
         const count = this.ircBridge.getStore().getRoomCount();
-        const limit = this.ircBridge.config.ircService.provisioning?.channelLimit || false;
+        const limit = this.ircBridge.config.ircService.provisioning?.roomLimit || false;
         return {
             count,
             limit,


### PR DESCRIPTION
This does some basic checks to see if the bridge has reached the configured maximum number of rooms when provisioning. It also adds a endpoint to check the current number and limit.