### PR TITLE
Media filenames

### DIFF
--- a/changelog.d/1087.feature
+++ b/changelog.d/1087.feature
@@ -1,0 +1,1 @@
+Media URLs now include the filename when sent to IRC.

--- a/src/bridge/MatrixHandler.ts
+++ b/src/bridge/MatrixHandler.ts
@@ -953,7 +953,7 @@ export class MatrixHandler {
             event.content.body = "sent a long message: ";
 
             // Create a file event to reflect the recent upload
-            const mAction = MatrixAction.fromEvent(event, this.mediaUrl);
+            const mAction = MatrixAction.fromEvent(event, this.mediaUrl, "message.txt");
             const bigFileIrcAction = IrcAction.fromMatrixAction(mAction);
             if (!bigFileIrcAction) {
                 return;

--- a/src/datastore/NedbDataStore.ts
+++ b/src/datastore/NedbDataStore.ts
@@ -40,7 +40,7 @@ export class NeDBDataStore implements DataStore {
         private bridgeDomain: string,
         pkeyPath?: string) {
         const errLog = function(fieldName: string) {
-            return (err: Error) => {
+            return (err: Error|null) => {
                 if (err) {
                     log.error("Failed to ensure '%s' index on store: " + err, fieldName);
                     return;
@@ -107,7 +107,7 @@ export class NeDBDataStore implements DataStore {
             fieldName: "data.client_config." + domainKey + ".username",
             unique: true,
             sparse: true
-        }, (err: Error) => {
+        }, (err: Error|null) => {
             if (err) {
                 log.error("Failed to ensure ident username index on users database!");
                 return;

--- a/src/models/MatrixAction.ts
+++ b/src/models/MatrixAction.ts
@@ -155,7 +155,7 @@ export class MatrixAction {
         }
     }
 
-    public static fromEvent(event: MatrixMessageEvent, mediaUrl: string) {
+    public static fromEvent(event: MatrixMessageEvent, mediaUrl: string, forceFilename?: string) {
         event.content = event.content || {};
         let type = EVENT_TO_TYPE[event.type] || "message"; // mx event type to action type
         let text = event.content.body;
@@ -179,7 +179,14 @@ export class MatrixAction {
                     fileSize = " (" + Math.round(event.content.info.size / 1024) + "KB)";
                 }
 
-                const url = ContentRepo.getHttpUriForMxc(mediaUrl, event.content.url);
+                let url = ContentRepo.getHttpUriForMxc(mediaUrl, event.content.url);
+                if (forceFilename) {
+                    url += `/${forceFilename}`;
+                }
+                else if (event.content.body?.match(/\.[\w\d]{2,4}$/)) {
+                    // Add filename to url if body is a filename.
+                    url += `/${event.content.body}`;
+                }
                 text = `${event.content.body}${fileSize} < ${url} >`;
             }
         }

--- a/src/models/MatrixAction.ts
+++ b/src/models/MatrixAction.ts
@@ -155,7 +155,7 @@ export class MatrixAction {
         }
     }
 
-    public static fromEvent(event: MatrixMessageEvent, mediaUrl: string, forceFilename?: string) {
+    public static fromEvent(event: MatrixMessageEvent, mediaUrl: string, filename?: string) {
         event.content = event.content || {};
         let type = EVENT_TO_TYPE[event.type] || "message"; // mx event type to action type
         let text = event.content.body;
@@ -180,12 +180,13 @@ export class MatrixAction {
                 }
 
                 let url = ContentRepo.getHttpUriForMxc(mediaUrl, event.content.url);
-                if (forceFilename) {
-                    url += `/${forceFilename}`;
-                }
-                else if (/\.[\w\d]{2,4}$/.test(event.content.body)) {
+                if (!filename && event.content.body && /\S*\.[\w\d]{2,4}$/.test(event.content.body)) {
                     // Add filename to url if body is a filename.
-                    url += `/${event.content.body}`;
+                    filename = event.content.body;
+                }
+
+                if (filename) {
+                    url += `/${filename}`;
                 }
                 text = `${event.content.body}${fileSize} < ${url} >`;
             }

--- a/src/models/MatrixAction.ts
+++ b/src/models/MatrixAction.ts
@@ -176,14 +176,14 @@ export class MatrixAction {
                 let fileSize = "";
                 if (event.content.info && event.content.info.size &&
                         typeof event.content.info.size === "number") {
-                    fileSize = " (" + Math.round(event.content.info.size / 1024) + "KB)";
+                    fileSize = " (" + Math.round(event.content.info.size / 1024) + "KiB)";
                 }
 
                 let url = ContentRepo.getHttpUriForMxc(mediaUrl, event.content.url);
                 if (forceFilename) {
                     url += `/${forceFilename}`;
                 }
-                else if (event.content.body?.match(/\.[\w\d]{2,4}$/)) {
+                else if (/\.[\w\d]{2,4}$/.test(event.content.body)) {
                     // Add filename to url if body is a filename.
                     url += `/${event.content.body}`;
                 }


### PR DESCRIPTION
Fixes #1085 

This PR includes the filename (if given) onto a media link. It will also call all long message uploads "message.txt".