### PR TITLE
Fix config.sample.yaml

### DIFF
--- a/changelog.d/1316.bugfix
+++ b/changelog.d/1316.bugfix
@@ -1,0 +1,1 @@
+Fix config.sample.yaml default value for the "permissions" field.

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -538,7 +538,7 @@ ircService:
   # options. Currently, you may either set the value to be 'admin', or leave the key
   # out to imply that the user does not have special permissions.
   # UserID takes precedence over domain, which takes precedence over wildcard.
-  permissions:
+  permissions: {}
   # '*': admin
   # 'matrix.org': admin
   # '@fibble:matrix.org': admin


### PR DESCRIPTION
The default permission value is incorrect: the schema does not allow a null value.

```
mai 15 13:17:50 robin node[21779]: {"field":"data.ircService.permissions","message":"is the wrong type","value":null,"type":"object","schemaPath":["properties","ircService","properties","permissions"]}
mai 15 13:17:50 robin node[21779]: The field data.ircService.permissions is null which is the wrong type
mai 15 13:17:50 robin node[21779]: /home/bridge/matrix-appservice-irc/node_modules/matrix-appservice-bridge/lib/components/config-validator.js:77
mai 15 13:17:50 robin node[21779]:             throw e;
mai 15 13:17:50 robin node[21779]:             ^
mai 15 13:17:50 robin node[21779]: Error: Failed to validate file
mai 15 13:17:50 robin node[21779]:     at ConfigValidator.validate (/home/bridge/matrix-appservice-irc/node_modules/matrix-appservice-bridge/lib/components/config-validator.js:75:23)
mai 15 13:17:50 robin node[21779]:     at Cli.loadConfig (/home/bridge/matrix-appservice-irc/node_modules/matrix-appservice-bridge/lib/components/cli.js:207:26)
mai 15 13:17:50 robin node[21779]:     at Cli.assignConfigFile (/home/bridge/matrix-appservice-irc/node_modules/matrix-appservice-bridge/lib/components/cli.js:187:29)
mai 15 13:17:50 robin node[21779]:     at Cli.run (/home/bridge/matrix-appservice-irc/node_modules/matrix-appservice-bridge/lib/components/cli.js:179:14)
mai 15 13:17:50 robin node[21779]:     at Object.<anonymous> (/home/bridge/matrix-appservice-irc/app.js:78:4)
mai 15 13:17:50 robin systemd[1]: matrix-appservice-irc.service: Main process exited, code=exited, status=1/FAILUR
```