### PR TITLE
Make ESLint stricter

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -9,9 +9,13 @@
   },
   "env": {
     "node": true,
+    "es6": true,
     "jasmine": true
   },
-  "extends": ["plugin:@typescript-eslint/recommended"],
+  "extends": [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/recommended"
+  ],
   "rules": {
     "consistent-return": 2,
     "curly": 1,
@@ -55,6 +59,8 @@
     "no-unexpected-multiline": 2,
     "no-unused-expressions": 2,
     "no-use-before-define": [1, "nofunc"],
+    "no-useless-escape": 0,
+    "no-var": 2,
     "use-isnan": 2,
     "valid-typeof": 2,
     "array-bracket-spacing": [1, "never"],
@@ -78,6 +84,7 @@
     "@typescript-eslint/ban-ts-ignore": 0,
     "no-unused-vars": 0, // covered by @typescript-eslint/no-unused-vars
     "strict": ["error", "never" ],
-    "no-var": 2
+    "eqeqeq": 2,
+    "prefer-const": 2
   }
 }

--- a/changelog.d/1078.misc
+++ b/changelog.d/1078.misc
@@ -1,0 +1,1 @@
+Enable many recommended ESLint rules to catch errors

--- a/src/DebugApi.ts
+++ b/src/DebugApi.ts
@@ -72,15 +72,15 @@ export class DebugApi {
             return;
         }
 
