### PR TITLE
Trim Markdown code block syntax

### DIFF
--- a/changelog.d/1275.bugfix
+++ b/changelog.d/1275.bugfix
@@ -1,0 +1,1 @@
+[M->I]: Trim Markdown code block syntax

--- a/spec/unit/formatting.spec.js
+++ b/spec/unit/formatting.spec.js
@@ -39,4 +39,43 @@ describe("Formatting", function() {
             ).toBe(null);
         });
     });
+    describe("ircToHtml", function() {
+        it("should have non-HTML for non-formatted inputs", function() {
+            expect(
+                formatting.ircToHtml("The quick brown fox jumps over the lazy dog.")
+            ).toBe("The quick brown fox jumps over the lazy dog.");
+        });
+        it("should <b> for bold inputs", function() {
+            expect(
+                formatting.ircToHtml("The quick brown \u0002fox\u000f jumps over the lazy \u0002dog\u000f.")
+            ).toBe("The quick brown <b>fox</b> jumps over the lazy <b>dog</b>.");
+        });
+    });
+    describe("markdownCodeToIrc", function() {
+        it("should return null for a non-code input", function() {
+            expect(
+                formatting.markdownCodeToIrc("The quick brown fox jumps over the lazy dog.")
+            ).toBe(null);
+        });
+        it("should remove markdown code delimiters", function() {
+            expect(
+                formatting.markdownCodeToIrc("```\nconst matrixBridge = true;\n```")
+            ).toBe("const matrixBridge = true;");
+        });
+        it("should trim whitespaces around the markdown code delimiters", function () {
+            expect(
+                formatting.markdownCodeToIrc(" \t\n```\nconst matrixBridge = true;\n```\n ")
+            ).toBe("const matrixBridge = true;");
+        });
+        it("should support multiple lines", function () {
+            expect(
+                formatting.markdownCodeToIrc("```\n'use strict';\nconst matrixBridge = true;\nparty();\n```")
+            ).toBe("'use strict';\nconst matrixBridge = true;\nparty();");
+        });
+        it("should remove language annotation in the after the intro delimiter", function () {
+            expect(
+                formatting.markdownCodeToIrc("```js\nconst matrixBridge = true;\n```")
+            ).toBe("const matrixBridge = true;");
+        });
+    });
 });

--- a/src/bridge/IrcHandler.ts
+++ b/src/bridge/IrcHandler.ts
@@ -802,7 +802,7 @@ export class IrcHandler {
             }
 
             // Show a reason if the part is not a regular part, or reason text was given.
-            const kindText = kind[0].toUpperCase() + kind.substr(1);
+            const kindText = kind[0].toUpperCase() + kind.substring(1);
             if (reason) {
                 reason = `${kindText}: ${reason}`;
             }

--- a/src/bridge/MatrixHandler.ts
+++ b/src/bridge/MatrixHandler.ts
@@ -975,7 +975,7 @@ export class MatrixHandler {
             return;
         }
 
-        const potentialCodeText = trimCodeMessages(text)
+        const potentialCodeText = trimCodeMessages(text);
         if (potentialCodeText) {
             ircAction.text = text = potentialCodeText;
         }

