### PR TITLE
Allow reverse-format realnames

### DIFF
--- a/changelog.d/1229.feature
+++ b/changelog.d/1229.feature
@@ -1,0 +1,1 @@
+Add `ircClients.realnameFormat` option in the config to show mxid in reverse in the realname field of clients.

--- a/changelog.d/1229.feature
+++ b/changelog.d/1229.feature
@@ -1,1 +1,1 @@
-Add `ircClients.realnameFormat` option in the config to show mxid in reverse in the realname field of clients.
+Add `ircClients.realnameFormat` option in the config to show mxid in reverse in the realname field of IRC clients.

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -371,6 +371,9 @@ ircService:
         # through the bridge e.g. caller ID as there is no way to /ACCEPT.
         # Default: "" (no user modes)
         # userModes: "R"
+        # The format of the realname defined for users, either mxid or reverse-mxid
+        realnameFormat: "mxid"
+
   # Set information about the bridged channel in the room state, so that client's may
   # present relevant UI to the user. MSC2346
   bridgeInfoState:

--- a/config.schema.yml
+++ b/config.schema.yml
@@ -364,6 +364,9 @@ properties:
                                     minimum: 0
                                 allowNickChanges:
                                     type: "boolean"
+                                realnameFormat:
+                                    type: "string"
+                                    enum: ["mxid","reverse-mxid"]
                                 ipv6:
                                     type: "object"
                                     properties:

--- a/src/irc/BridgedClient.ts
+++ b/src/irc/BridgedClient.ts
@@ -219,7 +219,7 @@ export class BridgedClient extends EventEmitter {
 
         try {
             const nameInfo = await this.identGenerator.getIrcNames(
-                this.clientConfig, this.matrixUser
+                this.clientConfig, this.server, this.matrixUser,
             );
             const ipv6Prefix = this.server.getIpv6Prefix();
             if (ipv6Prefix) {
@@ -478,7 +478,7 @@ export class BridgedClient extends EventEmitter {
 
         const c = this.state.client;
 
-        return new Promise((resolve) => {
+        return new Promise<void>((resolve) => {
             this.log.debug("Kicking %s from channel %s", nick, channel);
             c.send("KICK", channel, nick, reason);
             resolve(); // wait for some response? Is there even one?

--- a/src/irc/IdentGenerator.ts
+++ b/src/irc/IdentGenerator.ts
@@ -19,6 +19,7 @@ import { getLogger } from "../logging";
 import { DataStore } from "../datastore/DataStore";
 import { MatrixUser } from "matrix-appservice-bridge";
 import { IrcClientConfig } from "../models/IrcClientConfig";
+import Ident from "./Ident";
 
 const log = getLogger("IdentGenerator");
 
@@ -43,6 +44,10 @@ export class IdentGenerator {
         });
     }
 
+    static switchAroundMxid(user: MatrixUser) {
+        return `${user.host}:${user.localpart}`;
+    }
+
     /**
      * Get the IRC name info for this user.
      * @param {IrcClientConfig} clientConfig IRC client configuration info.
@@ -55,8 +60,9 @@ export class IdentGenerator {
     public async getIrcNames(ircClientConfig: IrcClientConfig, matrixUser?: MatrixUser):
         Promise<{username: string; realname: string}> {
         const username = ircClientConfig.getUsername();
+        
         const realname = (matrixUser ?
-            IdentGenerator.sanitiseRealname(matrixUser.getId()) :
+            IdentGenerator.sanitiseRealname(IdentGenerator.switchAroundMxid(matrixUser)) :
             IdentGenerator.sanitiseRealname(username || "")
                 ).substring(
                     0, IdentGenerator.MAX_REAL_NAME_LENGTH

--- a/src/irc/IdentGenerator.ts
+++ b/src/irc/IdentGenerator.ts
@@ -45,7 +45,10 @@ export class IdentGenerator {
     }
 
     static switchAroundMxid(user: MatrixUser) {
-        return `${user.host}:${user.localpart}`;
+        return user.host.split('.')
+                .reverse()
+                .join('.')
+                .substr(0, 30) + (user.host.length > 30 ? ">:" : ":") + user.localpart;
     }
 
     /**

--- a/src/irc/IdentGenerator.ts
+++ b/src/irc/IdentGenerator.ts
@@ -48,7 +48,7 @@ export class IdentGenerator {
         return user.host.split('.')
                 .reverse()
                 .join('.')
-                .substr(0, 30) + (user.host.length > 30 ? ">:" : ":") + user.localpart;
+                .substring(0, 30) + (user.host.length > 30 ? ">:" : ":") + user.localpart;
     }
 
     /**

--- a/src/irc/IrcServer.ts
+++ b/src/irc/IrcServer.ts
@@ -159,6 +159,10 @@ export class IrcServer {
         return this.config.ircClients.userModes || "";
     }
 
+    public getRealNameFormat() {
+        return this.config.ircClients.realnameFormat || "mxid";
+    }
+
     public getJoinRule() {
         return this.config.dynamicChannels.joinRule;
     }
@@ -726,6 +730,7 @@ export interface IrcServerConfig {
         };
         lineLimit: number;
         userModes?: string;
+        realnameFormat?: "mxid"|"reverse-mxid";
     };
     excludedUsers: Array<
         {

--- a/src/irc/IrcServer.ts
+++ b/src/irc/IrcServer.ts
@@ -159,7 +159,7 @@ export class IrcServer {
         return this.config.ircClients.userModes || "";
     }
 
-    public getRealNameFormat() {
+    public getRealNameFormat(): "mxid"|"reverse-mxid" {
         return this.config.ircClients.realnameFormat || "mxid";
     }
 


### PR DESCRIPTION
on behalf of freenode and oftc, this allows the bridge to show the host:localpart in the realname for easy pattern matching