### PR TITLE
Code improvements: Simplify use of Map and RegEx methods

### DIFF
--- a/changelog.d/1076.misc
+++ b/changelog.d/1076.misc
@@ -1,0 +1,1 @@
+Code improvements: Simplify use of Map and RegEx methods

--- a/src/bridge/IrcBridge.ts
+++ b/src/bridge/IrcBridge.ts
@@ -1114,7 +1114,7 @@ export class IrcBridge {
                 // The bot user has a userId of null, ignore it.
                 continue;
             }
-            if (exclude && exclude.exec(userId)) {
+            if (exclude && exclude.test(userId)) {
                 logCb(`${userId} is excluded`);
                 continue;
             }

--- a/src/irc/ClientPool.ts
+++ b/src/irc/ClientPool.ts
@@ -369,7 +369,7 @@ export class ClientPool {
         const clientList: {[userId: string]: BridgedClient[]} = {};
         domainList.forEach((domain) => {
             this.virtualClients[domain].userIds.forEach((_value, userId) => {
-                if (userIdRegex.exec(userId) === null) {
+                if (!userIdRegex.test(userId)) {
                     return;
                 }
                 if (!clientList[userId]) {

--- a/src/irc/ClientPool.ts
+++ b/src/irc/ClientPool.ts
@@ -368,10 +368,10 @@ export class ClientPool {
         const domainList = Object.keys(this.virtualClients);
         const clientList: {[userId: string]: BridgedClient[]} = {};
         domainList.forEach((domain) => {
-            [...this.virtualClients[domain].userIds.keys()]
-            .filter(
-                (u) => userIdRegex.exec(u) !== null
-            ).forEach((userId: string) => {
+            this.virtualClients[domain].userIds.forEach((_value, userId) => {
+                if (userIdRegex.exec(userId) === null) {
+                    return;
+                }
                 if (!clientList[userId]) {
                     clientList[userId] = [];
                 }

--- a/src/irc/IrcServer.ts
+++ b/src/irc/IrcServer.ts
@@ -67,7 +67,7 @@ export class IrcServer {
 
         if (this.config.dynamicChannels.groupId !== undefined &&
             this.config.dynamicChannels.groupId.trim() !== "") {
-            this.groupIdValid = GROUP_ID_REGEX.exec(this.config.dynamicChannels.groupId) !== null;
+            this.groupIdValid = GROUP_ID_REGEX.test(this.config.dynamicChannels.groupId);
             if (!this.groupIdValid) {
                 log.warn(
     `${domain} has an incorrectly configured groupId for dynamicChannels and will not set groups.`


### PR DESCRIPTION
* Use `map.forEach()` instead of iterating a map into an unused array.
* Use `regex.test()` when we don't care about the match.