### PR TITLE
Add config option to disable kicking Matrix users from rooms

### DIFF
--- a/changelog.d/1294.feature
+++ b/changelog.d/1294.feature
@@ -1,0 +1,1 @@
+Add new `kickOn` config option to disable kicking Matrix users under certain conditions

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -384,6 +384,12 @@ ircService:
         # Whilst the IRCd *should* be sending pings to us to keep the connection alive, it appears
         # that sometimes they don't get around to it and end up ping timing us out.
         # pingRateMs: 60000
+        # Choose 
+        kickOn:
+          channelJoinFailure: true
+          ircConnectionFailure: true
+          userQuit: true
+
 
   # Set information about the bridged channel in the room state, so that client's may
   # present relevant UI to the user. MSC2346

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -384,10 +384,15 @@ ircService:
         # Whilst the IRCd *should* be sending pings to us to keep the connection alive, it appears
         # that sometimes they don't get around to it and end up ping timing us out.
         # pingRateMs: 60000
-        # Choose 
+        # Choose which conditions the IRC bridge should kick Matrix users for. Decisions to this from
+        # defaults should be taken with care as it may dishonestly repesent Matrix users on the IRC
+        # network, and cause your bridge to be banned.
         kickOn:
+          # Kick a Matrix user from a bridged room if they fail to join the IRC channel.
           channelJoinFailure: true
+          # Kick a Matrix user from ALL rooms if they are unable to get connected to IRC.
           ircConnectionFailure: true
+          # Kick a Matrix user from ALL rooms if they choose to QUIT the IRC network.
           userQuit: true
 
 

--- a/config.schema.yml
+++ b/config.schema.yml
@@ -383,6 +383,15 @@ properties:
                                     type: "integer"
                                 pingRateMs:
                                     type: "integer"
+                                kickOn:
+                                    type: "object"
+                                    properties:
+                                        channelJoinFailure:
+                                            type: "boolean"
+                                        ircConnectionFailure:
+                                            type: "boolean"
+                                        userQuit:
+                                            type: "boolean"
                         excludeUsers:
                             type: "array"
                             properties:

--- a/src/irc/ClientPool.ts
+++ b/src/irc/ClientPool.ts
@@ -670,6 +670,9 @@ export class ClientPool {
         if (!userId || bridgedClient.isBot) {
             return; // the bot itself can get these join errors
         }
+        if (!bridgedClient.server.config.ircClients.kickOn.channelJoinFailure) {
+            return; // The bridge is configured not to kick on failure.
+        }
         // TODO: this is a bit evil, no one in their right mind would expect
         // the client pool to be kicking matrix users from a room :(
         log.info(`Kicking ${userId} from room due to ${err}`);

--- a/src/irc/IrcServer.ts
+++ b/src/irc/IrcServer.ts
@@ -96,6 +96,11 @@ export interface IrcServerConfig {
         realnameFormat?: "mxid"|"reverse-mxid";
         pingTimeoutMs: number;
         pingRateMs: number;
+        kickOn: {
+            channelJoinFailure: boolean;
+            ircConnectionFailure: boolean;
+            userQuit: boolean;
+        }
     };
     excludedUsers: Array<
         {
@@ -694,6 +699,11 @@ export class IrcServer {
                 lineLimit: 3,
                 pingTimeoutMs: 1000 * 60 * 10,
                 pingRateMs: 1000 * 60,
+                kickOn: {
+                    ircConnectionFailure: true,
+                    channelJoinFailure: true,
+                    userQuit: true
+                }
             },
             membershipLists: {
                 enabled: false,


### PR DESCRIPTION
This setting allows a bridge to selectively opt out of kicking Matrix users depending on the reason for the kick. This solves #1284 for self hosters, while matrix.org users will need to wait for us to release a per-channel config option.