### PR TITLE
Catch channel join failures during reconnect

### DIFF
--- a/changelog.d/1255.bugfix
+++ b/changelog.d/1255.bugfix
@@ -1,0 +1,1 @@
+Fixed an issue where users would not be rejoined to some channels on reconnect if they failed to rejoin any channel.

--- a/src/irc/BridgedClient.ts
+++ b/src/irc/BridgedClient.ts
@@ -327,7 +327,7 @@ export class BridgedClient extends EventEmitter {
             "Reconnected %s@%s", this.nick, this.server.domain
         );
         this.log.info("Rejoining %s channels", this._chanList.size);
-        // This needs to be synchronous to avoid spamming freenode
+        // This needs to be synchronous to avoid spamming the IRCD
         // with lots of reconnects.
         for (const channel of this._chanList) {
             try {

--- a/src/irc/BridgedClient.ts
+++ b/src/irc/BridgedClient.ts
@@ -327,10 +327,15 @@ export class BridgedClient extends EventEmitter {
             "Reconnected %s@%s", this.nick, this.server.domain
         );
         this.log.info("Rejoining %s channels", this._chanList.size);
-        // This needs to be synchronous
+        // This needs to be synchronous to avoid spamming freenode
+        // with lots of reconnects.
         for (const channel of this._chanList) {
-            // XXX: Why do we not catch these?
-            await this.joinChannel(channel);
+            try {
+                await this.joinChannel(channel);
+            }
+            catch (ex) {
+                this.log.error(`Failed to rejoin channel: ${ex}`);
+            }
         }
         this.log.info("Rejoined channels");
     }


### PR DESCRIPTION
Previously if we failed to rejoin a channel, we would exit the loop prematurely and not join any other channels either. This PR ensures that we only log a failure to rejoin