### PR TITLE
Debounce performance improvements

### DIFF
--- a/changelog.d/1228.bugfix
+++ b/changelog.d/1228.bugfix
@@ -1,0 +1,1 @@
+Fix an issue where the QuitDebouncer would reprocess old QUITs, and process QUITs too early during the debouncing process.

--- a/src/bridge/QuitDebouncer.ts
+++ b/src/bridge/QuitDebouncer.ts
@@ -15,6 +15,7 @@ export class QuitDebouncer {
     };
 
     private quitProcessQueue: Queue<{channel: string; server: IrcServer}>;
+    private wasSplitOccuring = false;
 
     constructor(
         servers: IrcServer[],
@@ -104,7 +105,12 @@ export class QuitDebouncer {
         // We don't want to debounce users that are quiting legitimately so return early, and
         // we do want to make their virtual matrix user leave the room, so return true.
         if (!isSplitOccuring) {
+            this.wasSplitOccuring = isSplitOccuring;
             return true;
+        }
+        else if (isSplitOccuring !== this.wasSplitOccuring) {
+            log.warn(`A netsplit is occuring: debouncing QUITs`)
+            this.wasSplitOccuring = true;
         }
 
         log.debug(`Dropping QUIT for ${nick}`);

--- a/src/bridge/QuitDebouncer.ts
+++ b/src/bridge/QuitDebouncer.ts
@@ -1,6 +1,5 @@
 import { IrcServer } from "../irc/IrcServer";
 import Log from "../logging";
-import { Queue } from "../util/Queue";
 
 const log = Log("QuitDebouncer");
 
@@ -11,20 +10,19 @@ export class QuitDebouncer {
         [domain: string]: {
             quitTimestampsMs: number[];
             splitChannelUsers: Map<string, Set<string>>; //"$channel $nick"
+            existingTimeouts: Set<string>; // Existing channel timeouts
         };
     };
 
-    private quitProcessQueue: Queue<{channel: string; server: IrcServer}>;
     private wasSplitOccuring = false;
 
     constructor(
         servers: IrcServer[],
-        private handleQuit: (item: {channel: string; server: IrcServer}) => Promise<void>) {
+        private handleQuit: (channel: string, server: IrcServer, nicks: string[]) => Promise<void>) {
         // Measure the probability of a net-split having just happened using QUIT frequency.
         // This is to smooth incoming PART spam from IRC clients that suffer from a
         // net-split (or other issues that lead to mass PART-ings)
         this.debouncerForServer = {};
-        this.quitProcessQueue = new Queue(this.handleQuit);
 
         // Keep a track of the times at which debounceQuit was called, and use this to
         // determine the rate at which quits are being received. This can then be used
@@ -33,6 +31,7 @@ export class QuitDebouncer {
             this.debouncerForServer[domain] = {
                 quitTimestampsMs: [],
                 splitChannelUsers: new Map(),
+                existingTimeouts: new Set(),
             };
         });
     }
@@ -44,19 +43,34 @@ export class QuitDebouncer {
      * @param {IrcServer} server The sending IRC server.
      */
     public onJoin(nick: string, channel: string, server: IrcServer) {
-        if (!this.debouncerForServer[server.domain]) {
+        const debouncer = this.debouncerForServer[server.domain];
+        if (!debouncer) {
             return;
         }
-        const set = this.debouncerForServer[server.domain].splitChannelUsers.get(channel);
+        const set = debouncer.splitChannelUsers.get(channel);
         if (!set) {
+            // We are either not debouncing, or this channel has been handled already.
             return;
         }
         set.delete(nick);
-
-        if (set.size === 0) {
+        if (debouncer.existingTimeouts.has(channel)) {
+            // We are already handling this one.
             return;
         }
-        this.quitProcessQueue.enqueue(channel+server.domain, {channel, server});
+        if (set.size === 0) {
+            // Nobody to debounce, yay.
+            return;
+        }
+        const delay = Math.max(server.getQuitDebounceDelayMinMs(), server.getQuitDebounceDelayMaxMs() * Math.random());
+        log.info(`Will attempt to reconnect users for ${channel} after ${delay}ms`)
+        setTimeout(() => {
+            // Clear our existing sets, we're about to operate on the channel.
+            const nicks = this.getQuitNicksForChannel(channel, server);
+            debouncer.splitChannelUsers.delete(channel);
+            debouncer.existingTimeouts.delete(channel);
+            this.handleQuit(channel, server, nicks);
+        }, delay);
+        debouncer.existingTimeouts.add(channel);
     }
 
     /**
@@ -64,11 +78,12 @@ export class QuitDebouncer {
      * @param channel The IRC channel
      * @param server The IRC server
      */
-    public getQuitNicksForChannel(channel: string, server: IrcServer) {
+    private getQuitNicksForChannel(channel: string, server: IrcServer) {
         // A little hint on iterators here:
         // You can return values() (an IterableIterator<string>) and if the Set gets modified,
         // the iterator will skip the value that was deleted.
-        return this.debouncerForServer[server.domain].splitChannelUsers.get(channel)?.values() || [];
+        const nicks = this.debouncerForServer[server.domain].splitChannelUsers.get(channel)?.values();
+        return nicks ? [...nicks] : [];
     }
 
     /**

--- a/src/irc/Scheduler.ts
+++ b/src/irc/Scheduler.ts
@@ -66,12 +66,12 @@ export default {
             } as QueueItem
         );
 
-        log.info(
+        log.debug(
             `Queued scheduled promise for ${server.domain} ${nick}` +
             (addedDelayMs > 0 ? ` with ${Math.round(addedDelayMs)}ms added delay`:'')
         );
 
-        log.info(
+        log.debug(
             `Queue for ${server.domain} length = ${q.size()}`
         );
 


### PR DESCRIPTION
Currently the debouncer does too much work when a netsplit is ongoing. It will immediately try to send QUITs for a channel as soon as it sees anyone join it from the IRC side, and it will also repeatedly send those QUITs because the list of nicks is not removed afterwards. This PR aims to fix those things.

This PR changes the debounce code so that:
- We now log when a debounce has begun, for easy tracing in the logs.
- We *only* try to send QUITs after a random interval of time (between min,max in the config), rather than as soon as we see the first join.
- :exclamation:  We do not **reprocess** the QUIT queue for the same channel 