### PR TITLE
Add metrics worker

### DIFF
--- a/changelog.d/1069.feature
+++ b/changelog.d/1069.feature
@@ -1,0 +1,1 @@
+Split out metrics endpoint to a seperate worker

--- a/config.schema.yml
+++ b/config.schema.yml
@@ -55,6 +55,10 @@ properties:
                 properties:
                     enabled:
                         type: "boolean"
+                    port:
+                        type: "number"
+                    host:
+                        type: "string"
                     remoteUserAgeBuckets:
                         type: "array"
                         items:

--- a/package-lock.json
+++ b/package-lock.json
@@ -79,6 +79,14 @@
       "integrity": "sha512-trGNYSfwq5s0SgM1BMEB8hX3NDmO7EP2wsDGDexiaKMB92BaRpS+qZfpkMqUBhcsOTBwNy9B/jieo4ad/t/z2g==",
       "dev": true
     },
+    "@babel/runtime": {
+      "version": "7.10.3",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.3.tgz",
+      "integrity": "sha512-RzGO0RLSdokm9Ipe/YD+7ww8X2Ro79qiXZF3HU9ljrM+qnJmH1Vqth+hbiQZy761LnMJTMitHDuKVYTk3k4dLw==",
+      "requires": {
+        "regenerator-runtime": "^0.13.4"
+      }
+    },
     "@babel/template": {
       "version": "7.8.6",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.6.tgz",
@@ -327,6 +335,11 @@
       "integrity": "sha512-L8ogeT6vDzT1vxlW3KITTCt+BVXXVkLXfZ/XNm6UqbcJgxf+KPO7yjWx7dQQE8RW07KopL10x2gNMs41+IkMGQ==",
       "dev": true
     },
+    "@types/qs": {
+      "version": "6.9.3",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.3.tgz",
+      "integrity": "sha512-7s9EQWupR1fTc2pSMtXRQ9w9gLOcrJn+h7HOXw4evxyvVqMi4f+q7d2tnFe3ng3SNHjtK+0EzGMGFUQX4/AQRA=="
+    },
     "@types/range-parser": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.3.tgz",
@@ -572,15 +585,6 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.1.tgz",
       "integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug=="
     },
-    "babel-runtime": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-      "requires": {
-        "core-js": "^2.4.0",
-        "regenerator-runtime": "^0.11.0"
-      }
-    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -631,8 +635,7 @@
     "bintrees": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.1.tgz",
-      "integrity": "sha1-DmVcm5wkNeqraL9AJyJtK1WjRSQ=",
-      "dev": true
+      "integrity": "sha1-DmVcm5wkNeqraL9AJyJtK1WjRSQ="
     },
     "bluebird": {
       "version": "3.7.2",
@@ -883,11 +886,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
-    },
-    "core-js": {
-      "version": "2.6.11",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
-      "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -1321,9 +1319,9 @@
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
     },
     "eventemitter3": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.0.tgz",
-      "integrity": "sha512-qerSRB0p+UDEssxTtm6EDKcE7W4OaoisfIMl4CngyEhjpYglocpNg6UEqCvemdGhosAsg4sO2dXJOdyBifPGCg=="
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.4.tgz",
+      "integrity": "sha512-rlaVLnVxtxvoyLsQQFBx53YmXHDxRIzzTLbdfxqi4yocpSjAxXwkU0cScM5JgSKMqEhrZpnvQ2D9gjylR0AimQ=="
     },
     "express": {
       "version": "4.17.1",
@@ -2321,25 +2319,38 @@
       }
     },
     "matrix-appservice-bridge": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/matrix-appservice-bridge/-/matrix-appservice-bridge-1.12.2.tgz",
