### PR TITLE
Rewrite the quit debouncer to drop quits early

### DIFF
--- a/changelog.d/1091.feature
+++ b/changelog.d/1091.feature
@@ -1,0 +1,1 @@
+The quit debouncer has been rewritten to be more performant, dropping QUITs entirely until the bridge is able to cope with them.

--- a/src/bridge/IrcBridge.ts
+++ b/src/bridge/IrcBridge.ts
@@ -410,8 +410,6 @@ export class IrcBridge {
 
         await this.dataStore.removeConfigMappings();
 
-        this.clientPool = new ClientPool(this, this.dataStore);
-
         if (this.config.ircService.debugApi.enabled) {
             this.debugApi = new DebugApi(
                 this,
@@ -453,6 +451,8 @@ export class IrcBridge {
             await this.dataStore.setServerFromConfig(server, completeConfig);
             this.ircServers.push(server);
         }
+
+        this.clientPool = new ClientPool(this, this.dataStore);
 
         if (this.ircServers.length === 0) {
             throw Error("No IRC servers specified.");

--- a/src/bridge/IrcHandler.ts
+++ b/src/bridge/IrcHandler.ts
@@ -48,8 +48,6 @@ export class IrcHandler {
     // need to re-invite them if they bail.
     private readonly roomIdToPrivateMember: RoomIdtoPrivateMember = {};
 
-    private readonly quitDebouncer: QuitDebouncer;
-
     // Use per-channel queues to keep the setting of topics in rooms atomic in
     // order to prevent races involving several topics being received from IRC
     // in quick succession. If `(server, channel, topic)` are the same, an
@@ -85,7 +83,6 @@ export class IrcHandler {
         private readonly ircBridge: IrcBridge,
         config: IrcHandlerConfig = {},
         private readonly membershipQueue: MembershipQueue) {
-        this.quitDebouncer = new QuitDebouncer(ircBridge);
         this.roomAccessSyncer = new RoomAccessSyncer(ircBridge);
         this.mentionMode = config.mapIrcMentionsToMatrix || "on";
         this.getMetrics();
@@ -613,8 +610,6 @@ export class IrcHandler {
             return BridgeRequestErr.ERR_VIRTUAL_USER;
         }
 
-        this.quitDebouncer.onJoin(nick, server);
-
         // get virtual matrix user
         const matrixUser = await this.ircBridge.getMatrixUser(joiningUser);
         const matrixRooms = await this.ircBridge.getStore().getMatrixRoomsForChannel(server, chan);
@@ -782,18 +777,6 @@ export class IrcHandler {
         }
         else {
             const matrixUser = await this.ircBridge.getMatrixUser(leavingUser);
-            // Presence syncing and Quit Debouncing
-            //  When an IRC user quits, debounce before leaving them from matrix rooms. In the meantime,
-            //  update presence to "offline". If the user rejoins a channel before timeout, do not part
-            //  user from the room. Otherwise timeout and leave rooms.
-            if (kind === "quit" && server.shouldDebounceQuits()) {
-                const shouldBridgePart = await this.quitDebouncer.debounceQuit(
-                    req, server, matrixUser, nick
-                );
-                if (!shouldBridgePart) {
-                    return undefined;
-                }
-            }
             userId = matrixUser.userId;
         }
 

--- a/src/bridge/IrcHandler.ts
+++ b/src/bridge/IrcHandler.ts
@@ -1,5 +1,4 @@
 import { IrcBridge } from "./IrcBridge";
-import { QuitDebouncer } from "./QuitDebouncer";
 import { Queue } from "../util/Queue";
 import { RoomAccessSyncer } from "./RoomAccessSyncer";
 import { IrcServer, MembershipSyncKind } from "../irc/IrcServer";

--- a/src/irc/ClientPool.ts
+++ b/src/irc/ClientPool.ts
@@ -64,6 +64,7 @@ export class ClientPool {
             this.ircBridge.getAppServiceBridge(),
             this,
             this.ircBridge.ircHandler,
+            this.ircBridge.getServers(),
         );
     }
 

--- a/src/irc/IrcEventBroker.ts
+++ b/src/irc/IrcEventBroker.ts
@@ -91,6 +91,8 @@ import { ClientPool } from "./ClientPool";
 import { BridgedClient } from "./BridgedClient";
 import { IrcMessage, ConnectionInstance } from "./ConnectionInstance";
 import { IrcHandler } from "../bridge/IrcHandler";
+import { QuitDebouncer } from "../bridge/QuitDebouncer";
+import { IrcServer } from "./IrcServer";
 
 const log = getLogger("IrcEventBroker");
 
@@ -107,12 +109,15 @@ function complete(req: BridgeRequest, promise: Promise<BridgeRequestErr|void>) {
 export class IrcEventBroker {
     private processed: ProcessedDict;
     private channelReqBuffer: {[channel: string]: Promise<unknown>} = {};
+    private quitDebouncer: QuitDebouncer;
     constructor(
         private readonly appServiceBridge: Bridge,
         private readonly pool: ClientPool,
-        private readonly ircHandler: IrcHandler) {
+        private readonly ircHandler: IrcHandler,
+        private readonly servers: string[]) {
         this.processed = new ProcessedDict();
         this.processed.startCleaner(log);
+        this.quitDebouncer = new QuitDebouncer(servers, this.handleDebouncedQuit.bind(this));
     }
 
 
@@ -200,6 +205,32 @@ export class IrcEventBroker {
                 }
             }
         });
+    }
+
+    public async handleDebouncedQuit(item: {channel: string; server: IrcServer; nicks: string[]}) {
+        const createUser = (nick: string) => {
+            return new IrcUser(
+                item.server, nick,
+                this.pool.nickIsVirtual(item.server, nick)
+            );
+        };
+
+        const createRequest = () => {
+            return new BridgeRequest(
+                this.appServiceBridge.getRequestFactory().newRequest({
+                    data: {
+                        isFromIrc: true
+                    }
+                })
+            );
+        };
+        const req = createRequest();
+        log.info(`Sending delayed QUITs for ${item.channel} with nicks ${item.nicks}`)
+        for (const nick of item.nicks) {
+            complete(req, this.ircHandler.onPart(
+                req, item.server, createUser(nick), item.channel, "quit"
+            ));
+        }
     }
 
     public sendMetadata(client: BridgedClient, msg: string, force = false, err?: IrcMessage) {
@@ -302,12 +333,14 @@ export class IrcEventBroker {
         });
         this.hookIfClaimed(client, connInst, "quit", (nick: string, reason: string, chans: string[]) => {
             chans = chans || [];
-            chans.forEach((chan) => {
-                const req = createRequest();
-                complete(req, ircHandler.onPart(
-                    req, server, createUser(nick), chan, "quit"
-                ));
-            });
+            if (!server.shouldDebounceQuits() || this.quitDebouncer.debounceQuit(nick, server, chans)) {
+                chans.forEach((chan) => {
+                    const req = createRequest();
+                    complete(req, ircHandler.onPart(
+                        req, server, createUser(nick), chan, "quit"
+                    ));
+                });
+            }
         });
         this.hookIfClaimed(client, connInst, "kick", (chan: string, nick: string, by: string, reason: string) => {
             const req = createRequest();
@@ -317,6 +350,7 @@ export class IrcEventBroker {
         });
         this.hookIfClaimed(client, connInst, "join", (chan: string, nick: string) => {
             const req = createRequest();
+            this.quitDebouncer.onJoin(nick, chan, server);
             complete(req, ircHandler.onJoin(
                 req, server, createUser(nick), chan, "join"
             ));

--- a/src/irc/IrcEventBroker.ts
+++ b/src/irc/IrcEventBroker.ts
@@ -114,7 +114,7 @@ export class IrcEventBroker {
         private readonly appServiceBridge: Bridge,
         private readonly pool: ClientPool,
         private readonly ircHandler: IrcHandler,
-        private readonly servers: string[]) {
+        servers: IrcServer[]) {
         this.processed = new ProcessedDict();
         this.processed.startCleaner(log);
         this.quitDebouncer = new QuitDebouncer(servers, this.handleDebouncedQuit.bind(this));
@@ -210,7 +210,7 @@ export class IrcEventBroker {
     /**
      * This function is called when the quit debouncer has deemed it safe to start sending
      * quits from users who were debounced.
-     * @param item 
+     * @param item The channel/server pair to send QUITs from
      */
     private async handleDebouncedQuit(item: {channel: string; server: IrcServer}) {
         const createUser = (nick: string) => {


### PR DESCRIPTION
For the uninitiated: Debouncing quits is something we do when a IRC server netsplits, to avoid the matrix server being flooded with /leave requests and/or killing the bridge.

Currently the quit debouncer code operates at the IrcHandler level, which means it's already gone through some hot paths of the code such as identifying which rooms to talk into. Furthermore, the debouncer operates by storing a deferred promise to work on later when bridging delayed QUITs.

In the field, we've noticed that the bridge will crash and burn long before it gets to this queue, so this code attempts to drop QUITs very early on, and store the work in a simple data structure to try and limit the amount of work involved when debouncing.

Please review this PR with a mindset of trying to achieve the above with the smallest per-request footprint on CPU/memory. 