### PR TITLE
Ignore idle users on startup rather than connecting them

### DIFF
--- a/changelog.d/1156.feature
+++ b/changelog.d/1156.feature
@@ -1,0 +1,1 @@
+Pre-emptively ignore users who are already idle when starting up the bridge

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -263,6 +263,16 @@ ircService:
               initial: false
               incremental: false
 
+        # Should the bridge ignore users which are not considered active on the bridge
+        # during startup
+        ignoreIdleUsersOnStartup:
+          enabled: true
+          # How many hours can a user be considered idle for before they are considered
+          # ignoreable
+          idleForHours: 720
+          # A regex which will exclude matching MXIDs from this check.
+          exclude: "foobar"
+
       mappings:
         # 1:many mappings from IRC channels to room IDs on this IRC server.
         # The matrix room must already exist. Your matrix client should expose

--- a/config.schema.yml
+++ b/config.schema.yml
@@ -220,6 +220,15 @@ properties:
                                     type: "boolean"
                                 floodDelayMs:
                                     type: "integer"
+                                ignoreIdleUsersOnStartup:
+                                    type: "object"
+                                    properties:
+                                        enabled:
+                                            type: "boolean"
+                                        idleForHours:
+                                            type: "integer"
+                                        exclude:
+                                            type: "string"
                                 global:
                                     type: "object"
                                     properties:

--- a/src/bridge/IrcBridge.ts
+++ b/src/bridge/IrcBridge.ts
@@ -61,11 +61,11 @@ export class IrcBridge {
     public readonly matrixHandler: MatrixHandler;
     public readonly ircHandler: IrcHandler;
     public readonly publicitySyncer: PublicitySyncer;
+    public readonly activityTracker: MatrixActivityTracker|null = null;
     private clientPool!: ClientPool; // This gets defined in the `run` function
     private ircServers: IrcServer[] = [];
     private memberListSyncers: {[domain: string]: MemberListSyncer} = {};
     private joinedRoomList: string[] = [];
-    private activityTracker: MatrixActivityTracker|null = null;
     private dataStore!: DataStore;
     private startedUp = false;
     private debugApi: DebugApi|null = null;


### PR DESCRIPTION
Fixes #1142 

matrix.org runs a kick script every day to remove idle users, but due to permission issues not every user will be kicked (the bridge lacks permissions to kick in some rooms). In order ensure we don't reconnect users who are idle, this config change will cause the bridge to ignore them on startup.