-        if (path == "/killUser") {
+        if (path === "/killUser") {
             this.onKillUser(req, response);
             return;
         }
-        else if (req.method === "POST" && path == "/reapUsers") {
+        else if (req.method === "POST" && path === "/reapUsers") {
             this.onReapUsers(query, response);
             return;
         }
-        else if (req.method === "POST" && path == "/killPortal") {
+        else if (req.method === "POST" && path === "/killPortal") {
             this.killPortal(req, response);
             return;
         }
@@ -320,7 +320,7 @@ export class DebugApi {
         // Should we tell the room about the deletion. Defaults to true.
         const notice = !(body["leave_notice"] === false);
         // Should we remove the alias from the room. Defaults to true.
-        const remove_alias = !(body["remove_alias"] === false);
+        const removeAlias = !(body["remove_alias"] === false);
 
         if (result.error.length > 0) {
             this.wrapJsonResponse(result.error, false, response);
@@ -332,7 +332,7 @@ export class DebugApi {
     Domain: ${domain}
     Channel: ${channel}
     Leave Notice: ${notice}
-    Remove Alias: ${remove_alias}`);
+    Remove Alias: ${removeAlias}`);
 
         // Find room
         const room = await store.getRoom(
@@ -377,7 +377,7 @@ export class DebugApi {
             }
         }
 
-        if (remove_alias) {
+        if (removeAlias) {
             const roomAlias = server.getAliasFromChannel(channel);
             try {
                 await this.ircBridge.getAppServiceBridge().getIntent().client.deleteAlias(roomAlias);

--- a/src/bridge/AdminRoomHandler.ts
+++ b/src/bridge/AdminRoomHandler.ts
@@ -158,11 +158,11 @@ export class AdminRoomHandler {
             case "!help":
                 await this.showHelp(adminRoom);
                 break;
-            default:
+            default: {
                 const notice = new MatrixAction("notice",
                 "The command was not recognised. Available commands are listed by !help");
                 await this.ircBridge.sendMatrixAction(adminRoom, this.botUser, notice);
-                break;
+            }
         }
     }
 
@@ -267,7 +267,7 @@ export class AdminRoomHandler {
             // keyword could be a failed server or a malformed command
             if (!keyword.match(/^[A-Z]+$/)) {
                 // if not a domain OR is only word (which implies command)
-                if (!keyword.match(/^[a-z0-9:\.-]+$/) || args.length == 1) {
+                if (!keyword.match(/^[a-z0-9:\.-]+$/) || args.length === 1) {
                     throw new Error(`Malformed command: ${keyword}`);
                 }
                 else {
@@ -275,7 +275,7 @@ export class AdminRoomHandler {
                 }
             }
 
-            if (blacklist.indexOf(keyword) != -1) {
+            if (blacklist.includes(keyword)) {
                 throw new Error(`Command blacklisted: ${keyword}`);
             }
 

--- a/src/bridge/IrcHandler.ts
+++ b/src/bridge/IrcHandler.ts
@@ -689,7 +689,7 @@ export class IrcHandler {
                 server, kickee.nick
             );
             if (!bridgedIrcClient || bridgedIrcClient.isBot || !bridgedIrcClient.userId) {
-                return; // unexpected given isVirtual == true, but meh, bail.
+                return; // unexpected given isVirtual === true, but meh, bail.
             }
             const userId = bridgedIrcClient.userId;
             await Promise.all(matrixRooms.map((room) =>

--- a/src/datastore/NedbDataStore.ts
+++ b/src/datastore/NedbDataStore.ts
@@ -449,7 +449,7 @@ export class NeDBDataStore implements DataStore {
      */
     public async getAdminRoomById(roomId: string): Promise<MatrixRoom|null> {
         const entries: Entry[] = await this.roomStore.getEntriesByMatrixId(roomId);
-        if (entries.length == 0) {
+        if (entries.length === 0) {
             return null;
         }
         if (entries.length > 1) {

--- a/src/irc/BridgedClient.ts
+++ b/src/irc/BridgedClient.ts
@@ -56,7 +56,7 @@ export interface BridgedClientLogger {
 }
 /* eslint-enable @typescript-eslint/no-explicit-any */
 
-export const illegalCharactersRegex = /[^A-Za-z0-9\]\[\^\\\{\}\-`_\|]/g;
+export const illegalCharactersRegex = /^A-Za-z0-9\]\[\^\\\{\}\-`_\|]/g;
 
 export class BridgedClient extends EventEmitter {
     public readonly userId: string|null;
@@ -683,7 +683,7 @@ export class BridgedClient extends EventEmitter {
             // nicks can't be too long
             let maxNickLen = 9; // RFC 1459 default
             if (this.unsafeClient.supported &&
-                    typeof this.unsafeClient.supported.nicklength == "number") {
+                    typeof this.unsafeClient.supported.nicklength === "number") {
                 maxNickLen = this.unsafeClient.supported.nicklength;
             }
             if (n.length > maxNickLen) {
@@ -804,13 +804,13 @@ export class BridgedClient extends EventEmitter {
                 return;
             }
 
-            if (msgType == "action") {
+            if (msgType === "action") {
                 await this.unsafeClient.action(room.channel, text);
             }
-            else if (msgType == "notice") {
+            else if (msgType === "notice") {
                 await this.unsafeClient.notice(room.channel, text);
             }
-            else if (msgType == "message") {
+            else if (msgType === "message") {
                 await this.unsafeClient.say(room.channel, text);
             }
             defer.resolve();

--- a/src/irc/BridgedClient.ts
+++ b/src/irc/BridgedClient.ts
@@ -56,7 +56,7 @@ export interface BridgedClientLogger {
 }
 /* eslint-enable @typescript-eslint/no-explicit-any */
 
-export const illegalCharactersRegex = /^A-Za-z0-9\]\[\^\\\{\}\-`_\|]/g;
+export const illegalCharactersRegex = /^[A-Za-z0-9\]\[\^\\\{\}\-`_\|]/g;
 
 export class BridgedClient extends EventEmitter {
     public readonly userId: string|null;

--- a/src/irc/BridgedClient.ts
+++ b/src/irc/BridgedClient.ts
@@ -56,7 +56,7 @@ export interface BridgedClientLogger {
 }
 /* eslint-enable @typescript-eslint/no-explicit-any */
 
-export const illegalCharactersRegex = /^[A-Za-z0-9\]\[\^\\\{\}\-`_\|]/g;
+export const illegalCharactersRegex = /[^A-Za-z0-9\]\[\^\\\{\}\-`_\|]/g;
 
 export class BridgedClient extends EventEmitter {
     public readonly userId: string|null;

--- a/src/irc/ConnectionInstance.ts
+++ b/src/irc/ConnectionInstance.ts
@@ -188,7 +188,6 @@ export class ConnectionInstance {
                 return;
             }
             // do the callback
-            // eslint is usually confused about IArguments
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             fn.apply(fn, args as any);
         });

--- a/src/irc/IdentGenerator.ts
+++ b/src/irc/IdentGenerator.ts
@@ -226,6 +226,7 @@ export class IdentGenerator {
 
     private static sanitiseRealname(realname: string) {
         // real name can be any old ASCII
+        // eslint-disable-next-line no-control-regex
         return realname.replace(/[^\x00-\x7F]/g, "");
     }
 }

--- a/src/irc/Scheduler.ts
+++ b/src/irc/Scheduler.ts
@@ -50,6 +50,7 @@ export default {
     // Returns a promise that will be resolved when retryConnection returns a promise that
     //  resolves, in other words, when the connection is made. The promise will reject if the
     //  promise returned from retryConnection is rejected.
+    // eslint-disable-next-line require-yield
     reschedule: Bluebird.coroutine(function*(
         server: IrcServer,
         addedDelayMs: number,

--- a/src/irc/formatting.ts
+++ b/src/irc/formatting.ts
@@ -149,7 +149,9 @@ export function htmlTag(state: StyleState, name: string, open?: boolean): string
 
 export function stripIrcFormatting(text: string) {
     return text
+        // eslint-disable-next-line no-control-regex
         .replace(/(\x03\d{0,2}(,\d{0,2})?|\u200B)/g, '') // strip colors
+        // eslint-disable-next-line no-control-regex
         .replace(/[\x0F\x02\x16\x1F\x1D]/g, ''); // styles too
 }
 
@@ -259,6 +261,7 @@ export function ircToHtml(text: string): string {
     // - The colour formatting character (\x03) followed by 0 to 2 digits for
     //   the foreground colour and (optionally) a comma and 1-2 digits for the
     //   background colour.
+    // eslint-disable-next-line no-control-regex
     const colorRegex = /[\x02\x1d\x1f\x0f\x16]|\x03(\d{0,2})(?:,(\d{1,2}))?/g;
 
     // Maintain a small state machine of which tags are open so we can close the right
@@ -280,13 +283,14 @@ export function ircToHtml(text: string): string {
             case STYLE_UNDERLINE:
                 return htmlTag(state, 'u');
 
-            case REVERSE_CODE:
+            case REVERSE_CODE: {
                 // Swap the foreground and background colours.
                 const temp = state.color;
                 state.color = state.bcolor;
                 state.bcolor = temp;
                 // Close and re-open the font tag.
                 return htmlTag(state, 'font', false) + htmlTag(state, 'font', true);
+            }
 
             case RESET_CODE:
                 // Close tags

--- a/src/models/MatrixAction.ts
+++ b/src/models/MatrixAction.ts
@@ -70,7 +70,7 @@ export interface MatrixMessageEvent {
 }
 
 const MentionRegex = function(matcher: string): RegExp {
-    const WORD_BOUNDARY = "^|\:|\#|```|\\s|$|,";
+    const WORD_BOUNDARY = "^|:|#|```|\\s|$|,";
     return new RegExp(
         `(${WORD_BOUNDARY})(@?(${matcher}))(?=${WORD_BOUNDARY})`,
         "igm"
@@ -190,7 +190,7 @@ export class MatrixAction {
         switch (ircAction.type) {
             case "message":
             case "emote":
-            case "notice":
+            case "notice": {
                 const htmlText = ircFormatting.ircToHtml(ircAction.text);
                 return new MatrixAction(
                     ircAction.type,
@@ -199,6 +199,7 @@ export class MatrixAction {
                     // will send everything as HTML and never text only.
                     ircAction.text !== htmlText ? htmlText : undefined
                 );
+            }
             case "topic":
                 return new MatrixAction("topic", ircAction.text);
             default:

--- a/src/provisioning/Provisioner.ts
+++ b/src/provisioning/Provisioner.ts
@@ -619,7 +619,7 @@ export class Provisioner {
     }
 
     public async handlePm (server: IrcServer, fromUser: IrcUser, text: string) {
-        if (['y', 'yes'].indexOf(text.trim().toLowerCase()) == -1) {
+        if (!['y', 'yes'].includes(text.trim().toLowerCase())) {
             log.warn(`Provisioner only handles text 'yes'/'y' ` +
                     `(from ${fromUser.nick} on ${server.domain})`);
 
@@ -881,7 +881,7 @@ export class Provisioner {
             if (e.type === "m.room.member" && e.state_key === options.user_id) {
                 isJoined = e.content.membership === "join";
             }
-            else if (e.type == "m.room.power_levels" && e.state_key === "") {
+            else if (e.type === "m.room.power_levels" && e.state_key === "") {
                 let powerRequired = e.content.state_default;
                 if (e.content.events && e.content.events["m.room.power_levels"]) {
                     powerRequired = e.content.events["m.room.power_levels"];


### PR DESCRIPTION
* Inherit rules from "eslint-recommended".
* Add the env "es6" for globals like "Promise" (that's not included in setting `ecmaVersion` to 9)
* Prefer `array.includes()` over `array.indexOf() !== 1`.