### PR TITLE
Debounce joins to improve performance

### DIFF
--- a/changelog.d/1231.bugfix
+++ b/changelog.d/1231.bugfix
@@ -1,0 +1,1 @@
+Fix an issue where the QuitDebouncer would reprocess old QUITs, and process QUITs too early during the debouncing process.

--- a/src/irc/IrcEventBroker.ts
+++ b/src/irc/IrcEventBroker.ts
@@ -361,6 +361,12 @@ export class IrcEventBroker {
                 req, server, createUser(nick), chan, "part", reason
             ));
         });
+        this.hookIfClaimed(client, connInst, "kick", (chan: string, nick: string, by: string, reason: string) => {
+            const req = createRequest();
+            complete(req, ircHandler.onKick(
+                req, server, createUser(by), createUser(nick), chan, reason
+            ));
+        });
         this.hookIfClaimed(client, connInst, "quit", (nick: string, reason: string, chans: string[]) => {
             chans = chans || [];
             // True if a leave should be sent, otherwise false.
@@ -373,18 +379,14 @@ export class IrcEventBroker {
                 });
             }
         });
-        this.hookIfClaimed(client, connInst, "kick", (chan: string, nick: string, by: string, reason: string) => {
-            const req = createRequest();
-            complete(req, ircHandler.onKick(
-                req, server, createUser(by), createUser(nick), chan, reason
-            ));
-        });
         this.hookIfClaimed(client, connInst, "join", (chan: string, nick: string) => {
             const req = createRequest();
-            this.quitDebouncer.onJoin(nick, chan, server);
-            complete(req, ircHandler.onJoin(
-                req, server, createUser(nick), chan, "join"
-            ));
+            // True if a join should be sent, otherwise false
+            if (this.quitDebouncer.onJoin(nick, chan, server)) {
+                complete(req, ircHandler.onJoin(
+                    req, server, createUser(nick), chan, "join"
+                ));
+            }
         });
         this.hookIfClaimed(client, connInst, "nick", (oldNick: string, newNick: string, chans: string[]) => {
             chans = chans || [];


### PR DESCRIPTION
This was a quick win that struck me as I read the code.

(Note to reviewer: We debounce quits when they come in great numbers and defer them for later so that the bridge doesn't melt)

When we handle QUITs for users while debouncing, we perform no action and store the quit in memory instead. However when we see the user join the channel again, we remove them from memory BUT process the join. In reality we don't need to take any action if we have seen a QUIT>JOIN as the user will still be joined to the room.

With this in mind, we do a fairly simple check to ensure that if a user is in the quitters pool, we will take no action to join them which will save a few CPU cycles.