### PR TITLE
 Correct nick validation

### DIFF
--- a/changelog.d/1114.bugfix
+++ b/changelog.d/1114.bugfix
@@ -1,0 +1,7 @@
+Correct nick validation
+
+According to RFC 2812 § 2.3.1 is allowed to start with either a letter or a
+special character. Previously, this followed the older RFC 1459 that only
+allowed letters (but the rest of the logic follows RFC 2812).
+
+Fixes #467

--- a/changelog.d/1114.bugfix
+++ b/changelog.d/1114.bugfix
@@ -1,7 +1,1 @@
-Correct nick validation
-
-According to RFC 2812 § 2.3.1 is allowed to start with either a letter or a
-special character. Previously, this followed the older RFC 1459 that only
-allowed letters (but the rest of the logic follows RFC 2812).
-
-Fixes #467
+Allow nicknames to start with a special character or number according to RFC 2812 § 2.3.1

--- a/spec/unit/BridgedClient.spec.js
+++ b/spec/unit/BridgedClient.spec.js
@@ -21,7 +21,7 @@ const STATE_CONN_MAX5 = {
 
 describe("BridgedClient", function() {
     describe("getValidNick", function() {
-        it("valid nick unchanged", function() {
+        it("should not change a valid nick", function() {
             expect(BridgedClient.getValidNick("foobar", true, STATE_DISC)).toBe("foobar");
         });
         it("remove invalid character", function() {

--- a/spec/unit/BridgedClient.spec.js
+++ b/spec/unit/BridgedClient.spec.js
@@ -34,7 +34,7 @@ describe("BridgedClient", function() {
             expect(BridgedClient.getValidNick("-foobar", false, STATE_DISC)).toBe("M-foobar");
             expect(BridgedClient.getValidNick("12345", false, STATE_DISC)).toBe("M12345");
         });
-        it("throw if nick invalid", function() {
+        it("will throw if the nick is invalid", function() {
             expect(() => BridgedClient.getValidNick("f+/\u3052oobar", true, STATE_DISC)).toThrowError();
             expect(() => BridgedClient.getValidNick("a".repeat(20), true, STATE_CONN)).toThrowError();
             expect(() => BridgedClient.getValidNick("-foobar", true, STATE_CONN)).toThrowError();

--- a/spec/unit/BridgedClient.spec.js
+++ b/spec/unit/BridgedClient.spec.js
@@ -27,7 +27,7 @@ describe("BridgedClient", function() {
         it("should remove invalid characters", function() {
             expect(BridgedClient.getValidNick("f+/\u3052oobar", false, STATE_DISC)).toBe("foobar");
         });
-        it("nick must start with letter of special character", function() {
+        it("will allow nicks that start with a special character", function() {
             expect(BridgedClient.getValidNick("foo-bar", false, STATE_DISC)).toBe("foo-bar");
             expect(BridgedClient.getValidNick("[foobar]", false, STATE_DISC)).toBe("[foobar]");
             expect(BridgedClient.getValidNick("{foobar}", false, STATE_DISC)).toBe("{foobar}");

--- a/spec/unit/BridgedClient.spec.js
+++ b/spec/unit/BridgedClient.spec.js
@@ -1,0 +1,44 @@
+"use strict";
+const { BridgedClient, BridgedClientStatus } = require("../../lib/irc/BridgedClient.js");
+
+const STATE_DISC = {
+    status: BridgedClientStatus.DISCONNECTED
+}
+
+const STATE_CONN = {
+    status: BridgedClientStatus.CONNECTED,
+    client: {}
+}
+
+const STATE_CONN_MAX5 = {
+    status: BridgedClientStatus.CONNECTED,
+    client: {
+        supported: {
+            nicklength: 5
+        }
+    }
+}
+
+describe("BridgedClient", function() {
+    describe("getValidNick", function() {
+        it("valid nick unchanged", function() {
+            expect(BridgedClient.getValidNick("foobar", true, STATE_DISC)).toBe("foobar");
+        });
+        it("remove invalid character", function() {
+            expect(BridgedClient.getValidNick("f+/\u3052oobar", false, STATE_DISC)).toBe("foobar");
+        });
+        it("throw if nick invalid", function() {
+            expect(() => BridgedClient.getValidNick("f+/\u3052oobar", true, STATE_DISC)).toThrowError();
+            expect(() => BridgedClient.getValidNick("a".repeat(20), true, STATE_CONN)).toThrowError();
+        });
+        it("don't truncate nick if disconnected", function() {
+            expect(BridgedClient.getValidNick("a".repeat(20), false, STATE_DISC)).toBe("a".repeat(20));
+        });
+        it("truncate nick", function() {
+            expect(BridgedClient.getValidNick("a".repeat(20), false, STATE_CONN)).toBe("a".repeat(9));
+        });
+        it("truncate nick with custom max", function() {
+            expect(BridgedClient.getValidNick("a".repeat(20), false, STATE_CONN_MAX5)).toBe("a".repeat(5));
+        });
+    });
+});

--- a/spec/unit/BridgedClient.spec.js
+++ b/spec/unit/BridgedClient.spec.js
@@ -24,7 +24,7 @@ describe("BridgedClient", function() {
         it("should not change a valid nick", function() {
             expect(BridgedClient.getValidNick("foobar", true, STATE_DISC)).toBe("foobar");
         });
-        it("remove invalid character", function() {
+        it("should remove invalid characters", function() {
             expect(BridgedClient.getValidNick("f+/\u3052oobar", false, STATE_DISC)).toBe("foobar");
         });
         it("nick must start with letter of special character", function() {

--- a/spec/unit/BridgedClient.spec.js
+++ b/spec/unit/BridgedClient.spec.js
@@ -27,9 +27,17 @@ describe("BridgedClient", function() {
         it("remove invalid character", function() {
             expect(BridgedClient.getValidNick("f+/\u3052oobar", false, STATE_DISC)).toBe("foobar");
         });
+        it("nick must start with letter of special character", function() {
+            expect(BridgedClient.getValidNick("foo-bar", false, STATE_DISC)).toBe("foo-bar");
+            expect(BridgedClient.getValidNick("[foobar]", false, STATE_DISC)).toBe("[foobar]");
+            expect(BridgedClient.getValidNick("{foobar}", false, STATE_DISC)).toBe("{foobar}");
+            expect(BridgedClient.getValidNick("-foobar", false, STATE_DISC)).toBe("M-foobar");
+            expect(BridgedClient.getValidNick("12345", false, STATE_DISC)).toBe("M12345");
+        });
         it("throw if nick invalid", function() {
             expect(() => BridgedClient.getValidNick("f+/\u3052oobar", true, STATE_DISC)).toThrowError();
             expect(() => BridgedClient.getValidNick("a".repeat(20), true, STATE_CONN)).toThrowError();
+            expect(() => BridgedClient.getValidNick("-foobar", true, STATE_CONN)).toThrowError();
         });
         it("don't truncate nick if disconnected", function() {
             expect(BridgedClient.getValidNick("a".repeat(20), false, STATE_DISC)).toBe("a".repeat(20));

--- a/spec/unit/BridgedClient.spec.js
+++ b/spec/unit/BridgedClient.spec.js
@@ -39,7 +39,7 @@ describe("BridgedClient", function() {
             expect(() => BridgedClient.getValidNick("a".repeat(20), true, STATE_CONN)).toThrowError();
             expect(() => BridgedClient.getValidNick("-foobar", true, STATE_CONN)).toThrowError();
         });
-        it("don't truncate nick if disconnected", function() {
+        it("will not truncate a nick if disconnected", function() {
             expect(BridgedClient.getValidNick("a".repeat(20), false, STATE_DISC)).toBe("a".repeat(20));
         });
         it("truncate nick", function() {

--- a/spec/unit/BridgedClient.spec.js
+++ b/spec/unit/BridgedClient.spec.js
@@ -42,7 +42,7 @@ describe("BridgedClient", function() {
         it("will not truncate a nick if disconnected", function() {
             expect(BridgedClient.getValidNick("a".repeat(20), false, STATE_DISC)).toBe("a".repeat(20));
         });
-        it("truncate nick", function() {
+        it("will truncate nick", function() {
             expect(BridgedClient.getValidNick("a".repeat(20), false, STATE_CONN)).toBe("a".repeat(9));
         });
         it("truncate nick with custom max", function() {

--- a/spec/unit/BridgedClient.spec.js
+++ b/spec/unit/BridgedClient.spec.js
@@ -45,7 +45,7 @@ describe("BridgedClient", function() {
         it("will truncate nick", function() {
             expect(BridgedClient.getValidNick("a".repeat(20), false, STATE_CONN)).toBe("a".repeat(9));
         });
-        it("truncate nick with custom max", function() {
+        it("will truncate a nick with a custom max character limit", function() {
             expect(BridgedClient.getValidNick("a".repeat(20), false, STATE_CONN_MAX5)).toBe("a".repeat(5));
         });
     });

--- a/src/irc/BridgedClient.ts
+++ b/src/irc/BridgedClient.ts
@@ -133,7 +133,7 @@ export class BridgedClient extends EventEmitter {
         else {
             throw Error("Could not determine nick for user");
         }
-        this._nick = this.getValidNick(chosenNick, false);
+        this._nick = BridgedClient.getValidNick(chosenNick, false, this.state);
         this.password = (
             clientConfig.getPassword() ? clientConfig.getPassword() : server.config.password
         );
@@ -362,7 +362,7 @@ export class BridgedClient extends EventEmitter {
      */
     public async changeNick(newNick: string, throwOnInvalid: boolean): Promise<string> {
         this.log.info(`Trying to change nick from ${this.nick} to ${newNick}`);
-        const validNick = this.getValidNick(newNick, throwOnInvalid);
+        const validNick = BridgedClient.getValidNick(newNick, throwOnInvalid, this.state);
         if (validNick === this.nick) {
             throw Error(`Your nick is already '${validNick}'.`);
         }
@@ -692,7 +692,7 @@ export class BridgedClient extends EventEmitter {
      * The error message will contain a human-readable message which can be sent
      * back to a user.
      */
-    private getValidNick(nick: string, throwOnInvalid: boolean): string {
+    static getValidNick(nick: string, throwOnInvalid: boolean, state: State): string {
         // Apply a series of transformations to the nick, and check after each
         // stage for mismatches to the input (and throw if appropriate).
 
@@ -713,12 +713,12 @@ export class BridgedClient extends EventEmitter {
             n = "M" + n;
         }
 
-        if (this.state.status === BridgedClientStatus.CONNECTED) {
+        if (state.status === BridgedClientStatus.CONNECTED) {
             // nicks can't be too long
             let maxNickLen = 9; // RFC 1459 default
-            if (this.state.client.supported &&
-                    typeof this.state.client.supported.nicklength === "number") {
-                maxNickLen = this.state.client.supported.nicklength;
+            if (state.client.supported &&
+                    typeof state.client.supported.nicklength === "number") {
+                maxNickLen = state.client.supported.nicklength;
             }
             if (n.length > maxNickLen) {
                 if (throwOnInvalid) {

--- a/src/irc/BridgedClient.ts
+++ b/src/irc/BridgedClient.ts
@@ -704,9 +704,11 @@ export class BridgedClient extends EventEmitter {
         }
 
         // nicks must start with a letter
-        if (!/^[A-Za-z]/.test(n)) {
+        if (!/^[A-Za-z\[\]\\`_^\{\|\}]/.test(n)) {
             if (throwOnInvalid) {
-                throw new Error(`Nick '${nick}' must start with a letter.`);
+                throw new Error(
+                    `Nick '${nick}' must start with a letter or special character (dash is not a special character).`
+                );
             }
             // Add arbitrary letter prefix. This is important for guest user
             // IDs which are all numbers.


### PR DESCRIPTION
According to RFC 2812 § 2.3.1 is allowed to start with either a letter or a
special character. Previously, this followed the older RFC 1459 that only
allowed letters (but the rest of the logic follows RFC 2812).

Fixes #467. Supersedes #552.