### PR TITLE
Fix race around irc->matrix membership bridging for bot mode bridges

### DIFF
--- a/changelog.d/1256.bugfix
+++ b/changelog.d/1256.bugfix
@@ -1,0 +1,1 @@
+Fix an issue where IRC membership would not be bridged to new rooms when `botConfig.enabled` is `true`. 

--- a/src/bridge/IrcBridge.ts
+++ b/src/bridge/IrcBridge.ts
@@ -1145,21 +1145,6 @@ export class IrcBridge {
         return new IrcUser(ircInfo.server, ircInfo.nick, true);
     }
 
-    public async trackChannel(server: IrcServer, channel: string, key?: string): Promise<IrcRoom> {
-        if (!server.isBotEnabled()) {
-            log.info("trackChannel: Bot is disabled.");
-            return new IrcRoom(server, channel);
-        }
-        const client = await this.getBotClient(server);
-        try {
-            return await client.joinChannel(channel, key);
-        }
-        catch (ex) {
-            log.error(ex);
-            throw Error("Failed to join channel");
-        }
-    }
-
     public connectToIrcNetworks() {
         return promiseutil.allSettled(this.ircServers.map((server) =>
             Bluebird.cast(this.clientPool.loginToServer(server))

--- a/src/bridge/RoomCreation.ts
+++ b/src/bridge/RoomCreation.ts
@@ -60,6 +60,8 @@ export async function trackChannelAndCreateRoom(ircBridge: IrcBridge, req: Bridg
     if (server.isExcludedChannel(ircChannel)) {
         throw Error('Channel is excluded');
     }
+    // See https://github.com/matrix-org/matrix-appservice-irc/pull/1256
+    // for context on why we don't join the room here.
     req.log.debug("Going to track IRC channel %s", ircChannel);
     const ircRoom = new IrcRoom(server, ircChannel);
     let roomId;

--- a/src/bridge/RoomCreation.ts
+++ b/src/bridge/RoomCreation.ts
@@ -3,6 +3,7 @@ import { IrcBridge } from "./IrcBridge";
 import { MatrixRoom, Intent } from "matrix-appservice-bridge";
 import { BridgeRequest } from "../models/BridgeRequest";
 import { RoomOrigin } from "../datastore/DataStore";
+import { IrcRoom } from "../models/IrcRoom";
 
 interface TrackChannelOpts {
     server: IrcServer;
@@ -56,9 +57,11 @@ export async function trackChannelAndCreateRoom(ircBridge: IrcBridge, req: Bridg
             )
         )
     }
-    req.log.info("Going to track IRC channel %s", ircChannel);
-    const ircRoom = await ircBridge.trackChannel(server, ircChannel, key);
-    req.log.info("Bot is now tracking IRC channel.");
+    if (server.isExcludedChannel(ircChannel)) {
+        throw Error('Channel is excluded');
+    }
+    req.log.debug("Going to track IRC channel %s", ircChannel);
+    const ircRoom = new IrcRoom(server, ircChannel);
     let roomId;
     try {
         const response = await intent.createRoom({
@@ -76,7 +79,7 @@ export async function trackChannelAndCreateRoom(ircBridge: IrcBridge, req: Bridg
             }
         });
         roomId = response.room_id;
-        req.log.info("Matrix room %s created.", roomId);
+        req.log.info("Matrix room %s created for %s", roomId, ircChannel);
     }
     catch (ex) {
         req.log.error("Failed to create room: %s", ex.stack);
@@ -85,6 +88,17 @@ export async function trackChannelAndCreateRoom(ircBridge: IrcBridge, req: Bridg
 
     const mxRoom = new MatrixRoom(roomId);
     await ircBridge.getStore().storeRoom(ircRoom, mxRoom, origin);
+    // Join the room now we've stored it, if we're the bot user.
+    if (server.isBotEnabled()) {
+        try {
+            const client = await ircBridge.getBotClient(server)
+            await client.joinChannel(ircChannel, key);
+            req.log.info(`Bot joined channel`);
+        }
+        catch (ex) {
+            req.log.error(`Bot failed to join channel: ${ex}`);
+        }
+    }
     // /mode the channel AFTER we have created the mapping so we process
     // +s and +i correctly. This is done asyncronously.
     ircBridge.publicitySyncer.initModeForChannel({server, channel: ircChannel}).catch(() => {


### PR DESCRIPTION
Fixes https://github.com/matrix-org/matrix-appservice-irc/issues/1250

This comes down to some confusing logic in the bridge when users attempt to bridge a new IRC channel, what would typically happen is:

- User tries a `!join #channel` or a `/join #irc_#channel:example.com`
- The bridge will try to join the channel **if the irc bridge bot is configured**
- The bridge will join the channel and immediately get NAMES information on the IRC side, and try to bridge I->M
- It will fail because the room isn't stored yet
- The bridge joins and the ircChannel,server,roomId mapping gets stored
- The room is now stored, but it's too late because the irc side has already sent the membership info and we missed it.

However if the bridge bot isn't configured then the bridge will only join the IRC channel **after** the mapping is stored, which means the bridge will be able to handle the NAMES information. This is typically the mode that most bridges run under.

Because it's very hard to make the bridge join the channel first without either:
1) Lots of deferred storage of membership until the room is mapped, creating a lot of fragile code and further increasing our memory footprint
2) Re-requesting the membership, causing additional load.

I'm going to make it so that we never join the IRC channel in either mode, as we seem to have been happy to do without it on our major bridges anyway. This also means our logic for bot and botless bridges are identical which should avoid surprises.