-      "integrity": "sha512-cGD31MLi4ARnx4DIyJndIhHIsNjaWUoBMXeAbnHhvkwkdVgZ9pgA6IKKmcBCFfsNX1r/I04KjcjlKpVdmZu4VQ==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/matrix-appservice-bridge/-/matrix-appservice-bridge-1.13.0.tgz",
+      "integrity": "sha512-STR2eF+IX2RNmFAgP5X2D5L7QCi2oMXXaIVqjimZ7KJGHuJg4SCCTt7Y+QWjjRzVnf8Eg9vXzFtH4WL8x/AGsQ==",
       "requires": {
+        "@types/express": "^4.17.6",
         "bluebird": "^2.9.34",
         "chalk": "^2.4.1",
         "extend": "^3.0.0",
         "is-my-json-valid": "^2.19.0",
         "js-yaml": "^3.12.0",
         "matrix-appservice": "^0.4.1",
-        "matrix-js-sdk": "^2.3.0",
+        "matrix-js-sdk": "^6.0.0",
         "nedb": "^1.1.3",
         "nopt": "^3.0.3",
         "p-queue": "^6.3.0",
+        "prom-client": "^12.0.0",
         "request": "^2.61.0",
         "winston": "^3.1.0",
         "winston-daily-rotate-file": "^3.3.3"
       },
       "dependencies": {
+        "@types/express": {
+          "version": "4.17.6",
+          "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.6.tgz",
+          "integrity": "sha512-n/mr9tZI83kd4azlPG5y997C/M4DNABK9yErhFM6hKdym4kkmd9j0vtsJyjFIwfRBxtrxZtAfGZCNRIBMFLK5w==",
+          "requires": {
+            "@types/body-parser": "*",
+            "@types/express-serve-static-core": "*",
+            "@types/qs": "*",
+            "@types/serve-static": "*"
+          }
+        },
         "bluebird": {
           "version": "2.11.0",
           "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
@@ -2445,13 +2456,12 @@
       }
     },
     "matrix-js-sdk": {
-      "version": "2.4.6",
-      "resolved": "https://registry.npmjs.org/matrix-js-sdk/-/matrix-js-sdk-2.4.6.tgz",
-      "integrity": "sha512-ydU64WwAYFjaTJ7JTv/JM3HmSY7leHWm3x3j0J4KWVhDDxsLoQ/v8Tc6FwlVom9/B9VvGTk+AG3aY0zgNk8LQg==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/matrix-js-sdk/-/matrix-js-sdk-6.2.2.tgz",
+      "integrity": "sha512-uTXmKVzl7GXM3R70cl2E87H+mtwN3ILqPeB80Z/2ITN9Vaf9pMURCCAuHePEBXbhnD7DOZj7Cke42uP+ByR6Hw==",
       "requires": {
+        "@babel/runtime": "^7.8.3",
         "another-json": "^0.2.0",
-        "babel-runtime": "^6.26.0",
-        "bluebird": "3.5.5",
         "browser-request": "^0.3.3",
         "bs58": "^4.0.1",
         "content-type": "^1.0.2",
@@ -2459,13 +2469,6 @@
         "qs": "^6.5.2",
         "request": "^2.88.0",
         "unhomoglyph": "^1.0.2"
-      },
-      "dependencies": {
-        "bluebird": {
-          "version": "3.5.5",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz",
-          "integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w=="
-        }
       }
     },
     "matrix-lastactive": {
@@ -2794,9 +2797,9 @@
       }
     },
     "p-queue": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.3.0.tgz",
-      "integrity": "sha512-fg5dJlFpd5+3CgG3/0ogpVZUeJbjiyXFg0nu53hrOYsybqSiDyxyOpad0Rm6tAiGjgztAwkyvhlYHC53OiAJOA==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.4.0.tgz",
+      "integrity": "sha512-X7ddxxiQ+bLR/CUt3/BVKrGcJDNxBr0pEEFKHHB6vTPWNUhgDv36GpIH18RmGM3YGPpBT+JWGjDDqsVGuF0ERw==",
       "requires": {
         "eventemitter3": "^4.0.0",
         "p-timeout": "^3.1.0"
@@ -3036,7 +3039,6 @@
       "version": "12.0.0",
       "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-12.0.0.tgz",
       "integrity": "sha512-JbzzHnw0VDwCvoqf8y1WDtq4wSBAbthMB1pcVI/0lzdqHGJI3KBJDXle70XK+c7Iv93Gihqo0a5LlOn+g8+DrQ==",
-      "dev": true,
       "requires": {
         "tdigest": "^0.1.1"
       }
@@ -3143,9 +3145,9 @@
       }
     },
     "regenerator-runtime": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+      "version": "0.13.5",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
+      "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
     },
     "regexpp": {
       "version": "2.0.1",
@@ -3595,7 +3597,6 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.1.tgz",
       "integrity": "sha1-Ljyyw56kSeVdHmzZEReszKRYgCE=",
-      "dev": true,
       "requires": {
         "bintrees": "1.0.1"
       }
@@ -3719,9 +3720,9 @@
       "integrity": "sha1-YaajIBBiKvoHljvzJSA88SI51gQ="
     },
     "unhomoglyph": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/unhomoglyph/-/unhomoglyph-1.0.5.tgz",
