### PR TITLE
Add support for setting the pastebin line limit in room state

### DIFF
--- a/changelog.d/1301.feature
+++ b/changelog.d/1301.feature
@@ -1,0 +1,1 @@
+Add support for specifying the paste bin limit in room state with the `org.matrix.appservice-irc.room-config` event type.

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -532,6 +532,16 @@ ircService:
   # 'matrix.org': admin
   # '@fibble:matrix.org': admin
 
+  # Allow room moderators to adjust the configuration of the bridge via room state.
+  # See docs/room_commands.md
+  # Optional: Off by default
+  perRoomConfig:
+    # Should the bridge use per-room configuration state. If false, the state
+    # events will be ignored.
+    enabled: false
+    # The maximum number that can be set for the `lineLimit` configuration option
+    # lineLimitMax: 5
+
 # Options here are generally only applicable to large-scale bridges and may have
 # consequences greater than other options in this configuration file.
 advanced:

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -4,6 +4,7 @@
 - [Usage](./usage.md)
   - [Admin Room](./admin_room.md)
   - [Room Commands](./room_commands.md)
+  - [Room Configuration](./room_configuration.md)
   - [IRC Modes](./irc_modes.md)
 - [Setup](./bridge_setup.md)
 - [Administrators Guide](./administrators_guide.md)

--- a/docs/room_configuration.md
+++ b/docs/room_configuration.md
@@ -1,0 +1,39 @@
+Room Configuration
+==================
+
+You can now configure certain options on a per-room basis from within your Matrix client. Currently
+this requires a bit of technical know-how as no clients expose an interface to changing the
+bridge configuration.
+
+## The `org.matrix.appservice-irc.config` event
+
+The bridge allows room moderators to create a state event in the room to change the way the bridge
+behaves in that room. 
+
+In Element you can modify the room state by:
+
+- Opening the room you wish to configure.
+- Typing `/devtools`.
+- Click Explore Room State.
+- Look for the `org.matrix.appservice-irc.config` event.
+- You should be able to click Edit to edit the content, and then hit Send to adjust the config.
+
+If an event does not exist yet, you can instead do:
+
+- Typing `/devtools`.
+- Click Send Custom Event.
+- Click the Event button to change the type to a **State Event**.
+- The event type must be `org.matrix.appservice-irc.config`
+- The state key can be left blank.
+- Entering the `Event Content` as described below.
+- You may now hit Send to apply the config.
+
+## Configuration Options
+
+### `lineLimit`
+
+Type: `number`
+
+This allows you to modify the minimum number of lines permitted in a room before the
+message is pastebinned. The setting is analogous to the `lineLimit` config option in
+the bridge config file.

--- a/docs/room_configuration.md
+++ b/docs/room_configuration.md
@@ -25,7 +25,7 @@ If an event does not exist yet, you can instead do:
 - Click the Event button to change the type to a **State Event**.
 - The event type must be `org.matrix.appservice-irc.config`
 - The state key can be left blank.
-- Entering the `Event Content` as described below.
+- Enter the `Event Content` as a JSON object. The schema is described in the following section.
 - You may now hit Send to apply the config.
 
 ## Configuration Options

--- a/src/bridge/IrcBridge.ts
+++ b/src/bridge/IrcBridge.ts
@@ -208,7 +208,7 @@ export class IrcBridge {
             homeserverToken,
             httpMaxSizeBytes: (this.config.advanced || { }).maxTxnSize || TXN_SIZE_DEFAULT,
         });
