### PR TITLE
Fix thundering herd problem with debouncer

### DIFF
--- a/changelog.d/1230.bugfix
+++ b/changelog.d/1230.bugfix
@@ -1,0 +1,1 @@
+Fix an issue where the QuitDebouncer would reprocess old QUITs, and process QUITs too early during the debouncing process.

--- a/spec/unit/IrcServer.spec.js
+++ b/spec/unit/IrcServer.spec.js
@@ -2,6 +2,23 @@
 const { IrcServer } = require("../../lib/irc/IrcServer");
 const extend = require("extend");
 describe("IrcServer", function() {
+    describe("getQuitDebounceDelay", () => {
+        it("should get a random period between min and max", () => {
+            const delayMinMs = 5;
+            const delayMaxMs = 10;
+            const server = new IrcServer("irc.foobar",
+                extend(true, IrcServer.DEFAULT_CONFIG, {
+                    quitDebounce: {
+                        delayMinMs,
+                        delayMaxMs,
+                    }
+                })
+            );
+            const delay = server.getQuitDebounceDelay();
+            expect(delay).toBeGreaterThan(delayMinMs);
+            expect(delay).toBeLessThan(delayMaxMs);
+        });
+    })
     describe("getNick", function() {
         it("should get a nick from a userid", function() {
             const server = new IrcServer("irc.foobar",

--- a/src/bridge/QuitDebouncer.ts
+++ b/src/bridge/QuitDebouncer.ts
@@ -61,6 +61,7 @@ export class QuitDebouncer {
             // Nobody to debounce, yay.
             return;
         }
+        const delay = server.getQuitDebounceDelay();
         log.info(`Will attempt to reconnect users for ${channel} after ${delay}ms`)
         setTimeout(() => {
             // Clear our existing sets, we're about to operate on the channel.
@@ -68,7 +69,7 @@ export class QuitDebouncer {
             debouncer.splitChannelUsers.delete(channel);
             debouncer.existingTimeouts.delete(channel);
             this.handleQuit(channel, server, nicks);
-        }, server.getQuitDebounceDelay());
+        }, delay);
         debouncer.existingTimeouts.add(channel);
     }
 

--- a/src/bridge/QuitDebouncer.ts
+++ b/src/bridge/QuitDebouncer.ts
@@ -61,7 +61,6 @@ export class QuitDebouncer {
             // Nobody to debounce, yay.
             return;
         }
-        const delay = Math.max(server.getQuitDebounceDelayMinMs(), server.getQuitDebounceDelayMaxMs() * Math.random());
         log.info(`Will attempt to reconnect users for ${channel} after ${delay}ms`)
         setTimeout(() => {
             // Clear our existing sets, we're about to operate on the channel.
@@ -69,7 +68,7 @@ export class QuitDebouncer {
             debouncer.splitChannelUsers.delete(channel);
             debouncer.existingTimeouts.delete(channel);
             this.handleQuit(channel, server, nicks);
-        }, delay);
+        }, server.getQuitDebounceDelay());
         debouncer.existingTimeouts.add(channel);
     }
 

--- a/src/irc/IrcServer.ts
+++ b/src/irc/IrcServer.ts
@@ -99,29 +99,10 @@ export class IrcServer {
      * `delayMinMs` and `delayMaxMs`
      */
     public getQuitDebounceDelay(): number {
-        return this.getQuitDebounceDelayMinMs() + (
-            this.getQuitDebounceDelayMaxMs() - this.getQuitDebounceDelayMinMs()
+        const { delayMaxMs, delayMinMs } = this.config.quitDebounce;
+        return delayMinMs + (
+            delayMaxMs - delayMinMs
         ) * Math.random();
-    }
-
-    /**
-     * Get the minimum number of ms to debounce before bridging a QUIT to Matrix
-     * during a detected net-split. If the user rejoins a channel before bridging
-     * the quit to a leave, the leave will not be sent.
-     * @return {number}
-     */
-    private getQuitDebounceDelayMinMs() {
-        return this.config.quitDebounce.delayMinMs;
-    }
-
-    /**
-     * Get the maximum number of ms to debounce before bridging a QUIT to Matrix
-     * during a detected net-split. If a leave is bridged, it will occur at a
-     * random time between delayMinMs (see above) delayMaxMs.
-     * @return {number}
-     */
-    private getQuitDebounceDelayMaxMs() {
-        return this.config.quitDebounce.delayMaxMs;
     }
 
     /**

--- a/src/irc/IrcServer.ts
+++ b/src/irc/IrcServer.ts
@@ -94,13 +94,19 @@ export class IrcServer {
         return this.config.quitDebounce.enabled;
     }
 
+    public getQuitDebounceDelay() {
+        return this.getQuitDebounceDelayMinMs() + (
+            this.getQuitDebounceDelayMaxMs() - this.getQuitDebounceDelayMinMs()
+        ) * Math.random();
+    }
+
     /**
      * Get the minimum number of ms to debounce before bridging a QUIT to Matrix
      * during a detected net-split. If the user rejoins a channel before bridging
      * the quit to a leave, the leave will not be sent.
      * @return {number}
      */
-    public getQuitDebounceDelayMinMs() {
+    private getQuitDebounceDelayMinMs() {
         return this.config.quitDebounce.delayMinMs;
     }
 
@@ -110,7 +116,7 @@ export class IrcServer {
      * random time between delayMinMs (see above) delayMaxMs.
      * @return {number}
      */
-    public getQuitDebounceDelayMaxMs() {
+    private getQuitDebounceDelayMaxMs() {
         return this.config.quitDebounce.delayMaxMs;
     }
 

--- a/src/irc/IrcServer.ts
+++ b/src/irc/IrcServer.ts
@@ -94,7 +94,11 @@ export class IrcServer {
         return this.config.quitDebounce.enabled;
     }
 
-    public getQuitDebounceDelay() {
+    /**
+     * Get a random interval to delay a quits for when debouncing. Will be between
+     * `delayMinMs` and `delayMaxMs`
+     */
+    public getQuitDebounceDelay(): number {
         return this.getQuitDebounceDelayMinMs() + (
             this.getQuitDebounceDelayMaxMs() - this.getQuitDebounceDelayMinMs()
         ) * Math.random();


### PR DESCRIPTION
There is a bug in the debouncer code that would often delay the debounce for the min period rather than a random period. This change ensures that two debounce efforts are hopefully not processed at the same time.