### PR TITLE
Publicity sync speedup

### DIFF
--- a/changelog.d/1091.feature
+++ b/changelog.d/1091.feature
@@ -1,0 +1,1 @@
+The quit debouncer has been rewritten to be more performant, dropping QUITs entirely until the bridge is able to cope with them.

--- a/changelog.d/1111.bugfix
+++ b/changelog.d/1111.bugfix
@@ -1,0 +1,1 @@
+Speed up operations on the publicity syncer for IRC -> Matrix

--- a/src/bridge/IrcBridge.ts
+++ b/src/bridge/IrcBridge.ts
@@ -410,8 +410,6 @@ export class IrcBridge {
 
         await this.dataStore.removeConfigMappings();
 
-        this.clientPool = new ClientPool(this, this.dataStore);
-
         if (this.config.ircService.debugApi.enabled) {
             this.debugApi = new DebugApi(
                 this,
@@ -453,6 +451,8 @@ export class IrcBridge {
             await this.dataStore.setServerFromConfig(server, completeConfig);
             this.ircServers.push(server);
         }
+
+        this.clientPool = new ClientPool(this, this.dataStore);
 
         if (this.ircServers.length === 0) {
             throw Error("No IRC servers specified.");

--- a/src/bridge/IrcHandler.ts
+++ b/src/bridge/IrcHandler.ts
@@ -48,8 +48,6 @@ export class IrcHandler {
     // need to re-invite them if they bail.
     private readonly roomIdToPrivateMember: RoomIdtoPrivateMember = {};
 
-    private readonly quitDebouncer: QuitDebouncer;
-
     // Use per-channel queues to keep the setting of topics in rooms atomic in
     // order to prevent races involving several topics being received from IRC
     // in quick succession. If `(server, channel, topic)` are the same, an
@@ -85,7 +83,6 @@ export class IrcHandler {
         private readonly ircBridge: IrcBridge,
         config: IrcHandlerConfig = {},
         private readonly membershipQueue: MembershipQueue) {
-        this.quitDebouncer = new QuitDebouncer(ircBridge);
         this.roomAccessSyncer = new RoomAccessSyncer(ircBridge);
         this.mentionMode = config.mapIrcMentionsToMatrix || "on";
         this.getMetrics();
@@ -613,8 +610,6 @@ export class IrcHandler {
             return BridgeRequestErr.ERR_VIRTUAL_USER;
         }
 
-        this.quitDebouncer.onJoin(nick, server);
-
         // get virtual matrix user
         const matrixUser = await this.ircBridge.getMatrixUser(joiningUser);
         const matrixRooms = await this.ircBridge.getStore().getMatrixRoomsForChannel(server, chan);
@@ -782,18 +777,6 @@ export class IrcHandler {
         }
         else {
             const matrixUser = await this.ircBridge.getMatrixUser(leavingUser);
-            // Presence syncing and Quit Debouncing
-            //  When an IRC user quits, debounce before leaving them from matrix rooms. In the meantime,
-            //  update presence to "offline". If the user rejoins a channel before timeout, do not part
-            //  user from the room. Otherwise timeout and leave rooms.
-            if (kind === "quit" && server.shouldDebounceQuits()) {
-                const shouldBridgePart = await this.quitDebouncer.debounceQuit(
-                    req, server, matrixUser, nick
-                );
-                if (!shouldBridgePart) {
-                    return undefined;
-                }
-            }
             userId = matrixUser.userId;
         }
 

--- a/src/bridge/IrcHandler.ts
+++ b/src/bridge/IrcHandler.ts
@@ -1,5 +1,4 @@
 import { IrcBridge } from "./IrcBridge";
-import { QuitDebouncer } from "./QuitDebouncer";
 import { Queue } from "../util/Queue";
 import { RoomAccessSyncer } from "./RoomAccessSyncer";
 import { IrcServer, MembershipSyncKind } from "../irc/IrcServer";

--- a/src/bridge/PublicitySyncer.ts
+++ b/src/bridge/PublicitySyncer.ts
@@ -16,11 +16,6 @@ const log = logger("PublicitySyncer");
 
 export class PublicitySyncer {
 
-    // This is used so that any updates to the visibility map will cause the syncer to
-    // reset a timer and begin counting down again to the eventual call to solve any
-    // inconsistencies in the visibility map.
-    private solveVisibilityTimeoutId: NodeJS.Timer|null = null;
-
     // Cache the mode of each channel, the visibility of each room and the
     // known mappings between them. When any of these change, any inconsistencies
     // should be resolved by keeping the matrix side as private as necessary
@@ -45,6 +40,7 @@ export class PublicitySyncer {
         roomVisibilities: {},
     };
     constructor (private ircBridge: IrcBridge) { }
+
 
     public async initModeForChannel(server: IrcServer, chan: string) {
         try {
@@ -86,7 +82,7 @@ export class PublicitySyncer {
         return `${networkId} ${channel}`;
     }
 
-    public updateVisibilityMap(isMode: boolean, key: string, value: boolean) {
+    public updateVisibilityMap(isMode: boolean, key: string, value: boolean, channel: string, server: IrcServer) {
         let hasChanged = false;
         if (isMode) {
             if (typeof value !== 'boolean') {
@@ -109,15 +105,9 @@ export class PublicitySyncer {
         }
 
         if (hasChanged) {
-            if (this.solveVisibilityTimeoutId) {
-                clearTimeout(this.solveVisibilityTimeoutId);
-            }
-
-            this.solveVisibilityTimeoutId = setTimeout(() => {
-                this.solveVisibility().catch((err: Error) => {
-                    log.error("Failed to sync publicity: " + err.message);
-                });
-            }, 10000);
+            this.solveVisibility(channel, server).catch((err: Error) => {
+                log.error(`Failed to sync publicity for ${channel}: ` + err.message);
+            });
         }
     }
 
@@ -129,27 +119,25 @@ export class PublicitySyncer {
        then the room is assumed secret (+s).
 
        The bare minimum is done to make sure no private channels are leaked into public
-       matrix channels. If ANY +s channel is somehow being bridged into a room, that room
+       matrix rooms. If ANY +s channel is somehow being bridged into a room, that room
        is updated to private. If ALL channels somehow being bridged into a room are NOT +s,
        that room is allowed to be public.
     */
-    private async solveVisibility () {
+    private async solveVisibility (channel: string, server: IrcServer) {
         // For each room, do a big OR on all of the channels that are linked in any way
-        const mappings = await this.ircBridge.getStore().getAllChannelMappings();
-        const roomIds = Object.keys(mappings);
+        const mappings = await this.ircBridge.getStore().getMatrixRoomsForChannel(server, channel);
+        const roomIds = mappings.map((m) => m.getId());
 
         this.visibilityMap.mappings = {};
 
         roomIds.forEach((roomId) => {
-            this.visibilityMap.mappings[roomId] = mappings[roomId].map((mapping) => {
-                const key = this.getIRCVisMapKey(mapping.networkId, mapping.channel);
-                // also assign reverse mapping for lookup speed later
-                if (!this.visibilityMap.networkToRooms[key]) {
-                    this.visibilityMap.networkToRooms[key] = [];
-                }
-                this.visibilityMap.networkToRooms[key].push(roomId);
-                return key;
-            });
+            const key = this.getIRCVisMapKey(server.getNetworkId(), channel);
+            // also assign reverse mapping for lookup speed later
+            if (!this.visibilityMap.networkToRooms[key]) {
+                this.visibilityMap.networkToRooms[key] = [];
+            }
+            this.visibilityMap.networkToRooms[key].push(roomId);
+            return key;
         });
 
         const shouldBePrivate = (roomId: string, checkedChannels: string[]): boolean => {

--- a/src/bridge/PublicitySyncer.ts
+++ b/src/bridge/PublicitySyncer.ts
@@ -152,9 +152,12 @@ export class PublicitySyncer {
             ...await this.ircBridge.getStore().getRoomsVisibility(roomIds),
         };
 
-        const promises = roomIds.map(async (roomId) => {
+        const correctState = this.visibilityMap.channelIsSecret[channel] ? 'private' : 'public';
+
+        log.info(`Solved visibility rules for ${channel} (${server.getNetworkId()}): ${correctState}`);
+
+        return Promise.all(roomIds.map(async (roomId) => {
             const currentState = currentStates[roomId];
-            const correctState: "private"|"public" = this.visibilityMap.channelIsSecret[channel] ? 'private' : 'public';
 
             // Use the server network ID of the first mapping
             // 'funNetwork #channel1' => 'funNetwork'
@@ -171,8 +174,6 @@ export class PublicitySyncer {
                     log.error(`Failed to setRoomDirectoryVisibility (${ex.message})`);
                 }
             }
-        });
-
-        return Promise.all(promises);
+        }));
     }
 }

--- a/src/bridge/RoomAccessSyncer.ts
+++ b/src/bridge/RoomAccessSyncer.ts
@@ -311,7 +311,7 @@ export class RoomAccessSyncer {
             });
             // Update the visibility for all rooms connected to this channel
             this.ircBridge.publicitySyncer.updateVisibilityMap(
-                true, key, enabled
+                true, key, enabled, channel, server,
             );
         }
         // "k" and "i"

--- a/src/irc/ClientPool.ts
+++ b/src/irc/ClientPool.ts
@@ -64,6 +64,7 @@ export class ClientPool {
             this.ircBridge.getAppServiceBridge(),
             this,
             this.ircBridge.ircHandler,
+            this.ircBridge.getServers(),
         );
     }
 

--- a/src/irc/IrcEventBroker.ts
+++ b/src/irc/IrcEventBroker.ts
@@ -91,6 +91,8 @@ import { ClientPool } from "./ClientPool";
 import { BridgedClient } from "./BridgedClient";
 import { IrcMessage, ConnectionInstance } from "./ConnectionInstance";
 import { IrcHandler } from "../bridge/IrcHandler";
+import { QuitDebouncer } from "../bridge/QuitDebouncer";
+import { IrcServer } from "./IrcServer";
 
 const log = getLogger("IrcEventBroker");
 
@@ -107,12 +109,15 @@ function complete(req: BridgeRequest, promise: Promise<BridgeRequestErr|void>) {
 export class IrcEventBroker {
     private processed: ProcessedDict;
     private channelReqBuffer: {[channel: string]: Promise<unknown>} = {};
+    private quitDebouncer: QuitDebouncer;
     constructor(
         private readonly appServiceBridge: Bridge,
         private readonly pool: ClientPool,
-        private readonly ircHandler: IrcHandler) {
+        private readonly ircHandler: IrcHandler,
+        private readonly servers: string[]) {
         this.processed = new ProcessedDict();
         this.processed.startCleaner(log);
+        this.quitDebouncer = new QuitDebouncer(servers, this.handleDebouncedQuit.bind(this));
     }
 
 
@@ -200,6 +205,32 @@ export class IrcEventBroker {
                 }
             }
         });
+    }
+
+    public async handleDebouncedQuit(item: {channel: string; server: IrcServer; nicks: string[]}) {
+        const createUser = (nick: string) => {
+            return new IrcUser(
+                item.server, nick,
+                this.pool.nickIsVirtual(item.server, nick)
+            );
+        };
+
+        const createRequest = () => {
+            return new BridgeRequest(
+                this.appServiceBridge.getRequestFactory().newRequest({
+                    data: {
+                        isFromIrc: true
+                    }
+                })
+            );
+        };
+        const req = createRequest();
+        log.info(`Sending delayed QUITs for ${item.channel} with nicks ${item.nicks}`)
+        for (const nick of item.nicks) {
+            complete(req, this.ircHandler.onPart(
+                req, item.server, createUser(nick), item.channel, "quit"
+            ));
+        }
     }
 
     public sendMetadata(client: BridgedClient, msg: string, force = false, err?: IrcMessage) {
@@ -302,12 +333,14 @@ export class IrcEventBroker {
         });
         this.hookIfClaimed(client, connInst, "quit", (nick: string, reason: string, chans: string[]) => {
             chans = chans || [];
-            chans.forEach((chan) => {
-                const req = createRequest();
-                complete(req, ircHandler.onPart(
-                    req, server, createUser(nick), chan, "quit"
-                ));
-            });
+            if (!server.shouldDebounceQuits() || this.quitDebouncer.debounceQuit(nick, server, chans)) {
+                chans.forEach((chan) => {
+                    const req = createRequest();
+                    complete(req, ircHandler.onPart(
+                        req, server, createUser(nick), chan, "quit"
+                    ));
+                });
+            }
         });
         this.hookIfClaimed(client, connInst, "kick", (chan: string, nick: string, by: string, reason: string) => {
             const req = createRequest();
@@ -317,6 +350,7 @@ export class IrcEventBroker {
         });
         this.hookIfClaimed(client, connInst, "join", (chan: string, nick: string) => {
             const req = createRequest();
+            this.quitDebouncer.onJoin(nick, chan, server);
             complete(req, ircHandler.onJoin(
                 req, server, createUser(nick), chan, "join"
             ));

--- a/src/irc/IrcEventBroker.ts
+++ b/src/irc/IrcEventBroker.ts
@@ -114,7 +114,7 @@ export class IrcEventBroker {
         private readonly appServiceBridge: Bridge,
         private readonly pool: ClientPool,
         private readonly ircHandler: IrcHandler,
-        private readonly servers: string[]) {
+        servers: IrcServer[]) {
         this.processed = new ProcessedDict();
         this.processed.startCleaner(log);
         this.quitDebouncer = new QuitDebouncer(servers, this.handleDebouncedQuit.bind(this));
@@ -210,7 +210,7 @@ export class IrcEventBroker {
     /**
      * This function is called when the quit debouncer has deemed it safe to start sending
      * quits from users who were debounced.
-     * @param item 
+     * @param item The channel/server pair to send QUITs from
      */
     private async handleDebouncedQuit(item: {channel: string; server: IrcServer}) {
         const createUser = (nick: string) => {


### PR DESCRIPTION
Currently we do a O(N) operation across all bridged channels if any of the modes change, which while safe was becoming computationally far too expensive to use.

This change makes it so that we only compute the publicity changes for the channel being changed, which should be safe enough.