### PR TITLE
Ping the bridge via the homeserver on startup to ensure the AS transport works

### DIFF
--- a/changelog.d/1160.feature
+++ b/changelog.d/1160.feature
@@ -1,0 +1,1 @@
+Add startup check to ensure the homeserver can send the bridge events.

--- a/package-lock.json
+++ b/package-lock.json
@@ -80,9 +80,9 @@
       "dev": true
     },
     "@babel/runtime": {
-      "version": "7.12.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.0.tgz",
-      "integrity": "sha512-lS4QLXQ2Vbw2ubfQjeQcn+BZgZ5+ROHW9f+DWjEp5Y+NHYmkRGKqHSJ1tuhbUauKu2nhZNTBIvsIQ8dXfY5Gjw==",
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.1.tgz",
+      "integrity": "sha512-J5AIf3vPj3UwXaAzb5j1xM4WAQDX3EMgemF8rjCP3SoW09LfRKAXQKt6CoVYl230P6iWdRcBbnLDDdnqWxZSCA==",
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
@@ -2364,9 +2364,9 @@
       }
     },
     "matrix-appservice-bridge": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/matrix-appservice-bridge/-/matrix-appservice-bridge-2.2.0.tgz",
-      "integrity": "sha512-pe4jEvfEZzsOscFktq3q2AoiF5Qepv8PJMyY1oPCJx4WsXfhqcngjEQFax2/kFnvsSPa6FhmgdE0TfyL8Cq8Ug==",
+      "version": "2.3.0-rc1",
+      "resolved": "https://registry.npmjs.org/matrix-appservice-bridge/-/matrix-appservice-bridge-2.3.0-rc1.tgz",
+      "integrity": "sha512-z5ZL05mz1ykFaAasTtojJWQgrPwor9Mh5ikoU/rYaowiYukne+iU31GaM/Iwim7LeaDIuj+hl3QiMd9s4Icjqg==",
       "requires": {
         "chalk": "^4.1.0",
         "extend": "^3.0.2",
@@ -2376,7 +2376,7 @@
         "matrix-js-sdk": "^8.4.1",
         "nedb": "^1.8.0",
         "nopt": "^4.0.3",
-        "p-queue": "^6.6.0",
+        "p-queue": "^6.6.2",
         "prom-client": "^12.0.0",
         "winston": "^3.3.3",
         "winston-daily-rotate-file": "^4.5.0"
@@ -2468,6 +2468,15 @@
           "integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
           "requires": {
             "fn.name": "1.x.x"
+          }
+        },
+        "p-queue": {
+          "version": "6.6.2",
+          "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
+          "integrity": "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==",
+          "requires": {
+            "eventemitter3": "^4.0.4",
+            "p-timeout": "^3.2.0"
           }
         },
         "string_decoder": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "js-yaml": "^3.2.7",
     "logform": "^2.1.2",
     "matrix-appservice": "^0.6.0",
-    "matrix-appservice-bridge": "2.2.0",
+    "matrix-appservice-bridge": "2.3.0-rc1",
     "matrix-lastactive": "^0.1.5",
     "nedb": "^1.1.2",
     "nopt": "^3.0.1",


### PR DESCRIPTION
This PR will cause the bridge to ping the homeserver on startup, by sending an event to a room, and then checking it can read it back across the transaction stream. 