### PR TITLE
Do not leave after joining

### DIFF
--- a/changelog.d/1143.bugfix
+++ b/changelog.d/1143.bugfix
@@ -1,0 +1,1 @@
+Fix a bug where the bridge would leave a user after joining

--- a/src/util/MembershipQueue.ts
+++ b/src/util/MembershipQueue.ts
@@ -114,7 +114,7 @@ export class MembershipQueue {
                 (JOIN_DELAY_MS * attempts) + (Math.random() * 500),
                 JOIN_DELAY_CAP_MS
             );
-            req.log.warn(`Failed to join ${roomId}, delaying for ${delay}ms`);
+            req.log.warn(`Failed to ${type} ${roomId}, delaying for ${delay}ms`);
             req.log.debug(`Failed with: ${ex.errcode} ${ex.message}`);
             await new Promise((r) => setTimeout(r, delay));
             this.queueMembership({...item, attempts: item.attempts + 1});

--- a/src/util/MembershipQueue.ts
+++ b/src/util/MembershipQueue.ts
@@ -92,6 +92,7 @@ export class MembershipQueue {
         try {
             if (type === "join") {
                 await intent.join(roomId);
+                return;
             }
 
             if (kickUser) {


### PR DESCRIPTION
We were allowing the .join call to fall through to the next statement. Ideally this should have been caught by tests.