-      "integrity": "sha512-rNAw2rGogjq4BVhsCX8K6qXrCcHmUaMCHETlUG0ujGZ3OHwnzJHwdMyzy3n/c9Y7lvlbckOd9nkW33grUVE3bg=="
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/unhomoglyph/-/unhomoglyph-1.0.6.tgz",
+      "integrity": "sha512-7uvcWI3hWshSADBu4JpnyYbTVc7YlhF5GDW/oPD5AxIxl34k4wXR3WDkPnzLxkN32LiTCTKMQLtKVZiwki3zGg=="
     },
     "unpipe": {
       "version": "1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -631,7 +631,8 @@
     "bintrees": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.1.tgz",
-      "integrity": "sha1-DmVcm5wkNeqraL9AJyJtK1WjRSQ="
+      "integrity": "sha1-DmVcm5wkNeqraL9AJyJtK1WjRSQ=",
+      "dev": true
     },
     "bluebird": {
       "version": "3.7.2",
@@ -2334,7 +2335,6 @@
         "nedb": "^1.1.3",
         "nopt": "^3.0.3",
         "p-queue": "^6.3.0",
-        "prom-client": "^11.1.1",
         "request": "^2.61.0",
         "winston": "^3.1.0",
         "winston-daily-rotate-file": "^3.3.3"
@@ -3033,9 +3033,10 @@
       "dev": true
     },
     "prom-client": {
-      "version": "11.5.3",
-      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-11.5.3.tgz",
-      "integrity": "sha512-iz22FmTbtkyL2vt0MdDFY+kWof+S9UB/NACxSn2aJcewtw+EERsen0urSkZ2WrHseNdydsvcxCTAnPcSMZZv4Q==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-12.0.0.tgz",
+      "integrity": "sha512-JbzzHnw0VDwCvoqf8y1WDtq4wSBAbthMB1pcVI/0lzdqHGJI3KBJDXle70XK+c7Iv93Gihqo0a5LlOn+g8+DrQ==",
+      "dev": true,
       "requires": {
         "tdigest": "^0.1.1"
       }
@@ -3594,6 +3595,7 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.1.tgz",
       "integrity": "sha1-Ljyyw56kSeVdHmzZEReszKRYgCE=",
+      "dev": true,
       "requires": {
         "bintrees": "1.0.1"
       }

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "eslint": "^5.16.0",
     "jasmine": "^3.1.0",
     "nyc": "^14.1.1",
-    "prom-client": "^11.5.3",
+    "prom-client": "^12.0.0",
     "proxyquire": "^1.4.0",
     "typescript": "^3.7.3"
   }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "js-yaml": "^3.2.7",
     "logform": "^2.1.2",
     "matrix-appservice": "^0.4.1",
-    "matrix-appservice-bridge": "^1.12.2",
+    "matrix-appservice-bridge": "^1.13.0",
     "matrix-lastactive": "^0.1.3",
     "nedb": "^1.1.2",
     "nopt": "^3.0.1",

--- a/src/bridge/IrcBridge.ts
+++ b/src/bridge/IrcBridge.ts
@@ -35,6 +35,8 @@ import { MatrixAction } from "../models/MatrixAction";
 import { BridgeConfig } from "../config/BridgeConfig";
 import { MembershipQueue } from "../util/MembershipQueue";
 import { BridgeStateSyncer } from "./BridgeStateSyncer";
+import { spawnMetricsWorker } from "../workers/MetricsWorker";
+import { Registry } from "prom-client";
 
 const log = getLogger("IrcBridge");
 const DEFAULT_PORT = 8090;
