### PR TITLE
Add !unlink command

### DIFF
--- a/changelog.d/1298.feature
+++ b/changelog.d/1298.feature
@@ -1,1 +1,1 @@
-Add !unlink command
+Added an !unlink command for Matrix users to unbridge two rooms

--- a/changelog.d/1298.feature
+++ b/changelog.d/1298.feature
@@ -1,0 +1,1 @@
+Add !unlink command

--- a/changelog.d/1298.feature
+++ b/changelog.d/1298.feature
@@ -1,1 +1,1 @@
-Added an !unlink command for Matrix users to unbridge two rooms
+Added an !unlink command for Matrix users to unbridge a channel from Matrix

--- a/docs/admin_room.md
+++ b/docs/admin_room.md
@@ -99,7 +99,7 @@ commands are reserved for bridge administrators, which can be configured in the 
 
 ### `!plumb`
 
-`!feature !room:example.com irc.network.net #channel`
+`!plumb !room:example.com irc.network.net #channel`
 
 *This command only works for bridge administrators*
 
@@ -108,6 +108,17 @@ validate that you have permission to do this on the IRC channel so please take c
 aware of your actions.
 
 You must invite the bridge bot into the Matrix room for this to work.
+
+
+### `!unlink`
+
+`!unlink !room:example.com irc.network.net #channel`
+
+*This command only works for moderators of a bridged Matrix room and bridge administrators*
+
+This command allows you to unlink a IRC channel from a room without using the HTTP provisioning API. For bridge
+administrators this command does NOT validate that you have permission to do this on the IRC channel so please
+take care to ensure that the IRC channel is aware of your actions.
 
 
 ### `!help`

--- a/docs/admin_room.md
+++ b/docs/admin_room.md
@@ -116,9 +116,7 @@ You must invite the bridge bot into the Matrix room for this to work.
 
 *This command only works for moderators of a bridged Matrix room and bridge administrators*
 
-This command allows you to unlink a IRC channel from a room without using the HTTP provisioning API. For bridge
-administrators this command does NOT validate that you have permission to do this on the IRC channel so please
-take care to ensure that the IRC channel is aware of your actions.
+This command allows you to unlink a IRC channel from a room. Users are only able to remove links for rooms they are a moderator in (power level of 50 or greater). Administrators of the bridge are able to remove links from any room.
 
 
 ### `!help`

--- a/src/bridge/AdminRoomHandler.ts
+++ b/src/bridge/AdminRoomHandler.ts
@@ -82,8 +82,7 @@ const COMMANDS: {[command: string]: {example: string; summary: string; requiresP
     },
     '!unlink': {
         example: `!unlink !room:example.com irc.example.net #foobar`,
-        summary: "Unlink an IRC channel from a Matrix room.",
-        requiresPermission: 'admin'
+        summary: "Unlink an IRC channel from a Matrix room. You need to be a Moderator of the Matrix room.",
     }
 };
 

