### PR TITLE
config schema: require at least one server

### DIFF
--- a/config.schema.yml
+++ b/config.schema.yml
@@ -138,6 +138,7 @@ properties:
                         type: "boolean"
             servers:
                 type: "object"
+                minProperties: 1
                 # all properties must follow the following
                 additionalProperties:
                     type: "object"


### PR DESCRIPTION
Before this, a minimal schema-accepted config would fail with:

```
2020-02-21 10:17:39 ERROR:CLI Failed to run bridge.
2020-02-21 10:17:39 ERROR:CLI undefined
```

Now it will work correctly.