@@ -61,8 +63,8 @@ export class IrcBridge {
     private bridge: Bridge;
     private appservice: AppService;
     private timers: {
-        matrix_request_seconds: Histogram;
-        remote_request_seconds: Histogram;
+        matrix_request_seconds: Histogram<string>;
+        remote_request_seconds: Histogram<string>;
     }|null = null;
     private membershipCache: MembershipCache;
     private readonly membershipQueue: MembershipQueue;
@@ -183,8 +185,22 @@ export class IrcBridge {
 
     private initialiseMetrics() {
         const zeroAge = new PrometheusMetrics.AgeCounters();
+        const registry = new Registry();
 
-        const metrics = this.bridge.getPrometheusMetrics();
+        const usingRemoteMetrics = !!this.config.ircService.metrics.port;
+
+        const metrics = this.bridge.getPrometheusMetrics(!usingRemoteMetrics, registry);
+
+        if (this.config.ircService.metrics.port) {
+            log.info(`Spawned metrics worker on http://${this.config.ircService.metrics.host}:${this.config.ircService.metrics.port}`);
+            spawnMetricsWorker(
+                this.config.ircService.metrics.port,
+                this.config.ircService.metrics.host,
+                () => {
+                    return registry.metrics();
+                }
+            );
+        }
 
         this.bridge.registerBridgeGauges(() => {
             const remoteUsersByAge = new PrometheusMetrics.AgeCounters(

--- a/src/bridge/IrcBridge.ts
+++ b/src/bridge/IrcBridge.ts
@@ -192,7 +192,9 @@ export class IrcBridge {
         const metrics = this.bridge.getPrometheusMetrics(!usingRemoteMetrics, registry);
 
         if (this.config.ircService.metrics.port) {
-            log.info(`Spawned metrics worker on http://${this.config.ircService.metrics.host}:${this.config.ircService.metrics.port}`);
+            log.info(
+            `Started metrics on http://${this.config.ircService.metrics.host}:${this.config.ircService.metrics.port}`
+            );
             spawnMetricsWorker(
                 this.config.ircService.metrics.port,
                 this.config.ircService.metrics.host,

--- a/src/config/BridgeConfig.ts
+++ b/src/config/BridgeConfig.ts
@@ -38,6 +38,8 @@ export interface BridgeConfig {
         databaseUri?: string;
         metrics: {
             enabled: boolean;
+            port?: number;
+            host?: string;
             remoteUserAgeBuckets: string[];
         };
         passwordEncryptionKeyPath?: string;

--- a/src/workers/MetricsWorker.ts
+++ b/src/workers/MetricsWorker.ts
@@ -37,7 +37,7 @@ function workerThread() {
             res.write(`${registry.metrics()}`);
             res.end();
         }, METRICS_DUMP_TIMEOUT_MS)
-        // eslint-disable-next-line no-unused-expressions
+
         parentPort?.once("message", (msg) => {
             clearTimeout(timeout);
             const time = Date.now();
@@ -48,7 +48,7 @@ function workerThread() {
             res.write(`${dump}\n${registry.metrics()}`);
             res.end();
         });
-        // eslint-disable-next-line no-unused-expressions
+
         parentPort?.postMessage("metricsdump");
     }).listen(workerData.port, workerData.hostname, 1);
 }
@@ -62,7 +62,7 @@ export function spawnMetricsWorker(port: number, hostname = "127.0.0.1", onMetri
         }
         else if (msg.startsWith("log")) {
             const [, logLevel, logMsg] = msg.split(":");
-            workerLogger.log(logLevel, logMsg);
+            workerLogger.log(logLevel, logMsg, { loggerName: "MetricsWorker" });
         }
     })
     return worker;

--- a/src/workers/MetricsWorker.ts
+++ b/src/workers/MetricsWorker.ts
@@ -41,7 +41,7 @@ function workerThread() {
         // We've checked for the existence of parentPort above.
 
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        parentPort!.once("message", (msg) => {
+        parentPort!.once("message", (msg: string) => {
             clearTimeout(timeout);
             const time = Date.now();
             intervalCounter.set(time - lastDumpTs);
@@ -60,7 +60,7 @@ function workerThread() {
 export function spawnMetricsWorker(port: number, hostname = "127.0.0.1", onMetricsRequested: () => string) {
     const worker = new Worker(__filename, { workerData: { port, hostname } });
     const workerLogger = getLog("MetricsWorker");
-    worker.on("message", (msg) => {
+    worker.on("message", (msg: string) => {
         if (msg === "metricsdump") {
             worker.postMessage("metricsdump:" + onMetricsRequested());
         }

--- a/src/workers/MetricsWorker.ts
+++ b/src/workers/MetricsWorker.ts
@@ -38,7 +38,10 @@ function workerThread() {
             res.end();
         }, METRICS_DUMP_TIMEOUT_MS)
 
-        parentPort?.once("message", (msg) => {
+        // We've checked for the existence of parentPort above.
+
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        parentPort!.once("message", (msg) => {
             clearTimeout(timeout);
             const time = Date.now();
             intervalCounter.set(time - lastDumpTs);
@@ -49,7 +52,8 @@ function workerThread() {
             res.end();
         });
 
-        parentPort?.postMessage("metricsdump");
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        parentPort!.postMessage("metricsdump");
     }).listen(workerData.port, workerData.hostname, 1);
 }
 

--- a/src/workers/MetricsWorker.ts
+++ b/src/workers/MetricsWorker.ts
@@ -1,0 +1,73 @@
+import { Worker, isMainThread, parentPort, workerData } from "worker_threads";
+import { createServer } from "http";
+import { Registry, Gauge } from "prom-client";
+import getLog from "../logging";
+const METRICS_DUMP_TIMEOUT_MS = 20000;
+
+function writeLog(level: string, msg: string) {
+    return parentPort?.postMessage(`log:${level}:${msg}`);
+}
+
+function workerThread() {
+    let lastDumpTs = Date.now();
+
+    const registry = new Registry();
+    const intervalCounter = new Gauge({
+        name: "metrics_worker_interval",
+        help: "Interval time for metrics being reported to the metrics worker process",
+        registers: [registry]
+    });
+
+    if (!parentPort) {
+        throw Error("Missing parentPort");
+    }
+
+    createServer((req, res) => {
+        res.setHeader("Content-Type", "text/plain");
+        if (!req.url || req.url !== "/metrics" || req.method !== "GET") {
+            res.statusCode = 404;
+            res.write('Path or method not known');
+            res.end();
+            return;
+        }
+        writeLog("debug", "Request for /metrics");
+        const timeout = setTimeout(() => {
+            intervalCounter.inc(METRICS_DUMP_TIMEOUT_MS);
+            res.statusCode = 200;
+            res.write(`${registry.metrics()}`);
+            res.end();
+        }, METRICS_DUMP_TIMEOUT_MS)
+        // eslint-disable-next-line no-unused-expressions
+        parentPort?.once("message", (msg) => {
+            clearTimeout(timeout);
+            const time = Date.now();
+            intervalCounter.set(time - lastDumpTs);
+            lastDumpTs = time;
+            const dump = msg.substr('metricsdump:'.length);
+            res.statusCode = 200;
+            res.write(`${dump}\n${registry.metrics()}`);
+            res.end();
+        });
+        // eslint-disable-next-line no-unused-expressions
+        parentPort?.postMessage("metricsdump");
+    }).listen(workerData.port, workerData.hostname, 1);
+}
+
+export function spawnMetricsWorker(port: number, hostname = "127.0.0.1", onMetricsRequested: () => string) {
+    const worker = new Worker(__filename, { workerData: { port, hostname } });
+    const workerLogger = getLog("MetricsWorker");
+    worker.on("message", (msg) => {
+        if (msg === "metricsdump") {
+            worker.postMessage("metricsdump:" + onMetricsRequested());
+        }
+        else if (msg.startsWith("log")) {
+            const [, logLevel, logMsg] = msg.split(":");
+            workerLogger.log(logLevel, logMsg);
+        }
+    })
+    return worker;
+}
+
+if (!isMainThread) {
+    workerThread();
+}

--- a/types/matrix-appservice-bridge/index.d.ts
+++ b/types/matrix-appservice-bridge/index.d.ts
@@ -30,9 +30,9 @@ declare module 'matrix-appservice-bridge' {
 
     export class PrometheusMetrics {
         addCollector(cb: () => void): void;
-        addCounter(opts: { name: string; help: string; labels: string[]; }): import("prom-client").Counter
-        addTimer(opts: { name: string; help: string; labels: string[]; }): import("prom-client").Histogram;
-        addGauge(arg0: { name: string; help: string; labels: string[]; }): import("prom-client").Gauge;
+        addCounter(opts: { name: string; help: string; labels: string[]; }): import("prom-client").Counter<string>
+        addTimer(opts: { name: string; help: string; labels: string[]; }): import("prom-client").Histogram<string>;
+        addGauge(arg0: { name: string; help: string; labels: string[]; }): import("prom-client").Gauge<string>;
     }
 
     interface RoomMemberDict {
@@ -257,7 +257,7 @@ declare module 'matrix-appservice-bridge' {
         getBot(): AppserviceBot;
         loadDatabases(): Promise<void>;
         getRequestFactory(): RequestFactory;
-        getPrometheusMetrics(): PrometheusMetrics;
+        getPrometheusMetrics(registerEndpoint?: boolean, registry?: unknown): PrometheusMetrics;
         getIntent(userId?: string): Intent;
         getIntentFromLocalpart(localpart: string): Intent;
         requestCheckToken(req: Express.Request): boolean;


### PR DESCRIPTION
This workerizes the metrics worker *if* the configuration specifies a custom port for the metrics to be listened on. The usefulness of this is that the metrics endpoint will not timeout should the main event loop be chocked up by IRC requests, since worker threads run their own event loop.

In the future I'd like to split more work out to workers, but for now this should be a good start.