--- a/src/bridge/AdminRoomHandler.ts
+++ b/src/bridge/AdminRoomHandler.ts
@@ -230,15 +230,6 @@ export class AdminRoomHandler {
         if (!ircChannel || !ircChannel.startsWith("#")) {
             return new MatrixAction("notice", "The channel name must start with a #");
         }
-        // Check if the room exists and the user is invited.
-        const intent = this.ircBridge.getAppServiceBridge().getIntent();
-        try {
-            await intent.getStateEvent(matrixRoomId, 'm.room.create');
-        }
-        catch (ex) {
-            log.error(`Could not join the target room of an !unlink command`, ex);
-            return new MatrixAction("notice", "Could not join the target room, you may need to invite the bot");
-        }
         try {
             await this.ircBridge.getProvisioner().unlink(
                 ProvisionRequest.createFake("adminCommand", log,

--- a/src/bridge/AdminRoomHandler.ts
+++ b/src/bridge/AdminRoomHandler.ts
@@ -81,8 +81,9 @@ const COMMANDS: {[command: string]: {example: string; summary: string; requiresP
         requiresPermission: 'admin'
     },
     '!unlink': {
-        example: `!unlink !room:example.com irc.example.net #foobar`,
-        summary: "Unlink an IRC channel from a Matrix room. You need to be a Moderator of the Matrix room.",
+        example: "!unlink !room:example.com irc.example.net #foobar",
+        summary: "Unlink an IRC channel from a Matrix room. " +
+                "You need to be a moderator of the Matrix room or an administrator of this bridge.",
     }
 };
 
@@ -243,13 +244,15 @@ export class AdminRoomHandler {
         }
         try {
             await this.ircBridge.getProvisioner().unlink(
-                ProvisionRequest.createFake("adminCommand", log),
-                {
-                    remote_room_server: serverDomain,
-                    remote_room_channel: ircChannel,
-                    matrix_room_id: matrixRoomId,
-                    user_id: sender,
-                },
+                ProvisionRequest.createFake("adminCommand", log,
+                    {
+                        remote_room_server: serverDomain,
+                        remote_room_channel: ircChannel,
+                        matrix_room_id: matrixRoomId,
+                        user_id: sender,
+                    },
+                ),
+                userPermission === 'admin'
             );
         }
         catch (ex) {

--- a/src/bridge/AdminRoomHandler.ts
+++ b/src/bridge/AdminRoomHandler.ts
@@ -222,9 +222,6 @@ export class AdminRoomHandler {
     }
 
     private async handleUnlink(args: string[], sender: string, userPermission: string | undefined) {
-        if (userPermission !== 'admin') {
-            return new MatrixAction("notice", "You must be an admin to use this command");
-        }
         const [matrixRoomId, serverDomain, ircChannel] = args;
         const server = serverDomain && this.ircBridge.getServer(serverDomain);
         if (!server) {
@@ -252,7 +249,7 @@ export class AdminRoomHandler {
                         user_id: sender,
                     },
                 ),
-                userPermission === 'admin'
+                userPermission === "admin"
             );
         }
         catch (ex) {

--- a/src/bridge/AdminRoomHandler.ts
+++ b/src/bridge/AdminRoomHandler.ts
@@ -238,7 +238,7 @@ export class AdminRoomHandler {
             await intent.getStateEvent(matrixRoomId, 'm.room.create');
         }
         catch (ex) {
-            log.error(`Could not join the target room of a !plumb command`, ex);
+            log.error(`Could not join the target room of an !unlink command`, ex);
             return new MatrixAction("notice", "Could not join the target room, you may need to invite the bot");
         }
         try {
@@ -253,10 +253,10 @@ export class AdminRoomHandler {
             );
         }
         catch (ex) {
-            log.error(`Failed to handle !plumb command:`, ex);
-            return new MatrixAction("notice", "Failed to plumb room. Check the logs for details.");
+            log.error(`Failed to handle !unlink command:`, ex);
+            return new MatrixAction("notice", "Failed to unlink room. Check the logs for details.");
         }
-        return new MatrixAction("notice", "Room plumbed.");
+        return new MatrixAction("notice", "Room unlinked.");
     }
 
     private async handleJoin(req: BridgeRequest, args: string[], server: IrcServer, sender: string) {

--- a/src/bridge/AdminRoomHandler.ts
+++ b/src/bridge/AdminRoomHandler.ts
@@ -167,6 +167,7 @@ export class AdminRoomHandler {
                 response = await this.handlePlumb(args, event.sender, userPermission)
                 break;
             case "!unlink":
+            case "!unplumb": // alias for convinience
                 response = await this.handleUnlink(args, event.sender, userPermission)
                 break;
             case "!help":

--- a/src/provisioning/ProvisionRequest.ts
+++ b/src/provisioning/ProvisionRequest.ts
@@ -18,7 +18,7 @@ export class ProvisionRequest {
         return this.req.params;
     }
 
-    public static createFake(fnName: string, log: RequestLogger, body: Record<string, unknown> = {}) {
+    public static createFake(fnName: string, log: RequestLogger, body: Record<string, string> = {}) {
         // This is a DANGEROUS operation, used to create a fake request object
         // to make internal requests to the provisioner.
         const r = new ProvisionRequest({

--- a/src/provisioning/ProvisionRequest.ts
+++ b/src/provisioning/ProvisionRequest.ts
@@ -1,12 +1,11 @@
 import logging, { RequestLogger, newRequestLogger } from "../logging";
 import crypto from "crypto";
-import { Request } from "express";
 const rootLogger = logging("ProvisionRequest");
 
 export class ProvisionRequest {
     private id: string;
     public log: RequestLogger;
-    constructor(private req: Request, fnName: string) {
+    constructor(private req: { body: Record<string, string>, params: Record<string, string> }, fnName: string) {
         this.id = crypto.randomBytes(4).toString('hex');
         this.log = newRequestLogger(rootLogger, `${this.id} ${fnName}`, false);
     }
@@ -19,11 +18,13 @@ export class ProvisionRequest {
         return this.req.params;
     }
 
-    public static createFake(fnName: string, log: RequestLogger) {
+    public static createFake(fnName: string, log: RequestLogger, body: Record<string, unknown> = {}) {
         // This is a DANGEROUS operation, used to create a fake request object
         // to make internal requests to the provisioner.
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const r = new ProvisionRequest(null as any, fnName);
+        const r = new ProvisionRequest({
+            body,
+            params: {},
+        }, fnName);
         r.log = log;
         return r;
     }

--- a/src/provisioning/Provisioner.ts
+++ b/src/provisioning/Provisioner.ts
@@ -844,8 +844,9 @@ export class Provisioner {
     }
 
     // Unlink an IRC channel from a matrix room ID
-    public async unlink(req: ProvisionRequest) {
-        const options = req.body;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    public async unlink(req: ProvisionRequest, optionsOverride?: any) {
+        const options = req.body || optionsOverride;
         try {
             this.unlinkValidator.validate(options);
         }

--- a/src/provisioning/Provisioner.ts
+++ b/src/provisioning/Provisioner.ts
@@ -850,7 +850,6 @@ export class Provisioner {
      * @param ignorePermissions If true, permissions are ignored (e.g. for bridge admins).
      * Otherwise, the user needs to be a Moderator in the Matrix room.
      */
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     public async unlink(req: ProvisionRequest, ignorePermissions = false) {
         const options = req.body;
         try {


### PR DESCRIPTION
The Matrix user needs to be in the Matrix room and have Moderator permissions for this to work.

This command is the inverse of #1211.