### PR TITLE
Correct the comment above bindPort

### DIFF
--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -32,7 +32,7 @@ homeserver:
   # Default: true
   enablePresence: true
 
-  # Which port should the appservice bind to. Takes priority over the one provided in the
+  # Which port should the appservice bind to. Can be overriden by the one provided in the
   # command line! Optional.
   # bindPort: 9999
 


### PR DESCRIPTION
The comment seems to get it the other way around: the port specified in the command line takes precedence over the one in the config file.