### PR TITLE
Refactor nick => irc client mapping

### DIFF
--- a/changelog.d/1146.bugfix
+++ b/changelog.d/1146.bugfix
@@ -1,0 +1,1 @@
+Fix more cases of double bridged users

--- a/src/irc/ClientPool.ts
+++ b/src/irc/ClientPool.ts
@@ -77,7 +77,7 @@ export class ClientPool {
             return false;
         }
 
-        if (this.getBridgedClientByNick(server, nick)) {
+        if (this.getBridgedClientByNick(server, nick, true)) {
             return true;
         }
 
@@ -88,7 +88,6 @@ export class ClientPool {
     public killAllClients() {
         return Bluebird.all(Object.keys(this.virtualClients).map((domain) =>
             [
-                ...this.virtualClients[domain].nicks.values(),
                 ...this.virtualClients[domain].userIds.values(),
                 this.botClients.get(domain),
             ]
@@ -342,7 +341,7 @@ export class ClientPool {
         return cli;
     }
 
-    public getBridgedClientByNick(server: IrcServer, nick: string) {
+    public getBridgedClientByNick(server: IrcServer, nick: string, allowDead = false) {
         const bot = this.getBot(server);
         if (bot && bot.nick === nick) {
             return bot;
@@ -363,6 +362,7 @@ export class ClientPool {
             serverSet.nicks.set(cli.nick, cli);
         }
 
+        if (!allowDead && cli.isDead()) {
             return undefined;
         }
         return cli;


### PR DESCRIPTION
In order to fix cases of double bridging.

Rather than storing two mappings of nickname => Client and user_id => Client, we will store one map for the user_id => Client and a LRU cache for the nickname. The intention being that if for whatever reason we have a hole in the nick mapping, the bridge can fall back to searching through the other mapping, at a speed penalty.

We also now consider dead clients ours, to avoid the case where we kill a client and then subsequently bridge across resulting parting information.