### PR TITLE
Immediately remove PLs from users when unbridging

### DIFF
--- a/changelog.d/1257.bugfix
+++ b/changelog.d/1257.bugfix
@@ -1,0 +1,1 @@
+Update powerlevels immediately when unbridging to avoid rejoining the bridge bot to the room.

--- a/src/DebugApi.ts
+++ b/src/DebugApi.ts
@@ -324,12 +324,7 @@ export class DebugApi {
             return;
         }
 
-        log.warn(
-    `Requested deletion of portal room alias ${roomId} through debug API
-    Domain: ${domain}
-    Channel: ${channel}
-    Leave Notice: ${notice}
-    Remove Alias: ${removeAlias}`);
+        log.info(`Killing room ${roomId} (${domain} ${channel}) removeAlias: ${removeAlias} notice: ${notice}`);
 
         // Find room
         const room = await store.getRoom(

--- a/src/bridge/RoomAccessSyncer.ts
+++ b/src/bridge/RoomAccessSyncer.ts
@@ -88,9 +88,16 @@ export class RoomAccessSyncer {
     }
 
     public async removePowerLevels(roomId: string, users: string[], req: BridgeRequest) {
-        await Promise.all(users.map(userId =>
-            this.setPowerLevel(roomId, userId, null, req)
-        ));
+        const userMap: Record<string, null> = {};
+        users.forEach(userId => {userMap[userId] = null});
+        const existingPlChange = this.pendingPLChanges.get(roomId);
+        if (existingPlChange) {
+            if (existingPlChange.timeout) {
+                clearTimeout(existingPlChange.timeout);
+            }
+            this.pendingPLChanges.delete(roomId);
+        }
+        return this.changePowerLevels(roomId, userMap, req);
     }
 
     /**

--- a/src/provisioning/Provisioner.ts
+++ b/src/provisioning/Provisioner.ts
@@ -942,13 +942,13 @@ export class Provisioner {
         }
         catch (err) {
             // keep going, we still need to part the bot; this is just cleanup
-            req.log.error(err.stack);
+            req.log.error(`Failed to unlink matrix/remote users from channel: ${err}`);
         }
 
         // Cause the bot to part the channel if there are no other rooms being mapped to this
         // channel
         const mxRooms = await this.ircBridge.getStore().getMatrixRoomsForChannel(server, ircChannel);
-        if (mxRooms.length === 0) {
+        if (mxRooms.length === 0 && server.isBotEnabled()) {
             const botClient = await this.ircBridge.getBotClient(server);
             req.log.info(`Leaving channel ${ircChannel} as there are no more provisioned mappings`);
             await botClient.leaveChannel(ircChannel);
@@ -1039,6 +1039,9 @@ export class Provisioner {
             roomId
         );
         if (roomChannels.length > 0) {
+            req.log.warn(
+                `Not leaving matrix virtuals from room, room is still bridged to ${roomChannels.length} channel(s)`
+            );
             // We can't determine who should and shouldn't be in the room.
             return;
         }


### PR DESCRIPTION
Related to #1248 

A while ago we altered the bridge code to asynchronously alter the PLs of users so that we would send fewer PL events into the room so that if 5 users all needed changing, we would debounce and send one change. However, this causes problems for unbridging where we will:

1. Tell the bridge to remove PLs for the irc ghosts in the room
2. Leave the IRC bridge bot from the room
3. Re-join the IRC bridge bot as 1. will execute asynchronously.
4. This leaves the IRC bridge in the room forever.