### PR TITLE
Warn when the matrix user is unable to talk in a channel

### DIFF
--- a/changelog.d/1204.feature
+++ b/changelog.d/1204.feature
@@ -1,0 +1,1 @@
+Warn Matrix users if they are unable to speak in a channel.

--- a/src/bridge/IrcHandler.ts
+++ b/src/bridge/IrcHandler.ts
@@ -873,8 +873,7 @@ export class IrcHandler {
 
         const botUser = new MatrixUser(this.ircBridge.appServiceUserId);
 
-
-        if (ircMsg && ircMsg.command === "err_nosuchnick") {
+        if (ircMsg?.command === "err_nosuchnick") {
             const otherNick = ircMsg.args[1];
             const otherUser = new MatrixUser(client.server.getUserIdFromNick(otherNick));
             const room = await this.ircBridge.getStore().getMatrixPmRoom(client.userId, otherUser.userId);
@@ -919,6 +918,11 @@ export class IrcHandler {
         }
         else {
             adminRoom = fetchedAdminRoom;
+        }
+
+
+        if (ircMsg?.command === "err_cannotsendtochan") {
+            msg = `Message could not be sent to ${ircMsg.args[1]}`;
         }
 
         const notice = new MatrixAction("notice", msg);

--- a/src/irc/BridgedClient.ts
+++ b/src/irc/BridgedClient.ts
@@ -292,7 +292,7 @@ export class BridgedClient extends EventEmitter {
             });
             connInst.client.addListener("error", (err: IrcMessage) => {
                 // Errors we MUST notify the user about, regardless of the bridge's admin room config.
-                const ERRORS_TO_FORCE = ["err_nononreg", "err_nosuchnick"];
+                const ERRORS_TO_FORCE = ["err_nononreg", "err_nosuchnick", "err_cannotsendtochan"];
                 if (!err || !err.command || connInst.dead) {
                     return;
                 }


### PR DESCRIPTION
This will send an error inside the user's admin room, like we do for other failures.

Fixes #1203 