### PR TITLE
Remove admin/pm rooms when the matrix-side user leaves to allow server to GC

### DIFF
--- a/changelog.d/1258.misc
+++ b/changelog.d/1258.misc
@@ -1,0 +1,1 @@
+Leave DM rooms and admin rooms if the Matrix user leaves so that a homeserver may clear them up later.

--- a/src/datastore/DataStore.ts
+++ b/src/datastore/DataStore.ts
@@ -124,6 +124,8 @@ export interface DataStore {
 
     getMatrixPmRoom(realUserId: string, virtualUserId: string): Promise<MatrixRoom|null>;
 
+    getMatrixPmRoomById(roomId: string): Promise<MatrixRoom|null>;
+
     getTrackedChannelsForServer(domain: string): Promise<string[]>;
 
     getRoomIdsFromConfig(): Promise<string[]>;
@@ -137,6 +139,8 @@ export interface DataStore {
     getAdminRoomById(roomId: string): Promise<MatrixRoom|null>;
 
     storeAdminRoom(room: MatrixRoom, userId: string): Promise<void>;
+
+    removeAdminRoom(room: MatrixRoom): Promise<void>;
 
     upsertMatrixRoom(room: MatrixRoom): Promise<void>;
 

--- a/src/datastore/NedbDataStore.ts
+++ b/src/datastore/NedbDataStore.ts
@@ -384,6 +384,18 @@ export class NeDBDataStore implements DataStore {
         return entry.matrix || null;
     }
 
+    public async getMatrixPmRoomById(roomId: string) {
+        const entry = await this.roomStore.getEntriesByMatrixId(roomId);
+        if (!entry) {
+            return null;
+        }
+        if (entry.length > 1) {
+            log.warn(`More than one PM room assigned to Matrix room ${roomId}, returning first`);
+        }
+        return entry[0].matrix || null;
+    }
+
+
     public async getTrackedChannelsForServer(domain: string) {
         const entries: Entry[] = await this.roomStore.getEntriesByRemoteRoomData({ domain });
         const channels = new Set<string>();
@@ -477,6 +489,12 @@ export class NeDBDataStore implements DataStore {
             matrix: room,
             remote: undefined,
             data: {},
+        });
+    }
+
+    public async removeAdminRoom(room: MatrixRoom): Promise<void> {
+        await this.roomStore.delete({
+            matrix: room,
         });
     }
 

--- a/src/datastore/postgres/PgDataStore.ts
+++ b/src/datastore/postgres/PgDataStore.ts
@@ -348,6 +348,18 @@ export class PgDataStore implements DataStore {
         return new MatrixRoom(res.rows[0].room_id);
     }
 
+    public async getMatrixPmRoomById(roomId: string): Promise<MatrixRoom|null> {
+        log.debug(`getMatrixPmRoom (roomId=${roomId})`);
+        const res = await this.pgPool.query(
+            "SELECT room_id, matrix_user_id, virtual_user_id FROM pm_rooms WHERE room_id = $1", [
+            roomId,
+        ]);
+        if (res.rowCount === 0) {
+            return null;
+        }
+        return new MatrixRoom(res.rows[0].room_id);
+    }
+
     public async getTrackedChannelsForServer(domain: string): Promise<string[]> {
         if (!this.serverMappings[domain]) {
             // Return empty if we don't know the server.
@@ -408,6 +420,10 @@ export class PgDataStore implements DataStore {
             return null;
         }
         return new MatrixRoom(res.rows[0].room_id);
+    }
+
+    public async removeAdminRoom(room: MatrixRoom): Promise<void> {
+        await this.pgPool.query("DELETE FROM admin_rooms WHERE room_id = $1", [room.roomId]);
     }
 
     public async storeMatrixUser(matrixUser: MatrixUser): Promise<void> {


### PR DESCRIPTION
Fixes #1207 

The idea here is that the rooms serve no purpose once the Matrix user has left them, so we might as well leave the bridge users from the room too and then Synapse can garbage collect the room (as it is unjoinable). Of course, https://github.com/matrix-org/synapse/issues/4720 needs to happen first.