### PR TITLE
Nicer format for Matrix quotes in IRC

### DIFF
--- a/changelog.d/1179.misc
+++ b/changelog.d/1179.misc
@@ -1,0 +1,1 @@
+Improve the format for Matrix quotes on IRC

--- a/spec/integ/matrix-to-irc.spec.js
+++ b/spec/integ/matrix-to-irc.spec.js
@@ -263,7 +263,7 @@ describe("Matrix-to-IRC message bridging", function() {
                 expect(client.nick).toEqual(testUser.nick);
                 expect(client.addr).toEqual(roomMapping.server);
                 expect(channel).toEqual(roomMapping.channel);
-                expect(text).toEqual(`<${repliesUser.nick} "This is the real message"> Reply Text`);
+                expect(text).toEqual(`"<${repliesUser.nick}> This is the real message" <- Reply Text`);
             }
         );
         const formatted_body = constructHTMLReply(
@@ -308,7 +308,7 @@ describe("Matrix-to-IRC message bridging", function() {
                 expect(client.addr).toEqual(roomMapping.server);
                 expect(channel).toEqual(roomMapping.channel);
                 // We use the nick over the displayname
-                expect(text).toEqual(`<M-friend "This is the real message"> Reply Text`);
+                expect(text).toEqual(`"<M-friend> This is the real message" <- Reply Text`);
             }
         );
         const formatted_body = constructHTMLReply(
@@ -352,7 +352,7 @@ describe("Matrix-to-IRC message bridging", function() {
                 expect(client.nick).toEqual(testUser.nick);
                 expect(client.addr).toEqual(roomMapping.server);
                 expect(channel).toEqual(roomMapping.channel);
-                expect(text).toEqual(`<${repliesUser.nick} "This"> Reply Text`);
+                expect(text).toEqual(`"<${repliesUser.nick}> This" <- Reply Text`);
             }
         );
         const formatted_body = constructHTMLReply(
@@ -460,7 +460,7 @@ describe("Matrix-to-IRC message bridging", function() {
                 expect(client.nick).toEqual(testUser.nick);
                 expect(client.addr).toEqual(roomMapping.server);
                 expect(channel).toEqual(roomMapping.channel);
-                expect(text).toEqual('<M-friend "Message #2"> Message #3');
+                expect(text).toEqual('"<M-friend> Message #2" <- Message #3');
             }
         );
 
@@ -507,7 +507,7 @@ describe("Matrix-to-IRC message bridging", function() {
                 expect(client.nick).toEqual(testUser.nick);
                 expect(client.addr).toEqual(roomMapping.server);
                 expect(channel).toEqual(roomMapping.channel);
-                expect(text).toEqual('<WibbleWob "This is the real message"> Reply Text');
+                expect(text).toEqual('"<WibbleWob> This is the real message" <- Reply Text');
             }
         );
         const formatted_body = constructHTMLReply(

--- a/src/bridge/MatrixHandler.ts
+++ b/src/bridge/MatrixHandler.ts
@@ -1156,8 +1156,6 @@ export class MatrixHandler {
             if (lines[0].length > REPLY_SOURCE_MAX_LENGTH) {
                 rplSource = rplSource + "...";
             }
-            // Wrap in formatting
-            rplSource = ` "${rplSource}"`;
         }
         else {
             // Don't show a source because we couldn't format one.
@@ -1179,7 +1177,7 @@ export class MatrixHandler {
         }
 
         return {
-            formatted: `<${rplName}${rplSource}> ${rplText}`,
+            formatted: `"<${rplName}> ${rplSource}" <- ${rplText}`,
             reply: rplText,
         };
     }


### PR DESCRIPTION
This addresses one of the most common complaints about using Matrix
quotes in IRC channels: That IRC users consider the format of quotes
"weird".

This commit changes the current format from

    <user "Original message"> Reply

to

    "<user> Original message" <- Reply

which is much more aligned with how IRC users manually quote a message.