### PR TITLE
config.schema.yml: fix permissions schema

### DIFF
--- a/changelog.d/1261.bugfix
+++ b/changelog.d/1261.bugfix
@@ -1,0 +1,1 @@
+Fix invalid JSON schema for `ircService.permissions`

--- a/config.schema.yml
+++ b/config.schema.yml
@@ -113,7 +113,7 @@ properties:
                     enableReload:
                         type: "boolean"
                     roomLimit:
-                        type: "number" 
+                        type: "number"
             passwordEncryptionKeyPath:
                 type: "string"
             matrixHandler:
@@ -137,8 +137,8 @@ properties:
             permissions:
                 type: "object"
                 additionalProperties:
-                    - type: "string"
-                      enum: ["admin"]
+                    type: "string"
+                    enum: ["admin"]
             servers:
                 type: "object"
                 # all properties must follow the following


### PR DESCRIPTION
The key reflects a key, value mapping from mxid to "admin", and
additionalProperties requires this to be either a boolean or an object,
but it is currently defined as a list. This breaks validation for us.

> The additionalProperties keyword may be either a boolean or an object

https://json-schema.org/understanding-json-schema/reference/object.html#id2

And objects to me sound like they describe an associative array, or
dictionary:

> Objects are the mapping type in JSON. They map “keys” to “values”.

https://json-schema.org/understanding-json-schema/reference/object.html#object

So let's fix this by replacing the spurious list definition with an
actual object.