### PR TITLE
Allow for configurable ping time

### DIFF
--- a/changelog.d/1232.feature
+++ b/changelog.d/1232.feature
@@ -1,0 +1,1 @@
+Add `pingTimeoutMs` and `pingRateMs` as options to the config 

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -373,6 +373,13 @@ ircService:
         # userModes: "R"
         # The format of the realname defined for users, either mxid or reverse-mxid
         realnameFormat: "mxid"
+        # The minimum time to wait between connection attempts if we were disconnected
+        # due to throttling.
+        # pingTimeoutMs: 600000
+        # The rate at which to send pings to the IRCd if the client is being quiet for a while.
+        # Whilst the IRCd *should* be sending pings to us to keep the connection alive, it appears
+        # that sometimes they don't get around to it and end up ping timing us out.
+        # pingRateMs: 60000
 
   # Set information about the bridged channel in the room state, so that client's may
   # present relevant UI to the user. MSC2346

--- a/config.schema.yml
+++ b/config.schema.yml
@@ -379,6 +379,10 @@ properties:
                                     type: "integer"
                                 userModes:
                                     type: "string"
+                                pingTimeoutMs:
+                                    type: "integer"
+                                pingRateMs:
+                                    type: "integer"
                         excludeUsers:
                             type: "array"
                             properties:

--- a/src/irc/ConnectionInstance.ts
+++ b/src/irc/ConnectionInstance.ts
@@ -89,7 +89,8 @@ export class ConnectionInstance {
      * @param {string} domain The domain (for logging purposes)
      * @param {string} nick The nick (for logging purposes)
      */
-    constructor (public readonly client: Client, private readonly domain: string, private nick: string, private pingOpts: {
+    constructor (public readonly client: Client, private readonly domain: string, private nick: string,
+        private pingOpts: {
         pingRateMs: number;
         pingTimeoutMs: number;
     }) {

--- a/src/irc/ConnectionInstance.ts
+++ b/src/irc/ConnectionInstance.ts
@@ -38,15 +38,8 @@ const FLOOD_PROTECTION_DELAY_MS = 700;
 // The max amount of time we should wait for the server to ping us before reconnecting.
 // Servers ping infrequently (2-3mins) so this should be high enough to allow up
 // to 2 pings to lapse before reconnecting (5-6mins).
-const PING_TIMEOUT_MS = 1000 * 60 * 10;
-// The minimum time to wait between connection attempts if we were disconnected
-// due to throttling.
-const THROTTLE_WAIT_MS = 20 * 1000;
 
-// The rate at which to send pings to the IRCd if the client is being quiet for a while.
-// Whilst the IRCd *should* be sending pings to us to keep the connection alive, it appears
-// that sometimes they don't get around to it and end up ping timing us out.
-const PING_RATE_MS = 1000 * 60;
+const THROTTLE_WAIT_MS = 20 * 1000;
 
 // String reply of any CTCP Version requests
 const CTCP_VERSION = 'matrix-appservice-irc, part of the Matrix.org Network';
@@ -96,7 +89,10 @@ export class ConnectionInstance {
      * @param {string} domain The domain (for logging purposes)
      * @param {string} nick The nick (for logging purposes)
      */
-    constructor (public readonly client: Client, private readonly domain: string, private nick: string) {
+    constructor (public readonly client: Client, private readonly domain: string, private nick: string, private pingOpts: {
+        pingRateMs: number;
+        pingTimeoutMs: number;
+    }) {
         this.listenForErrors();
         this.listenForPings();
         this.listenForCTCPVersions();
@@ -311,7 +307,7 @@ export class ConnectionInstance {
                 this.client.emit("netError", {
                     msg: "Client-side ping timeout"
                 });
-            }, PING_TIMEOUT_MS);
+            }, this.pingOpts.pingTimeoutMs);
         }
         this.client.on("ping", (svr: string) => {
             log.debug("Received ping from %s directed at %s", svr, this.nick);
@@ -348,7 +344,7 @@ export class ConnectionInstance {
             this.client.send("PING", "LAG" + Date.now());
             // keep doing it.
             this.resetPingSendTimer();
-        }, PING_RATE_MS);
+        }, this.pingOpts.pingRateMs);
     }
 
     /**
@@ -394,7 +390,10 @@ export class ConnectionInstance {
                 server.randomDomain(), opts.nick, connectionOpts
             );
             const inst = new ConnectionInstance(
-                nodeClient, server.domain, opts.nick
+                nodeClient, server.domain, opts.nick, {
+                    pingRateMs: server.pingRateMs,
+                    pingTimeoutMs: server.pingTimeout,
+                }
             );
             if (onCreatedCallback) {
                 onCreatedCallback(inst);

--- a/src/irc/IrcServer.ts
+++ b/src/irc/IrcServer.ts
@@ -286,6 +286,23 @@ export class IrcServer {
         return this.idleUsersStartupExcludeRegex;
     }
 
+    /**
+     * The amount of time to allow for inactivty on the connection, before considering the connection
+     * dead. This usually happens if the IRCd doesn't ping us.
+     */
+    public get pingTimeout() {
+        return this.config.ircClients.pingTimeoutMs;
+    }
+
+    /**
+     * The rate at which to send pings to the IRCd if the client is being quiet for a while.
+     * Whilst the IRCd *should* be sending pings to us to keep the connection alive, it appears
+     * that sometimes they don't get around to it and end up ping timing us out.
+    */
+    public get pingRateMs() {
+        return this.config.ircClients.pingRateMs;
+    }
+
     public canJoinRooms(userId: string) {
         return (
             this.config.dynamicChannels.enabled &&
@@ -551,7 +568,9 @@ export class IrcServer {
                 ipv6: {
                     only: false
                 },
-                lineLimit: 3
+                lineLimit: 3,
+                pingTimeoutMs: 1000 * 60 * 10,
+                pingRateMs: 1000 * 60,
             },
             membershipLists: {
                 enabled: false,
@@ -722,6 +741,8 @@ export interface IrcServerConfig {
         lineLimit: number;
         userModes?: string;
         realnameFormat?: "mxid"|"reverse-mxid";
+        pingTimeoutMs: number;
+        pingRateMs: number;
     };
     excludedUsers: Array<
         {


### PR DESCRIPTION
This PR allows us to configure how long to wait for pinging out, which helps for large bridges for freenode who have given us a slightly increased ping time to allow the node process some breathing room.