### PR TITLE
Fix matrix name change not propagating to irc

### DIFF
--- a/changelog.d/1125.bugfix
+++ b/changelog.d/1125.bugfix
@@ -1,0 +1,1 @@
+Fix Matrix displayname changes sometimes not propagating to IRC

--- a/src/bridge/MatrixHandler.ts
+++ b/src/bridge/MatrixHandler.ts
@@ -515,6 +515,7 @@ export class MatrixHandler {
 
                 // Check for a displayname change and update nick accordingly.
                 if (event.content && event.content.displayname !== bridgedClient.displayName) {
+                    bridgedClient.displayName = event.content.displayname || null;
                     // Changing the nick requires that:
                     // - the server allows nick changes
                     // - the nick is not custom
@@ -526,7 +527,7 @@ export class MatrixHandler {
                     ) {
                         try {
                             const newNick = room.server.getNick(
-                                bridgedClient.userId, event.content.displayname
+                                bridgedClient.userId, bridgedClient.displayName || undefined
                             );
                             bridgedClient.changeNick(newNick, false);
                         }

--- a/src/irc/BridgedClient.ts
+++ b/src/irc/BridgedClient.ts
@@ -81,7 +81,7 @@ type State = Connected | NotConnected
 
 export class BridgedClient extends EventEmitter {
     public readonly userId: string|null;
-    public readonly displayName: string|null;
+    public displayName: string|null;
     private _nick: string;
     public readonly id: string;
     private readonly password?: string;


### PR DESCRIPTION
When we receive a matrix join event, we compare `bridgedClient.displayName` with the new display name to see if we need to update the irc client's nick. However, we didn't set `bridgedClient.displayName` to the new nick afterwards. This means if the matrix user changes their display name back to the original, the change is not propagated to irc.