--- a/src/bridge/MatrixHandler.ts
+++ b/src/bridge/MatrixHandler.ts
@@ -1207,8 +1207,8 @@ export class MatrixHandler {
             // If we couldn't find a client for them, they might be a ghost.
             const ghostName = ircRoom.getServer().getNickFromUserId(rplName);
             // If we failed to get a name, just make a guess of it.
-            rplName = ghostName !== null ? ghostName : rplName.substring(1,
-                Math.min(REPLY_NAME_MAX_LENGTH + 1, rplName.indexOf(":") - 1)
+            rplName = ghostName !== null ? ghostName : rplName.substr(1,
+                Math.min(REPLY_NAME_MAX_LENGTH, rplName.indexOf(":") - 1)
             );
         }
 

--- a/src/bridge/MatrixHandler.ts
+++ b/src/bridge/MatrixHandler.ts
@@ -967,7 +967,7 @@ export class MatrixHandler {
         let body = cacheBody.trim().substring(0, REPLY_SOURCE_MAX_LENGTH);
         const nextNewLine = body.indexOf("\n");
         if (nextNewLine !== -1) {
-            body = cacheBody.substring(0, nextNewLine);
+            body = body.substring(0, nextNewLine);
         }
         this.eventCache.set(event.event_id, {
             body,

--- a/src/bridge/MatrixHandler.ts
+++ b/src/bridge/MatrixHandler.ts
@@ -23,6 +23,25 @@ async function reqHandler(req: BridgeRequest, promise: PromiseLike<unknown>) {
     }
 }
 
+/**
+ * Returns a trimmed string if the input text is all Markdown-style code.
+ * This is used to allow small code snippets to look nice in IRC and not be
+ * transformed into an upload.
+ */
+function trimCodeMessages(text: string): string|void {
+    let trimmedText = text.trim();
+    // If this post isn't all code, ignore it.
+    if (!/^```.*\n.*```$/s.test(trimmedText)) {
+        return;
+    }
+    // Remove the first line (e.g. ```js) and the ``` at the end
+    trimmedText = trimmedText.substring(trimmedText.indexOf('\n'), trimmedText.length - 3).trim();
+    // Add monospace character at the start of each line
+    // https://modern.ircdocs.horse/formatting.html#monospace
+    trimmedText = trimmedText.replace(/\n/, '\n\x11');
+    return trimmedText;
+}
+
 const MSG_PMS_DISABLED = "[Bridge] Sorry, PMs are disabled on this bridge.";
 const MSG_PMS_DISABLED_FEDERATION = "[Bridge] Sorry, PMs are disabled on this bridge over federation.";
 
@@ -956,6 +975,11 @@ export class MatrixHandler {
             return;
         }
 
+        const potentialCodeText = trimCodeMessages(text)
+        if (potentialCodeText) {
+            ircAction.text = text = potentialCodeText;
+        }
+        
         let cacheBody = text;
         if (event.content["m.relates_to"] && event.content["m.relates_to"]["m.in_reply_to"]) {
             const eventId = event.content["m.relates_to"]["m.in_reply_to"].event_id;

--- a/src/bridge/MatrixHandler.ts
+++ b/src/bridge/MatrixHandler.ts
@@ -23,25 +23,6 @@ async function reqHandler(req: BridgeRequest, promise: PromiseLike<unknown>) {
     }
 }
 
-/**
- * Returns a trimmed string if the input text is all Markdown-style code.
- * This is used to allow small code snippets to look nice in IRC and not be
- * transformed into an upload.
- */
-function trimCodeMessages(text: string): string|undefined {
-    let trimmedText = text.trim();
-    // If this post isn't all code, ignore it.
-    if (!/^```.*\n.*```$/s.test(trimmedText)) {
-        return undefined;
-    }
-    // Remove the first line (e.g. ```js) and the ``` at the end
-    trimmedText = trimmedText.substring(trimmedText.indexOf('\n'), trimmedText.length - 3).trim();
-    // Add monospace character at the start of each line
-    // https://modern.ircdocs.horse/formatting.html#monospace
-    trimmedText = trimmedText.replace(/\n/, '\n\x11');
-    return trimmedText;
-}
-
 const MSG_PMS_DISABLED = "[Bridge] Sorry, PMs are disabled on this bridge.";
 const MSG_PMS_DISABLED_FEDERATION = "[Bridge] Sorry, PMs are disabled on this bridge over federation.";
 
@@ -973,11 +954,6 @@ export class MatrixHandler {
         if (event.content.msgtype !== "m.text" || !text) {
             await this.ircBridge.sendIrcAction(ircRoom, ircClient, ircAction);
             return;
-        }
-
-        const potentialCodeText = trimCodeMessages(text);
-        if (potentialCodeText) {
-            ircAction.text = text = potentialCodeText;
         }
 
         let cacheBody = text;

--- a/src/bridge/MatrixHandler.ts
+++ b/src/bridge/MatrixHandler.ts
@@ -28,11 +28,11 @@ async function reqHandler(req: BridgeRequest, promise: PromiseLike<unknown>) {
  * This is used to allow small code snippets to look nice in IRC and not be
  * transformed into an upload.
  */
-function trimCodeMessages(text: string): string|void {
+function trimCodeMessages(text: string): string|undefined {
     let trimmedText = text.trim();
     // If this post isn't all code, ignore it.
     if (!/^```.*\n.*```$/s.test(trimmedText)) {
-        return;
+        return undefined;
     }
     // Remove the first line (e.g. ```js) and the ``` at the end
     trimmedText = trimmedText.substring(trimmedText.indexOf('\n'), trimmedText.length - 3).trim();
@@ -979,7 +979,7 @@ export class MatrixHandler {
         if (potentialCodeText) {
             ircAction.text = text = potentialCodeText;
         }
-        
+
         let cacheBody = text;
         if (event.content["m.relates_to"] && event.content["m.relates_to"]["m.in_reply_to"]) {
             const eventId = event.content["m.relates_to"]["m.in_reply_to"].event_id;

--- a/src/bridge/MatrixHandler.ts
+++ b/src/bridge/MatrixHandler.ts
@@ -964,10 +964,10 @@ export class MatrixHandler {
                 cacheBody = reply.reply;
             }
         }
-        let body = cacheBody.trim().substr(0, REPLY_SOURCE_MAX_LENGTH);
+        let body = cacheBody.trim().substring(0, REPLY_SOURCE_MAX_LENGTH);
         const nextNewLine = body.indexOf('\n');
         if (nextNewLine !== -1) {
-            body = cacheBody.substr(0, nextNewLine);
+            body = cacheBody.substring(0, nextNewLine);
         }
         this.eventCache.set(event.event_id, {
             body,
@@ -1164,7 +1164,7 @@ export class MatrixHandler {
                 else {
                     rplSource = eventContent.content.body;
                 }
-                rplSource = rplSource.substr(0, REPLY_SOURCE_MAX_LENGTH);
+                rplSource = rplSource.substring(0, REPLY_SOURCE_MAX_LENGTH);
                 this.eventCache.set(eventId, {sender: rplName, body: rplSource});
             }
             catch (err) {
@@ -1185,7 +1185,7 @@ export class MatrixHandler {
         const lines = rplSource.split('\n').filter((line) => !/^\s*$/.test(line))
         if (lines.length > 0) {
             // Cut to a maximum length.
-            rplSource = lines[0].substr(0, REPLY_SOURCE_MAX_LENGTH);
+            rplSource = lines[0].substring(0, REPLY_SOURCE_MAX_LENGTH);
             // Ellipsis if needed.
             if (lines[0].length > REPLY_SOURCE_MAX_LENGTH) {
                 rplSource = rplSource + "...";
@@ -1207,8 +1207,8 @@ export class MatrixHandler {
             // If we couldn't find a client for them, they might be a ghost.
             const ghostName = ircRoom.getServer().getNickFromUserId(rplName);
             // If we failed to get a name, just make a guess of it.
-            rplName = ghostName !== null ? ghostName : rplName.substr(1,
-                Math.min(REPLY_NAME_MAX_LENGTH, rplName.indexOf(":") - 1)
+            rplName = ghostName !== null ? ghostName : rplName.substring(1,
+                Math.min(REPLY_NAME_MAX_LENGTH + 1, rplName.indexOf(":") - 1)
             );
         }
 

--- a/src/bridge/MatrixHandler.ts
+++ b/src/bridge/MatrixHandler.ts
@@ -965,7 +965,7 @@ export class MatrixHandler {
             }
         }
         let body = cacheBody.trim().substring(0, REPLY_SOURCE_MAX_LENGTH);
-        const nextNewLine = body.indexOf('\n');
+        const nextNewLine = body.indexOf("\n");
         if (nextNewLine !== -1) {
             body = cacheBody.substring(0, nextNewLine);
         }

--- a/src/bridge/MatrixHandler.ts
+++ b/src/bridge/MatrixHandler.ts
@@ -1212,9 +1212,8 @@ export class MatrixHandler {
             );
         }
 
-        const RESET_CODE = '\u000f';
         return {
-            formatted: `<${rplName}${rplSource}${RESET_CODE}> ${rplText}`,
+            formatted: `<${rplName}${rplSource}> ${rplText}`,
             reply: rplText,
         };
     }

--- a/src/irc/BridgedClient.ts
+++ b/src/irc/BridgedClient.ts
@@ -734,7 +734,7 @@ export class BridgedClient extends EventEmitter {
                 if (throwOnInvalid) {
                     throw new Error(`Nick '${nick}' is too long. (Max: ${maxNickLen})`);
                 }
-                n = n.substr(0, maxNickLen);
+                n = n.substring(0, maxNickLen);
             }
         }
 

--- a/src/irc/IdentGenerator.ts
+++ b/src/irc/IdentGenerator.ts
@@ -245,7 +245,7 @@ export class IdentGenerator {
 
     private static modifyUsername(uname: string, suffix: number): { result: boolean; uname: string} {
         const suffixString = `${this.USER_NAME_DELIMITER}${suffix}`;
-        uname = `${uname.substr(0, this.MAX_USER_NAME_LENGTH - suffixString.length)}${suffixString}`;
+        uname = `${uname.substring(0, this.MAX_USER_NAME_LENGTH - suffixString.length)}${suffixString}`;
         return { result: suffix <= this.MAX_USER_NAME_SUFFIX, uname }; // break out if '~10000'
     }
 }

--- a/src/irc/formatting.ts
+++ b/src/irc/formatting.ts
@@ -341,9 +341,9 @@ export function markdownCodeToIrc(text: string): string|null {
         return null;
     }
     // Remove the first line (e.g. ```js) and the ``` at the end
-    trimmedText = trimmedText.substring(trimmedText.indexOf('\n'), trimmedText.length - 3);
+    trimmedText = trimmedText.substring(trimmedText.indexOf("\n"), trimmedText.length - 3);
     // Trim whitespaces but not indentation
-    trimmedText = trimmedText.replace(/^\s*?\n/, '').replace(/\s*$/, '');
+    trimmedText = trimmedText.replace(/^\s*?\n/, "").replace(/\s*$/, "");
     return trimmedText;
 }
 

--- a/src/irc/formatting.ts
+++ b/src/irc/formatting.ts
@@ -341,7 +341,9 @@ export function markdownCodeToIrc(text: string): string|null {
         return null;
     }
     // Remove the first line (e.g. ```js) and the ``` at the end
-    trimmedText = trimmedText.substring(trimmedText.indexOf('\n'), trimmedText.length - 3).trim();
+    trimmedText = trimmedText.substring(trimmedText.indexOf('\n'), trimmedText.length - 3);
+    // Trim whitespaces but not indentation
+    trimmedText = trimmedText.replace(/^\s*?\n/, '').replace(/\s*$/, '');
     return trimmedText;
 }
 

--- a/src/irc/formatting.ts
+++ b/src/irc/formatting.ts
@@ -329,6 +329,22 @@ export function ircToHtml(text: string): string {
     });
 }
 
+/**
+ * Returns a trimmed string if the input text is a Markdown-style code block.
+ * This is used to allow small code snippets to look nice in IRC and not be
+ * transformed into an upload.
+ */
+export function markdownCodeToIrc(text: string): string|null {
+    let trimmedText = text.trim();
+    // If this post isn't all code, ignore it.
+    if (!/^```.*\n.*```$/s.test(trimmedText)) {
+        return null;
+    }
+    // Remove the first line (e.g. ```js) and the ``` at the end
+    trimmedText = trimmedText.substring(trimmedText.indexOf('\n'), trimmedText.length - 3).trim();
+    return trimmedText;
+}
+
 export function toIrcLowerCase(str: string, caseMapping: "strict-rfc1459"|"rfc1459" = "rfc1459") {
     const lower = str.toLowerCase();
     if (caseMapping === "rfc1459") {

--- a/src/models/IrcAction.ts
+++ b/src/models/IrcAction.ts
@@ -42,8 +42,9 @@ export class IrcAction {
                     break;
                 }
                 if (matrixAction.htmlText) {
-                    const text = ircFormatting.htmlToIrc(matrixAction.htmlText);
-                    const ircText = text ?? matrixAction.text; // fallback if needed.
+                    const ircText = ircFormatting.htmlToIrc(matrixAction.htmlText)
+                        ?? ircFormatting.markdownCodeToIrc(matrixAction.text)
+                        ?? matrixAction.text; // fallback if needed.
                     if (ircText === null) {
                         throw Error("ircText is null");
                     }

--- a/src/models/MatrixAction.ts
+++ b/src/models/MatrixAction.ts
@@ -143,7 +143,7 @@ export class MatrixAction {
 
             if (identifier === undefined) {
                 // Fallback to userid.
-                identifier = userId.substr(1, userId.indexOf(":")-1)
+                identifier = userId.substring(1, userId.indexOf(":")-1)
             }
 
             const regex = MentionRegex(escapeStringRegexp(matchName));

--- a/src/models/MatrixAction.ts
+++ b/src/models/MatrixAction.ts
@@ -143,7 +143,7 @@ export class MatrixAction {
 
             if (identifier === undefined) {
                 // Fallback to userid.
-                identifier = userId.substring(1, userId.indexOf(":")-1)
+                identifier = userId.substring(1, userId.indexOf(":"));
             }
 
             const regex = MentionRegex(escapeStringRegexp(matchName));

--- a/src/workers/MetricsWorker.ts
+++ b/src/workers/MetricsWorker.ts
@@ -55,7 +55,7 @@ function workerThread() {
             const time = Date.now();
             intervalCounter.set(time - lastDumpTs);
             lastDumpTs = time;
-            const dump = msg.substr('metricsdump:'.length);
+            const dump = msg.substring('metricsdump:'.length);
             if (res.finished) {
                 // Sometimes a message will come in far too late because we've already
                 // sent an empty response. Drop it here.


### PR DESCRIPTION
Fixes #1271

Removes the code block syntax and [adds the monospace character `\x11` to the beginning of each line](https://modern.ircdocs.horse/formatting.html#monospace).

If the trimmed message is longer than the `lineLimit`, it still gets uploaded instead of posted directly.

![Screenshot_2021-03-26_13-30-13](https://user-images.githubusercontent.com/10872136/112632098-f6ce6900-8e37-11eb-8d95-05684068911a.png)
