### PR TITLE
IndentGenerator fixes

### DIFF
--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -139,6 +139,8 @@ ircService:
         enabled: true
         # The nickname to give the AS bot.
         nick: "MatrixBot"
+        # The username to give to the AS bot. Defaults to "matrixbot"
+        username: "matrixbot"
         # The password to give to NickServ or IRC Server for this nick. Optional.
         # password: "helloworld"
         #

--- a/config.schema.yml
+++ b/config.schema.yml
@@ -198,6 +198,8 @@ properties:
                                     type: "boolean"
                                 nick:
                                     type: "string"
+                                username:
+                                    type: "string"
                                 password:
                                     type: "string"
                                 joinChannelsIfNoUsers:

--- a/spec/unit/IdentGenerator.spec.js
+++ b/spec/unit/IdentGenerator.spec.js
@@ -1,12 +1,16 @@
 "use strict";
 const Promise = require("bluebird");
-const { IdentGenerator } = require("../../lib/irc/IdentGenerator.js");
+const { IdentGenerator } = require("../../lib/irc/IdentGenerator");
+const { IrcClientConfig } = require("../../lib/models/IrcClientConfig");
 
 describe("Username generation", function() {
-    var identGenerator;
-    var storeMock = {};
-    var existingUsernames = {};
-    var ircClientConfig;
+    let identGenerator;
+    let storeMock;
+    let existingUsernames;
+    let ircClientConfig;
+    let ircClientConfigs;
+    let ircClientConfigsUsername;
+    let ircClientConfigsUsernames;
 
     var mkMatrixUser = function(uid) {
         return {
@@ -17,6 +21,10 @@ describe("Username generation", function() {
 
     beforeEach(function() {
         existingUsernames = {};
+        ircClientConfigs = { };
+        ircClientConfigsUsername = { };
+        ircClientConfigsUsernames = [];
+        storeMock = {};
         var _uname;
         ircClientConfig = {
             getDesiredNick: () => { return "MyCrazyNick"; },
@@ -29,21 +37,28 @@ describe("Username generation", function() {
                 _uname = u;
             }
         };
-        storeMock.getMatrixUserByUsername = function(domain, uname) {
+        storeMock.getCountForUsernamePrefix = async function (domain, usernamePrefix) {
+            return ircClientConfigsUsernames.filter((uname) =>
+                uname.startsWith(usernamePrefix)
+            ).length;
+        }
+        storeMock.getMatrixUserByUsername = async function(domain, uname) {
             var obj;
             if (existingUsernames[uname]) {
                 obj = {
                     getId: function() { return existingUsernames[uname]; }
                 };
+            } else if (ircClientConfigsUsername[uname+domain]) {
+                return mkMatrixUser(ircClientConfigsUsername[uname+domain].getUserId());
             }
-            return Promise.resolve(obj);
+            return obj;
         };
-        storeMock.storeIrcClientConfig = function() {
-            return Promise.resolve();
-        };
-        storeMock.getIrcClientConfig = function() {
-            return Promise.resolve();
-        };
+        storeMock.getIrcClientConfig = async (sender, domain) => ircClientConfigs[sender+domain];
+        storeMock.storeIrcClientConfig = async (config) => { 
+            ircClientConfigs[config.userId+config.domain] = config;
+            ircClientConfigsUsername[config.getUsername()+config.domain] = config;
+            ircClientConfigsUsernames.push(config.getUsername());
+        }
 
         identGenerator = new IdentGenerator(storeMock);
         IdentGenerator.MAX_USER_NAME_LENGTH = 8;
@@ -106,5 +121,20 @@ describe("Username generation", function() {
         const uname = "M-myname";
         const info = await identGenerator.getIrcNames(ircClientConfig, mkMatrixUser(userId));
         expect(info.username).toEqual(uname);
+    });
+
+    it("should be able to handle many similar userids", async function() {
+        const userIdPrefix = "@_longprefix_";
+        for (let i = 0; i < 5000; i++) {
+            const userId = `${userIdPrefix}${i}:localhost`;
+            const config = new IrcClientConfig(userId, 'irc.example.com');
+            const result = await identGenerator.getIrcNames(config, mkMatrixUser(userId));
+            if (i === 0) {
+                expect(result.username).toBe("longpref");
+            } else {
+                // longpref_1, _2, _3 etc
+                expect(result.username).toBe(`${"longprefix".substr(0, 8 - 1 - (i+1).toString().length)}_${i+1}`);
+            }
+        }
     });
 });

--- a/spec/util/test-config.json
+++ b/spec/util/test-config.json
@@ -50,6 +50,7 @@
                 "botConfig": {
                     "enabled": true,
                     "nick": "ro_bot_nick",
+                    "username": "matrixbot",
                     "joinChannelsIfNoUsers": true
                 },
                 "privateMessages": {

--- a/src/datastore/DataStore.ts
+++ b/src/datastore/DataStore.ts
@@ -160,6 +160,8 @@ export interface DataStore {
 
     getMatrixUserByUsername(domain: string, username: string): Promise<MatrixUser|undefined>;
 
+    getCountForUsernamePrefix(domain: string, usernamePrefix: string): Promise<number>;
+
     roomUpgradeOnRoomMigrated(oldRoomId: string, newRoomId: string): Promise<void>;
 
     updateLastSeenTimeForUser(userId: string): Promise<void>;

--- a/src/datastore/NedbDataStore.ts
+++ b/src/datastore/NedbDataStore.ts
@@ -603,6 +603,18 @@ export class NeDBDataStore implements DataStore {
         return matrixUsers[0];
     }
 
+
+    public async getCountForUsernamePrefix(domain: string, usernamePrefix: string): Promise<number> {
+        const domainKey = domain.replace(/\./g, "_");
+        const rows = await this.userStore.select({
+            type: "matrix",
+            ["client_config." + domainKey + ".username"]: {
+                $regex: new RegExp(`${usernamePrefix}.+`),
+            }
+        });
+        return rows.length;
+    }
+
     public async updateLastSeenTimeForUser(userId: string) {
         let user = await this.userStore.getMatrixUser(userId);
         if (!user) {

--- a/src/datastore/postgres/PgDataStore.ts
+++ b/src/datastore/postgres/PgDataStore.ts
@@ -519,6 +519,13 @@ export class PgDataStore implements DataStore {
         return new MatrixUser(res.rows[0].user_id, res.rows[0].data);
     }
 
+    public async getCountForUsernamePrefix(domain: string, usernamePrefix: string): Promise<number> {
+        const res = await this.pgPool.query("SELECT COUNT(*) FROM client_config " +
+            "WHERE config->>'username' LIKE $1; AND domain = $2",
+        [`${usernamePrefix}%`, domain]);
+        return res.rows[0];
+    }
+
     public async roomUpgradeOnRoomMigrated(oldRoomId: string, newRoomId: string) {
         await this.pgPool.query("UPDATE rooms SET room_id = $1 WHERE room_id = $2", [newRoomId, oldRoomId]);
     }

--- a/src/irc/ClientPool.ts
+++ b/src/irc/ClientPool.ts
@@ -121,9 +121,9 @@ export class ClientPool {
 
     public async loginToServer(server: IrcServer): Promise<BridgedClient> {
         const uname = "matrixirc";
-        let bridgedClient = this.getBridgedClientByNick(server, uname);
+        let bridgedClient = this.getBot(server);
         if (!bridgedClient) {
-            const botIrcConfig = server.createBotIrcClientConfig(uname);
+            const botIrcConfig = server.createBotIrcClientConfig();
             bridgedClient = this.createIrcClient(botIrcConfig, null, true);
             log.debug(
                 "Created new bot client for %s : %s (bot enabled=%s)",

--- a/src/irc/IrcServer.ts
+++ b/src/irc/IrcServer.ts
@@ -273,9 +273,9 @@ export class IrcServer {
         return this.config.botConfig.nick;
     }
 
-    public createBotIrcClientConfig(username: string) {
+    public createBotIrcClientConfig() {
         return IrcClientConfig.newConfig(
-            null, this.domain, this.config.botConfig.nick, username,
+            null, this.domain, this.config.botConfig.nick, this.config.botConfig.username,
             this.config.botConfig.password
         );
     }
@@ -535,6 +535,7 @@ export class IrcServer {
             },
             botConfig: {
                 nick: "appservicebot",
+                username: "matrixbot",
                 joinChannelsIfNoUsers: true,
                 enabled: true
             },
@@ -671,6 +672,7 @@ export interface IrcServerConfig {
         joinChannelsIfNoUsers: boolean;
         enabled: boolean;
         password?: string;
+        username: string;
     };
     privateMessages: {
         enabled: boolean;


### PR DESCRIPTION
This PR attempts to address a long standing performance issue with the username generation portion of the bridge. But first, some backstory.

Due to IRC limitations, we decided to limit usernames to be 10 characters long. The usernames need to be unique, so we use the user_id as a base. This works fine, but if you end up with two @matthews, it simply truncates to `matthew` and `matthew_1`, or in the case of `thehalfshot`: `thehalfs_1`. This works fine in most cases, but what happens if you try to bridge @_discord_12345 users into IRC. It works fine up until a point, where you may end up accumulating thousands of discord clients over a long enough period. The alogrithm is smart enoguh to start doing `thehalf_10` if you end up with enough halfshots.

The current code is dumb, and will simply generate a username, check if it's registered by querying the DB, and moving on. This means if you are discord user #7001, you will need to perform 7001 queries to the database. This is only a problem on first join, but Discord users often join the matrix.org bridge for the first time which then causes the DB to hammer.

### Solution Time

I've gone for the most obvious solution which is to query the database to determine if a username *prefix* is "full". That is, if `matthew_1` through til `matthew_9` is registered, then don't bother checking all those user_ids. And the same goes for 10-99, 100-999 and so on. This ends up saving us a lot of time, as we can quickly arrive at `disco_7001` with 4 queries to the DB. 