### PR TITLE
Create DebugAPI after its dependency ClientPool

### DIFF
--- a/changelog.d/1206.bugfix
+++ b/changelog.d/1206.bugfix
@@ -1,0 +1,1 @@
+Create DebugAPI after its dependency ClientPool

--- a/changelog.d/1206.bugfix
+++ b/changelog.d/1206.bugfix
@@ -1,1 +1,1 @@
-Create DebugAPI after its dependency ClientPool
+Fix potential error when using killUser debug endpoind

--- a/changelog.d/1206.bugfix
+++ b/changelog.d/1206.bugfix
@@ -1,1 +1,1 @@
-Fix potential error when using killUser debug endpoind
+Fix potential error when using killUser debug endpoint

--- a/src/bridge/IrcBridge.ts
+++ b/src/bridge/IrcBridge.ts
@@ -530,17 +530,6 @@ export class IrcBridge {
 
         await this.dataStore.removeConfigMappings();
 
-        if (this.config.ircService.debugApi.enabled) {
-            this.debugApi = new DebugApi(
-                this,
-                this.config.ircService.debugApi.port,
-                this.ircServers,
-                this.clientPool,
-                this.registration.getAppServiceToken() as string
-            );
-            this.debugApi.run();
-        }
-
         if (this.activityTracker) {
             log.info("Restoring last active times from DB");
             const users = await this.dataStore.getLastSeenTimeForUsers();
@@ -567,6 +556,17 @@ export class IrcBridge {
         }
 
         this.clientPool = new ClientPool(this, this.dataStore);
+
+        if (this.config.ircService.debugApi.enabled) {
+            this.debugApi = new DebugApi(
+                this,
+                this.config.ircService.debugApi.port,
+                this.ircServers,
+                this.clientPool,
+                this.registration.getAppServiceToken() as string
+            );
+            this.debugApi.run();
+        }
 
         if (this.ircServers.length === 0) {
             throw Error("No IRC servers specified.");


### PR DESCRIPTION
Fixes #1199.

The issue is that DebugApi gets created before clientPool gets created. The parameter `this.clientPool` is undefined at this point.
`this.clientPool` is updated later but that does not get passed to DebugApi.

I tested this for a while but I'm not 100% confident that delaying the creation of DebugApi doesn't have some drawbacks.
Steps that are now run before its creation:
1. Restoring last active times from DB
2. maintain a list of IRC servers in-use (**this modifies config.ircServers which is another parameter of DebugApi**)
2.1. store the config mappings in the DB to keep everything in one place.
3. clientPool gets created