-        this.roomConfigs = new RoomConfig(this.bridge);
+        this.roomConfigs = new RoomConfig(this.bridge, this.config.ircService.perRoomConfig);
     }
 
     public async onConfigChanged(newConfig: BridgeConfig) {
@@ -238,6 +238,7 @@ export class IrcBridge {
         this.ircHandler.onConfigChanged(newConfig.ircHandler || {});
         this.config.ircHandler = newConfig.ircHandler;
         this.config.ircService.permissions = newConfig.ircService.permissions;
+        this.roomConfigs.config = newConfig.ircService.perRoomConfig;
 
         const hasLoggingChanged = JSON.stringify(oldConfig.ircService.logging)
             !== JSON.stringify(newConfig.ircService.logging);

--- a/src/bridge/IrcBridge.ts
+++ b/src/bridge/IrcBridge.ts
@@ -947,7 +947,7 @@ export class IrcBridge {
         }
         else if (event.type === RoomConfig.STATE_EVENT_TYPE && typeof event.state_key === 'string') {
             this.roomConfigs.invalidateConfig(event.room_id, event.state_key);
-        } 
+        }
         else if (event.type === "m.room.member" && event.state_key) {
             if (!event.content || !event.content.membership) {
                 return BridgeRequestErr.ERR_NOT_MAPPED;

--- a/src/bridge/MatrixHandler.ts
+++ b/src/bridge/MatrixHandler.ts
@@ -1031,7 +1031,8 @@ export class MatrixHandler {
 
         // Generate an array of individual messages that would be sent
         const potentialMessages = ircClient.getSplitMessages(ircRoom.channel, ircAction.text);
-        const lineLimit = ircRoom.server.getLineLimit();
+        const roomLineLimit = await this.ircBridge.roomConfigs.getLineLimit(event.room_id, ircRoom);
+        const lineLimit = roomLineLimit === null ? ircRoom.server.getLineLimit() : roomLineLimit;
 
         if (potentialMessages.length <= lineLimit) {
             await this.ircBridge.sendIrcAction(ircRoom, ircClient, ircAction);

--- a/src/bridge/RoomConfig.ts
+++ b/src/bridge/RoomConfig.ts
@@ -8,28 +8,52 @@ interface RoomConfigContent {
 }
 
 const MAX_CACHE_SIZE = 512;
+const STATE_TIMEOUT_MS = 2000;
 
 const log = getLogger("RoomConfig");
 export class RoomConfig {
-    public static readonly STATE_EVENT_TYPE = 'org.matrix.appservice-irc.room-config';
+    public static readonly STATE_EVENT_TYPE = 'org.matrix.appservice-irc.config';
     private cache = new QuickLRU<string, RoomConfigContent|undefined>({maxSize: MAX_CACHE_SIZE});
     constructor(private bridge: Bridge) { }
 
+    /**
+     * Fetch the state for the room, preferring a keyed state event over a global one.
+     * This request will time out after `STATE_TIMEOUT_MS` if the state could not be fetched in time.
+     * @param roomId The Matrix room ID
+     * @param ircRoom The IRC room we want the configuration for.
+     * @returns A content object containing the configuration, or null if the event was not found or the
+     *          request timed out.
+     */
     private async getRoomState(roomId: string, ircRoom?: IrcRoom): Promise<RoomConfigContent|null> {
         const cacheKey = `${roomId}:${ircRoom?.getId() || 'global'}`;
         let keyedConfig = this.cache.get(cacheKey);
         if (keyedConfig) {
             return keyedConfig;
         }
-        const intent = this.bridge.getIntent();
-        keyedConfig = ircRoom && await intent.getStateEvent(roomId, RoomConfig.STATE_EVENT_TYPE, ircRoom.getId(), true);
-        if (!keyedConfig) {
-            // Fall back to an empty key
-            keyedConfig = await intent.getStateEvent(roomId, RoomConfig.STATE_EVENT_TYPE, '', true);
+        const internalFunc = async () => {
+            const intent = this.bridge.getIntent();
+            keyedConfig = ircRoom &&
+                await intent.getStateEvent(roomId, RoomConfig.STATE_EVENT_TYPE, ircRoom.getId(), true);
+            if (!keyedConfig) {
+                // Fall back to an empty key
+                keyedConfig = await intent.getStateEvent(roomId, RoomConfig.STATE_EVENT_TYPE, '', true);
+            }
+            log.debug(
+                `Stored new config for ${cacheKey}: ${keyedConfig ? 'No config set' : JSON.stringify(keyedConfig)}`
+            );
+            this.cache.set(cacheKey, keyedConfig || undefined);
+            return keyedConfig as RoomConfigContent|null;
         }
-        log.debug(`Stored new config for ${cacheKey}:`, keyedConfig || 'No config set');
-        this.cache.set(cacheKey, keyedConfig || undefined);
-        return keyedConfig as RoomConfigContent|null;
+        // We don't want to spend too long trying to fetch the state, so return null.
+        return Promise.race([
+            internalFunc(),
+            new Promise<null>(res => setTimeout(() => res(null), STATE_TIMEOUT_MS)),
+        // We *never* want this function to throw, as it's critical for the bridging of messages.
+        // Instead we return null for any errors.
+        ]).catch(ex => {
+            log.warn(`Failed to fetch state for ${cacheKey}`, ex);
+            return null;
+        })
     }
 
     /**

--- a/src/bridge/RoomConfig.ts
+++ b/src/bridge/RoomConfig.ts
@@ -87,6 +87,6 @@ export class RoomConfig {
             // A missing line limit or an invalid one is considered invalid.
             return null;
         }
-        return roomState.lineLimit;
+        return Math.min(roomState.lineLimit, this.config?.lineLimitMax || roomState.lineLimit);
     }
 }

--- a/src/bridge/RoomConfig.ts
+++ b/src/bridge/RoomConfig.ts
@@ -1,0 +1,59 @@
+import { Bridge } from "matrix-appservice-bridge";
+import { IrcRoom } from "../models/IrcRoom";
+import QuickLRU from "quick-lru";
+import getLogger from "../logging";
+
+interface RoomConfigContent {
+    lineLimit?: number;
+}
+
+const MAX_CACHE_SIZE = 512;
+
+const log = getLogger("RoomConfig");
+export class RoomConfig {
+    public static readonly STATE_EVENT_TYPE = 'org.matrix.appservice-irc.room-config';
+    private cache = new QuickLRU<string, RoomConfigContent|undefined>({maxSize: MAX_CACHE_SIZE});
+    constructor(private bridge: Bridge) { }
+
+    private async getRoomState(roomId: string, ircRoom?: IrcRoom): Promise<RoomConfigContent|null> {
+        const cacheKey = `${roomId}:${ircRoom?.getId() || 'global'}`;
+        let keyedConfig = this.cache.get(cacheKey);
+        if (keyedConfig) {
+            return keyedConfig;
+        }
+        const intent = this.bridge.getIntent();
+        keyedConfig = ircRoom && await intent.getStateEvent(roomId, RoomConfig.STATE_EVENT_TYPE, ircRoom.getId(), true);
+        if (!keyedConfig) {
+            // Fall back to an empty key
+            keyedConfig = await intent.getStateEvent(roomId, RoomConfig.STATE_EVENT_TYPE, '', true);
+        }
+        log.debug(`Stored new config for ${cacheKey}:`, keyedConfig || 'No config set');
+        this.cache.set(cacheKey, keyedConfig || undefined);
+        return keyedConfig as RoomConfigContent|null;
+    }
+
+    /**
+     * Invalidate the cache for a room. Provide the key
+     * @param roomId The Matrix roomId
+     * @param stateKey The state event's key.
+     */
+    public invalidateConfig(roomId: string, stateKey = 'global') {
+        log.info(`Invalidating config for ${roomId}:${stateKey}`);
+        this.cache.delete(`${roomId}:${stateKey}`)
+    }
+
+    /**
+     * Get the per-room configuration for the paste bin limit for a room.
+     * @param roomId The Matrix roomId
+     * @param ircRoom The IRC roomId. Optional.
+     * @returns The number of lines required for a pastebin. `null` means no limit set in the room.
+     */
+    public async getLineLimit(roomId: string, ircRoom?: IrcRoom) {
+        const roomState = await this.getRoomState(roomId, ircRoom);
+        if (typeof roomState?.lineLimit !== 'number' || roomState.lineLimit > 0) {
+            // A missing line limit or an invalid one is considered invalid.
+            return null;
+        }
+        return roomState.lineLimit;
+    }
+}

--- a/src/bridge/RoomConfig.ts
+++ b/src/bridge/RoomConfig.ts
@@ -50,7 +50,7 @@ export class RoomConfig {
      */
     public async getLineLimit(roomId: string, ircRoom?: IrcRoom) {
         const roomState = await this.getRoomState(roomId, ircRoom);
-        if (typeof roomState?.lineLimit !== 'number' || roomState.lineLimit > 0) {
+        if (typeof roomState?.lineLimit !== 'number' || roomState.lineLimit <= 0) {
             // A missing line limit or an invalid one is considered invalid.
             return null;
         }

--- a/src/bridge/RoomConfig.ts
+++ b/src/bridge/RoomConfig.ts
@@ -66,7 +66,7 @@ export class RoomConfig {
     }
 
     /**
-     * Invalidate the cache for a room. Provide the key
+     * Invalidate the cache for a room.
      * @param roomId The Matrix roomId
      * @param stateKey The state event's key
      */

--- a/src/bridge/RoomConfig.ts
+++ b/src/bridge/RoomConfig.ts
@@ -56,7 +56,7 @@ export class RoomConfig {
         // We don't want to spend too long trying to fetch the state, so return null.
         return Promise.race([
             internalFunc(),
-            new Promise<null>(res => setTimeout(() => res(null), STATE_TIMEOUT_MS)),
+            new Promise<null>(res => setTimeout(res, STATE_TIMEOUT_MS)),
         // We *never* want this function to throw, as it's critical for the bridging of messages.
         // Instead we return null for any errors.
         ]).catch(ex => {
@@ -68,7 +68,7 @@ export class RoomConfig {
     /**
      * Invalidate the cache for a room. Provide the key
      * @param roomId The Matrix roomId
-     * @param stateKey The state event's key.
+     * @param stateKey The state event's key
      */
     public invalidateConfig(roomId: string, stateKey = 'global') {
         log.info(`Invalidating config for ${roomId}:${stateKey}`);
@@ -87,6 +87,6 @@ export class RoomConfig {
             // A missing line limit or an invalid one is considered invalid.
             return null;
         }
-        return Math.min(roomState.lineLimit, this.config?.lineLimitMax || roomState.lineLimit);
+        return Math.min(roomState.lineLimit, this.config?.lineLimitMax ?? roomState.lineLimit);
     }
 }

--- a/src/config/BridgeConfig.ts
+++ b/src/config/BridgeConfig.ts
@@ -1,6 +1,7 @@
 import { IrcServerConfig } from "../irc/IrcServer";
 import { LoggerConfig } from "../logging";
 import { IrcHandlerConfig } from "../bridge/IrcHandler";
+import { RoomConfigConfig } from "../bridge/RoomConfig";
 
 export interface BridgeConfig {
     matrixHandler: {
@@ -57,6 +58,7 @@ export interface BridgeConfig {
         permissions?: {
             [userIdOrDomain: string]: "admin";
         };
+        perRoomConfig?: RoomConfigConfig;
     };
     sentry?: {
         enabled: boolean;


### PR DESCRIPTION
This feature allows room admins to adjust the amount of lines required to end up in a pastebin by modifying the room state. This PR also paves the way for other features (like reply formats).

Fixed #1293  (accidentally)