### PR TITLE
Check if a user is in the room before doing a kick on QUIT

### DIFF
--- a/changelog.d/1165.bugfix
+++ b/changelog.d/1165.bugfix
@@ -1,0 +1,1 @@
+Fixed an issue where the bridge would kick users from rooms they never joined


### PR DESCRIPTION
Fixes #1163 

This change does a state lookup before kicking a user to determine if they should be kicked, as synapse will accept a (null) -> leave.