### PR TITLE
Docker image: Upgrade to NodeJS 14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Freebind build
-# node:12-slim uses debian:stretch-slim as a base, so it's safe to build on here.
+# node:14-slim uses debian:stretch-slim as a base, so it's safe to build on here.
 FROM debian:stretch-slim as freebind 
 
 RUN apt-get update \
@@ -9,7 +9,7 @@ RUN git clone https://github.com/matrix-org/freebindfree.git
 RUN cd freebindfree && make
 
 # Typescript build
-FROM node:12-slim as builder
+FROM node:14-slim as builder
 
 WORKDIR /build
 
@@ -22,7 +22,7 @@ RUN npm ci
 RUN npm run build
 
 # App
-FROM node:12-slim
+FROM node:14-slim
 
 RUN apt-get update && apt-get install -y sipcalc iproute2 openssl --no-install-recommends
 RUN rm -rf /var/lib/apt/lists/*

--- a/Dockerfile.README.md
+++ b/Dockerfile.README.md
@@ -1,6 +1,6 @@
 ## How to use the Dockerfile
 
-Ensure you have docker installed. The version this was tested
+Ensure you have Docker installed. The version this was tested
 with is `18.06.1-ce`.
 
 Create `./dockerdata`

--- a/changelog.d/1299.misc
+++ b/changelog.d/1299.misc
@@ -1,0 +1,1 @@
+Docker image: Upgrade to NodeJS 14

--- a/docs/bridge_setup.md
+++ b/docs/bridge_setup.md
@@ -4,11 +4,11 @@ This guide is written for server administrators who would like to set up their o
 
 ## Before setting up
 
-We recommend using Node.JS `v12` or greater when setting up the bridge, as we use `worker_threads` to handle 
+We recommend using Node.JS `v14` or greater when setting up the bridge, as we use `worker_threads` to handle 
 some of the traffic for larger bridges.
 
 If you wish to use Node.JS v10, you should enable the `--experimental-worker` on the commandline.
-Plase note that we offer no support for Node 10.
+Please note that we offer no support for Node 10.
 
 You should also ensure you have a recent Matrix homeserver that you have permission to bridge to. This can 
 either be your own, or one that you have the ability to setup Application Services with.


### PR DESCRIPTION
It's the current LTS.
https://nodejs.org/en/about/releases/

* Build and run the Docker images with NodeJS 14.
* Recommend running the bridge with NodeJS 14.
* Fix typo and lower case "docker"

Replaces #1249