### PR TITLE
Do an early check to see if the to nickname is valid before trying to handle a message

### DIFF
--- a/changelog.d/1189.bugfix
+++ b/changelog.d/1189.bugfix
@@ -1,0 +1,1 @@
+Drop IRC messages directed towards invalid nicks early.

--- a/src/irc/IrcEventBroker.ts
+++ b/src/irc/IrcEventBroker.ts
@@ -284,7 +284,6 @@ export class IrcEventBroker {
             const req = createRequest();
             // Check and drop here, because we want to avoid the performance impact.
             if (!IrcEventBroker.isValidNick(to)) {
-                req.log.warn(`Dropped message due to invalid nick. to: ${to}`);
                 req.resolve(BridgeRequestErr.ERR_DROPPED);
                 return;
             }
@@ -299,7 +298,6 @@ export class IrcEventBroker {
             const req = createRequest();
             // Check and drop here, because we want to avoid the performance impact.
             if (!IrcEventBroker.isValidNick(to)) {
-                req.log.warn(`Dropped message due to invalid nick. ${to}`);
                 req.resolve(BridgeRequestErr.ERR_DROPPED);
                 return;
             }
@@ -315,7 +313,6 @@ export class IrcEventBroker {
                 const req = createRequest();
                 // Check and drop here, because we want to avoid the performance impact.
                 if (!IrcEventBroker.isValidNick(to)) {
-                    req.log.warn(`Dropped message due to invalid nick. ${to}`);
                     req.resolve(BridgeRequestErr.ERR_DROPPED);
                     return;
                 }
@@ -585,6 +582,6 @@ export class IrcEventBroker {
 
     static isValidNick(nick: string) {
         // The first character must be one of these.
-        return /^[A-Za-z\[\]\\`_^\{\|\}]/.test(nick[0])
+        return /^[A-Za-z\[\]\\`_^\{\|\}]/.test(nick[0]);
     }
 }

--- a/src/irc/IrcEventBroker.ts
+++ b/src/irc/IrcEventBroker.ts
@@ -282,6 +282,12 @@ export class IrcEventBroker {
         connInst.addListener("message", (from: string, to: string, text: string) => {
             if (to.startsWith("#")) { return; }
             const req = createRequest();
+            // Check and drop here, because we want to avoid the performance impact.
+            if (!IrcEventBroker.isValidNick(to)) {
+                req.log.warn(`Dropped message due to invalid nick. to: ${to}`);
+                req.resolve(BridgeRequestErr.ERR_DROPPED);
+                return;
+            }
             complete(req, ircHandler.onPrivateMessage(
                 req,
                 server, createUser(from), createUser(to),
@@ -291,6 +297,12 @@ export class IrcEventBroker {
         connInst.addListener("notice", (from: string, to: string, text: string) => {
             if (!from || to.startsWith("#")) { return; }
             const req = createRequest();
+            // Check and drop here, because we want to avoid the performance impact.
+            if (!IrcEventBroker.isValidNick(to)) {
+                req.log.warn(`Dropped message due to invalid nick. ${to}`);
+                req.resolve(BridgeRequestErr.ERR_DROPPED);
+                return;
+            }
             complete(req, ircHandler.onPrivateMessage(
                 req,
                 server, createUser(from), createUser(to),
@@ -301,6 +313,12 @@ export class IrcEventBroker {
             if (to.startsWith("#")) { return; }
             if (text.startsWith("ACTION ")) {
                 const req = createRequest();
+                // Check and drop here, because we want to avoid the performance impact.
+                if (!IrcEventBroker.isValidNick(to)) {
+                    req.log.warn(`Dropped message due to invalid nick. ${to}`);
+                    req.resolve(BridgeRequestErr.ERR_DROPPED);
+                    return;
+                }
                 complete(req, ircHandler.onPrivateMessage(
                     req,
                     server, createUser(from), createUser(to),
@@ -563,5 +581,10 @@ export class IrcEventBroker {
             }
             await req();
         })();
+    }
+
+    static isValidNick(nick: string) {
+        // The first character must be one of these.
+        return /^[A-Za-z\[\]\\`_^\{\|\}]/.test(nick[0])
     }
 }


### PR DESCRIPTION
Partial fix to #1176 

Ideally we would work out why we are getting these messages too, but at the moment we can at least reject invalid nicks early on to avoid doing more processing than needed.