### PR TITLE
Properly urlencode media urls

### DIFF
--- a/changelog.d/1237.bugfix
+++ b/changelog.d/1237.bugfix
@@ -1,0 +1,1 @@
+MXC urls are now properly URL encoded when sent to IRC.

--- a/src/models/MatrixAction.ts
+++ b/src/models/MatrixAction.ts
@@ -192,7 +192,7 @@ export class MatrixAction {
                 }
                 else {
                     // If not a filename, print the body
-                    text = `${event.content.body} ${fileSize} < ${url} >`;
+                    text = `${event.content.body}${fileSize} < ${url} >`;
                 }
             }
         }

--- a/src/models/MatrixAction.ts
+++ b/src/models/MatrixAction.ts
@@ -187,9 +187,13 @@ export class MatrixAction {
                 }
 
                 if (filename) {
-                    url += `/${filename}`;
+                    url += `/${encodeURIComponent(filename)}`;
+                    text = `${fileSize} < ${url} >`;
                 }
-                text = `${event.content.body}${fileSize} < ${url} >`;
+                else {
+                    // If not a filename, print the body
+                    text = `${event.content.body} ${fileSize} < ${url} >`;
+                }
             }
         }
         return new MatrixAction(type, text, htmlText, event.origin_server_ts);

--- a/src/models/MatrixAction.ts
+++ b/src/models/MatrixAction.ts
@@ -177,7 +177,7 @@ export class MatrixAction {
                 let fileSize = "";
                 if (event.content.info && event.content.info.size &&
                         typeof event.content.info.size === "number") {
-                    fileSize = " (" + Math.round(event.content.info.size / 1024) + "KiB)";
+                    fileSize = "(" + Math.round(event.content.info.size / 1024) + "KiB)";
                 }
 
                 let url = ContentRepo.getHttpUriForMxc(mediaUrl, event.content.url);
@@ -191,6 +191,7 @@ export class MatrixAction {
                     text = `${fileSize} < ${url} >`;
                 }
                 else {
+                    fileSize = fileSize ? ` ${fileSize}` : "";
                     // If not a filename, print the body
                     text = `${event.content.body}${fileSize} < ${url} >`;
                 }


### PR DESCRIPTION
Fixes #1219 

This PR url encodes the filename parameter of a media file when sending to IRC and removes the filaname from the beginning of the message, if the body is detected to be a filename.