### PR TITLE
Add support for setting a username for users

### DIFF
--- a/changelog.d/1331.feature
+++ b/changelog.d/1331.feature
@@ -1,0 +1,1 @@
+Add support for setting a username, and reconnecting through the admin room. This change also changes `!storepass` to no longer reconnect you by default.

--- a/package-lock.json
+++ b/package-lock.json
@@ -2336,9 +2336,9 @@
       }
     },
     "iconv-lite": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.2.tgz",
-      "integrity": "sha512-2y91h5OpQlolefMPmUlivelittSWy0rP+oYVpn6A7GwVHNE8AWzoYOBNmlwks3LobaJxgHCYZAnyNo2GgpNRNQ==",
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       }
@@ -3038,9 +3038,9 @@
       }
     },
     "matrix-org-irc": {
-      "version": "1.0.0-alpha1",
-      "resolved": "https://registry.npmjs.org/matrix-org-irc/-/matrix-org-irc-1.0.0-alpha1.tgz",
-      "integrity": "sha512-oJ17FAKiI+JtKCF2YOFGV2XVlgaclv13gEpyjJbCa9HqPOcbFPBnT9l59G+FERovmJx8lkf8MUjyIUfSO7vzeg==",
+      "version": "1.0.0-alpha2",
+      "resolved": "https://registry.npmjs.org/matrix-org-irc/-/matrix-org-irc-1.0.0-alpha2.tgz",
+      "integrity": "sha512-3GnmfOIA6LUvrmIycShPBv2ID3/myAkt2Gr6gt4CW/QiL2fbV+mVmE+2d82ok1nxijTIYWadWwB+WB07RH2cyA==",
       "requires": {
         "chardet": "^1.3.0",
         "iconv-lite": "^0.6.2",

--- a/package.json
+++ b/package.json
@@ -10,10 +10,10 @@
   "scripts": {
     "prepare": "npm run build",
     "build": "tsc --project ./tsconfig.json",
-    "test": "BLUEBIRD_DEBUG=1 node --max_old_space_size=3072 jasmine --stop-on-failure=true",
+    "test": "BLUEBIRD_DEBUG=1 jasmine --stop-on-failure=true",
     "lint": "eslint -c .eslintrc --max-warnings 4 'src/**/*.ts'",
     "check": "npm test && npm run lint",
-    "ci-test": "node --max_old_space_size=3072 node_modules/nyc/bin/nyc.js --report text jasmine",
+    "ci-test": "nyc --report text jasmine",
     "ci": "npm run lint && npm run ci-test"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "prepare": "npm run build",
     "build": "tsc --project ./tsconfig.json",
-    "test": "BLUEBIRD_DEBUG=1 node --max_old_space_size=3072 node_modules/jasmine/bin/jasmine.js --stop-on-failure=true",
+    "test": "BLUEBIRD_DEBUG=1 node --max_old_space_size=3072 jasmine --stop-on-failure=true",
     "lint": "eslint -c .eslintrc --max-warnings 4 'src/**/*.ts'",
     "check": "npm test && npm run lint",
     "ci-test": "node --max_old_space_size=3072 node_modules/nyc/bin/nyc.js --report text jasmine",
@@ -31,7 +31,7 @@
     "escape-string-regexp": "^2.0.0",
     "extend": "^2.0.0",
     "he": "^1.1.1",
-    "matrix-org-irc": "1.0.0-alpha1",
+    "matrix-org-irc": "1.0.0-alpha2",
     "js-yaml": "^3.14.0",
     "logform": "^2.2.0",
     "matrix-appservice": "^0.8.0",

--- a/spec/integ/admin-rooms.spec.js
+++ b/spec/integ/admin-rooms.spec.js
@@ -22,61 +22,61 @@ describe("Creating admin rooms", function() {
     }));
 
     it("should be possible by sending an invite to the bot's user ID",
-    test.coroutine(function*() {
-        let botJoinedRoom = false;
-        let sdk = env.clientMock._client(botUserId);
-        sdk.joinRoom.and.callFake(function(roomId) {
-            expect(roomId).toEqual("!adminroomid:here");
-            botJoinedRoom = true;
-            return Promise.resolve({});
-        });
+        test.coroutine(function*() {
+            let botJoinedRoom = false;
+            let sdk = env.clientMock._client(botUserId);
+            sdk.joinRoom.and.callFake(function(roomId) {
+                expect(roomId).toEqual("!adminroomid:here");
+                botJoinedRoom = true;
+                return Promise.resolve({});
+            });
 
-        yield env.mockAppService._trigger("type:m.room.member", {
-            content: {
-                membership: "invite",
-                is_direct: true,
-            },
-            state_key: botUserId,
-            user_id: "@someone:somewhere",
-            room_id: "!adminroomid:here",
-            type: "m.room.member"
-        });
-        expect(botJoinedRoom).toBe(true);
-    }));
+            yield env.mockAppService._trigger("type:m.room.member", {
+                content: {
+                    membership: "invite",
+                    is_direct: true,
+                },
+                state_key: botUserId,
+                sender: "@someone:somewhere",
+                room_id: "!adminroomid:here",
+                type: "m.room.member"
+            });
+            expect(botJoinedRoom).toBe(true);
+        }));
 
     it("should not create a room for a non is_direct invite",
-    test.coroutine(function*() {
-        let botJoinedRoom = false;
-        let sdk = env.clientMock._client(botUserId);
-        sdk.joinRoom.and.callFake(function(roomId) {
-            expect(roomId).toEqual("!adminroomid:here");
-            botJoinedRoom = true;
-            return Promise.resolve({});
-        });
+        test.coroutine(function*() {
+            let botJoinedRoom = false;
+            let sdk = env.clientMock._client(botUserId);
+            sdk.joinRoom.and.callFake(function(roomId) {
+                expect(roomId).toEqual("!adminroomid:here");
+                botJoinedRoom = true;
+                return Promise.resolve({});
+            });
 
-        yield env.mockAppService._trigger("type:m.room.member", {
-            content: {
-                membership: "invite",
-            },
-            state_key: botUserId,
-            user_id: "@someone:somewhere",
-            room_id: "!adminroomid:here",
-            type: "m.room.member"
-        });
+            yield env.mockAppService._trigger("type:m.room.member", {
+                content: {
+                    membership: "invite",
+                },
+                state_key: botUserId,
+                sender: "@someone:somewhere",
+                room_id: "!adminroomid:here",
+                type: "m.room.member"
+            });
 
-        yield env.mockAppService._trigger("type:m.room.member", {
-            content: {
-                membership: "invite",
-                is_direct: false,
-            },
-            state_key: botUserId,
-            user_id: "@someone:somewhere",
-            room_id: "!adminroomid:here",
-            type: "m.room.member"
-        });
+            yield env.mockAppService._trigger("type:m.room.member", {
+                content: {
+                    membership: "invite",
+                    is_direct: false,
+                },
+                state_key: botUserId,
+                sender: "@someone:somewhere",
+                room_id: "!adminroomid:here",
+                type: "m.room.member"
+            });
 
-        expect(botJoinedRoom).toBe(false);
-    }));
+            expect(botJoinedRoom).toBe(false);
+        }));
 });
 
 describe("Admin rooms", function() {
@@ -137,7 +137,7 @@ describe("Admin rooms", function() {
                     is_direct: true
                 },
                 state_key: botUserId,
-                user_id: userId,
+                sender: userId,
                 room_id: adminRoomId,
                 type: "m.room.member"
             });
@@ -148,7 +148,7 @@ describe("Admin rooms", function() {
                     body: "ping",
                     msgtype: "m.text"
                 },
-                user_id: userId,
+                sender: userId,
                 room_id: roomMapping.roomId,
                 type: "m.room.message"
             });
@@ -161,73 +161,73 @@ describe("Admin rooms", function() {
     }));
 
     it("should respond to bad !nick commands with a help notice",
-    test.coroutine(function*() {
-        let sentNotice = false;
-        let sdk = env.clientMock._client(botUserId);
-        sdk.sendEvent.and.callFake(function(roomId, type, content) {
-            expect(roomId).toEqual(adminRoomId);
-            expect(content.msgtype).toEqual("m.notice");
-            sentNotice = true;
-            return Promise.resolve();
-        });
+        test.coroutine(function*() {
+            let sentNotice = false;
+            let sdk = env.clientMock._client(botUserId);
+            sdk.sendEvent.and.callFake(function(roomId, type, content) {
+                expect(roomId).toEqual(adminRoomId);
+                expect(content.msgtype).toEqual("m.notice");
+                sentNotice = true;
+                return Promise.resolve();
+            });
 
-        yield env.mockAppService._trigger("type:m.room.message", {
-            content: {
-                body: "!nick blargle wargle",
-                msgtype: "m.text"
-            },
-            user_id: userId,
-            room_id: adminRoomId,
-            type: "m.room.message"
-        });
-        expect(sentNotice).toBe(true);
-    }));
+            yield env.mockAppService._trigger("type:m.room.message", {
+                content: {
+                    body: "!nick blargle wargle",
+                    msgtype: "m.text"
+                },
+                sender: userId,
+                room_id: adminRoomId,
+                type: "m.room.message"
+            });
+            expect(sentNotice).toBe(true);
+        }));
 
     it("should respond to bad !join commands with a help notice",
-    test.coroutine(function*() {
-        let sentNotice = false;
-        let sdk = env.clientMock._client(botUserId);
-        sdk.sendEvent.and.callFake(function(roomId, type, content) {
-            expect(roomId).toEqual(adminRoomId);
-            expect(content.msgtype).toEqual("m.notice");
-            sentNotice = true;
-            return Promise.resolve();
-        });
+        test.coroutine(function*() {
+            let sentNotice = false;
+            let sdk = env.clientMock._client(botUserId);
+            sdk.sendEvent.and.callFake(function(roomId, type, content) {
+                expect(roomId).toEqual(adminRoomId);
+                expect(content.msgtype).toEqual("m.notice");
+                sentNotice = true;
+                return Promise.resolve();
+            });
 
-        yield env.mockAppService._trigger("type:m.room.message", {
-            content: {
-                body: "!join blargle",
-                msgtype: "m.text"
-            },
-            user_id: userId,
-            room_id: adminRoomId,
-            type: "m.room.message"
-        })
-        expect(sentNotice).toBe(true);
-    }));
+            yield env.mockAppService._trigger("type:m.room.message", {
+                content: {
+                    body: "!join blargle",
+                    msgtype: "m.text"
+                },
+                sender: userId,
+                room_id: adminRoomId,
+                type: "m.room.message"
+            })
+            expect(sentNotice).toBe(true);
+        }));
 
     it("should respond to unknown commands with a notice",
-    test.coroutine(function*() {
-        let sentNotice = false;
-        let sdk = env.clientMock._client(botUserId);
-        sdk.sendEvent.and.callFake(function(roomId, type, content) {
-            expect(roomId).toEqual(adminRoomId);
-            expect(content.msgtype).toEqual("m.notice");
-            sentNotice = true;
-            return Promise.resolve();
-        });
+        test.coroutine(function*() {
+            let sentNotice = false;
+            let sdk = env.clientMock._client(botUserId);
+            sdk.sendEvent.and.callFake(function(roomId, type, content) {
+                expect(roomId).toEqual(adminRoomId);
+                expect(content.msgtype).toEqual("m.notice");
+                sentNotice = true;
+                return Promise.resolve();
+            });
 
-        yield env.mockAppService._trigger("type:m.room.message", {
-            content: {
-                body: "notacommand",
-                msgtype: "m.text"
-            },
-            user_id: userId,
-            room_id: adminRoomId,
-            type: "m.room.message"
-        })
-        expect(sentNotice).toBe(true);
-    }));
+            yield env.mockAppService._trigger("type:m.room.message", {
+                content: {
+                    body: "notacommand",
+                    msgtype: "m.text"
+                },
+                sender: userId,
+                room_id: adminRoomId,
+                type: "m.room.message"
+            })
+            expect(sentNotice).toBe(true);
+        }));
 
     it("should ignore messages sent by the bot", test.coroutine(function*() {
         yield env.mockAppService._trigger("type:m.room.message", {
@@ -235,88 +235,88 @@ describe("Admin rooms", function() {
                 body: "!join blargle",
                 msgtype: "m.text"
             },
-            user_id: botUserId,
+            sender: botUserId,
             room_id: adminRoomId,
             type: "m.room.message"
         });
     }));
 
     it("should be able to change their nick using !nick",
-    test.coroutine(function*() {
-        let newNick = "Blurple";
-        let testText = "I don't know what colour I am.";
+        test.coroutine(function*() {
+            let newNick = "Blurple";
+            let testText = "I don't know what colour I am.";
 
-        // make sure that the nick command is sent
-        let sentNickCommand = false;
-        env.ircMock._whenClient(roomMapping.server, userIdNick, "send",
-        function(client, command, arg) {
-            expect(client.nick).toEqual(userIdNick, "use the old nick on /nick");
-            expect(client.addr).toEqual(roomMapping.server);
-            expect(command).toEqual("NICK");
-            expect(arg).toEqual(newNick);
-            client._changeNick(userIdNick, newNick);
-            sentNickCommand = true;
-        });
+            // make sure that the nick command is sent
+            let sentNickCommand = false;
+            env.ircMock._whenClient(roomMapping.server, userIdNick, "send",
+                function(client, command, arg) {
+                    expect(client.nick).toEqual(userIdNick, "use the old nick on /nick");
+                    expect(client.addr).toEqual(roomMapping.server);
+                    expect(command).toEqual("NICK");
+                    expect(arg).toEqual(newNick);
+                    client._changeNick(userIdNick, newNick);
+                    sentNickCommand = true;
+                });
 
-        env.ircMock._whenClient(roomMapping.server, userIdNick, "whois", (client, whoisNick) => {
-            expect(whoisNick).toEqual(newNick);
-            client.emit("error", {
-                commandType: "error",
-                command: "err_nosuchnick",
-                args: [undefined, newNick]
+            env.ircMock._whenClient(roomMapping.server, userIdNick, "whois", (client, whoisNick) => {
+                expect(whoisNick).toEqual(newNick);
+                client.emit("error", {
+                    commandType: "error",
+                    command: "err_nosuchnick",
+                    args: [undefined, newNick]
+                });
             });
-        });
 
-        // make sure that when a message is sent it uses the new nick
-        let sentSay = false;
-        env.ircMock._whenClient(roomMapping.server, newNick, "say",
-        function(client, channel, text) {
-            expect(client.nick).toEqual(newNick, "use the new nick on /say");
-            expect(client.addr).toEqual(roomMapping.server);
-            expect(channel).toEqual(roomMapping.channel);
-            expect(text.length).toEqual(testText.length);
-            expect(text).toEqual(testText);
-            sentSay = true;
-        });
+            // make sure that when a message is sent it uses the new nick
+            let sentSay = false;
+            env.ircMock._whenClient(roomMapping.server, newNick, "say",
+                function(client, channel, text) {
+                    expect(client.nick).toEqual(newNick, "use the new nick on /say");
+                    expect(client.addr).toEqual(roomMapping.server);
+                    expect(channel).toEqual(roomMapping.channel);
+                    expect(text.length).toEqual(testText.length);
+                    expect(text).toEqual(testText);
+                    sentSay = true;
+                });
 
-        // make sure the AS sends an ACK of the request as a notice in the admin
-        // room
-        let sentAckNotice = false;
-        let sdk = env.clientMock._client(botUserId);
-        sdk.sendEvent.and.callFake(function(roomId, type, content) {
-            expect(roomId).toEqual(adminRoomId);
-            expect(content.msgtype).toEqual("m.notice");
-            expect(content.body).toEqual(`Nick changed from '${userIdNick}' to '${newNick}'.`);
-            sentAckNotice = true;
-            return Promise.resolve();
-        });
+            // make sure the AS sends an ACK of the request as a notice in the admin
+            // room
+            let sentAckNotice = false;
+            let sdk = env.clientMock._client(botUserId);
+            sdk.sendEvent.and.callFake(function(roomId, type, content) {
+                expect(roomId).toEqual(adminRoomId);
+                expect(content.msgtype).toEqual("m.notice");
+                expect(content.body).toEqual(`Nick changed from '${userIdNick}' to '${newNick}'.`);
+                sentAckNotice = true;
+                return Promise.resolve();
+            });
 
-        // trigger the request to change the nick
-        yield env.mockAppService._trigger("type:m.room.message", {
-            content: {
-                body: "!nick " + roomMapping.server + " " + newNick,
-                msgtype: "m.text"
-            },
-            user_id: userId,
-            room_id: adminRoomId,
-            type: "m.room.message"
-        });
-        // trigger the message which should use the new nick
-        yield env.mockAppService._trigger("type:m.room.message", {
-            content: {
-                body: testText,
-                msgtype: "m.text"
-            },
-            user_id: userId,
-            room_id: roomMapping.roomId,
-            type: "m.room.message"
-        });
+            // trigger the request to change the nick
+            yield env.mockAppService._trigger("type:m.room.message", {
+                content: {
+                    body: "!nick " + roomMapping.server + " " + newNick,
+                    msgtype: "m.text"
+                },
+                sender: userId,
+                room_id: adminRoomId,
+                type: "m.room.message"
+            });
+            // trigger the message which should use the new nick
+            yield env.mockAppService._trigger("type:m.room.message", {
+                content: {
+                    body: testText,
+                    msgtype: "m.text"
+                },
+                sender: userId,
+                room_id: roomMapping.roomId,
+                type: "m.room.message"
+            });
 
-        // make sure everything was called
-        expect(sentNickCommand).toBe(true, "sent nick IRC command");
-        expect(sentAckNotice).toBe(true, "sent ACK m.notice");
-        expect(sentSay).toBe(true, "sent say IRC command");
-    }));
+            // make sure everything was called
+            expect(sentNickCommand).toBe(true, "sent nick IRC command");
+            expect(sentAckNotice).toBe(true, "sent ACK m.notice");
+            expect(sentSay).toBe(true, "sent say IRC command");
+        }));
 
     it("should be able to keep their name using !nick",
         test.coroutine(function* () {
@@ -367,7 +367,7 @@ describe("Admin rooms", function() {
                     body: `!nick ${roomMapping.server} ${newNick}`,
                     msgtype: "m.text"
                 },
-                user_id: userId,
+                sender: userId,
                 room_id: adminRoomId,
                 type: "m.room.message"
             });
@@ -377,7 +377,7 @@ describe("Admin rooms", function() {
                     body: testText,
                     msgtype: "m.text"
                 },
-                user_id: userId,
+                sender: userId,
                 room_id: roomMapping.roomId,
                 type: "m.room.message"
             });
@@ -387,103 +387,20 @@ describe("Admin rooms", function() {
             expect(sentAckNotice).toBe(true, "sent ACK m.notice");
             expect(sentSay).toBe(true, "sent say IRC command");
         }
-    ));
+        ));
 
     it("should be able to change their nick using !nick and have it persist across disconnects",
-    test.coroutine(function*() {
-        let newNick = "Blurple";
-        let testText = "I don't know what colour I am.";
-        // we will be disconnecting the user so we want to accept incoming connects/joins
-        // as the new nick.
-        env.ircMock._autoConnectNetworks(
-            roomMapping.server, newNick, roomMapping.server
-        );
-        env.ircMock._autoJoinChannels(
-            roomMapping.server, newNick, roomMapping.channel
-        );
-
-        // make sure that the nick command is sent
-        let sentNickCommand = false;
-        env.ircMock._whenClient(roomMapping.server, userIdNick, "send",
-        function(client, command, arg) {
-            expect(client.nick).toEqual(userIdNick, "use the old nick on /nick");
-            expect(client.addr).toEqual(roomMapping.server);
-            expect(command).toEqual("NICK");
-            expect(arg).toEqual(newNick);
-            client._changeNick(userIdNick, newNick);
-            sentNickCommand = true;
-        });
-
-        env.ircMock._whenClient(roomMapping.server, userIdNick, "whois", (client, whoisNick) => {
-            expect(whoisNick).toEqual(newNick);
-            client.emit("error", {
-                commandType: "error",
-                command: "err_nosuchnick",
-                args: [undefined, newNick]
-            });
-        });
-
-        // make sure that when a message is sent it uses the new nick
-        let sentSay = false;
-        env.ircMock._whenClient(roomMapping.server, newNick, "say",
-        function(client, channel, text) {
-            expect(client.nick).toEqual(newNick, "use the new nick on /say");
-            expect(client.addr).toEqual(roomMapping.server);
-            expect(channel).toEqual(roomMapping.channel);
-            expect(text.length).toEqual(testText.length);
-            expect(text).toEqual(testText);
-            sentSay = true;
-        });
-
-        // make sure the AS sends an ACK of the request as a notice in the admin
-        // room
-        let sdk = env.clientMock._client(botUserId);
-        sdk.sendEvent.and.callFake(function(roomId, type, content) {
-            return Promise.resolve();
-        });
-
-        // trigger the request to change the nick
-        yield env.mockAppService._trigger("type:m.room.message", {
-            content: {
-                body: "!nick " + roomMapping.server + " " + newNick,
-                msgtype: "m.text"
-            },
-            user_id: userId,
-            room_id: adminRoomId,
-            type: "m.room.message"
-        });
-
-        // disconnect the user
-        let cli = yield env.ircMock._findClientAsync(roomMapping.server, newNick);
-        cli.emit("error", {command: "err_testsezno"});
-
-        // wait a bit for reconnect timers
-        setImmediate(function() {
-            jasmine.clock().tick(1000 * 11);
-        });
-
-
-        // trigger the message which should use the new nick
-        yield env.mockAppService._trigger("type:m.room.message", {
-            content: {
-                body: testText,
-                msgtype: "m.text"
-            },
-            user_id: userId,
-            room_id: roomMapping.roomId,
-            type: "m.room.message"
-        });
-
-        // make sure everything was called
-        expect(sentNickCommand).toBe(true, "Client did not send nick IRC command");
-        expect(sentSay).toBe(true, "Client did not send message as new nick");
-    }));
-
-    it("should be able to change their nick using !nick and have it persist " +
-        "when changing the display name",
         test.coroutine(function*() {
             let newNick = "Blurple";
-            let displayName = "Durple";
+            let testText = "I don't know what colour I am.";
+            // we will be disconnecting the user so we want to accept incoming connects/joins
+            // as the new nick.
+            env.ircMock._autoConnectNetworks(
+                roomMapping.server, newNick, roomMapping.server
+            );
+            env.ircMock._autoJoinChannels(
+                roomMapping.server, newNick, roomMapping.channel
+            );
 
             // make sure that the nick command is sent
             let sentNickCommand = false;
@@ -506,12 +423,24 @@ describe("Admin rooms", function() {
                 });
             });
 
-            // make sure that a display name change is not propagated
-            let sentNick = false;
-            env.ircMock._whenClient(roomMapping.server, newNick, "send",
+            // make sure that when a message is sent it uses the new nick
+            let sentSay = false;
+            env.ircMock._whenClient(roomMapping.server, newNick, "say",
                 function(client, channel, text) {
-                    sentNick = true;
+                    expect(client.nick).toEqual(newNick, "use the new nick on /say");
+                    expect(client.addr).toEqual(roomMapping.server);
+                    expect(channel).toEqual(roomMapping.channel);
+                    expect(text.length).toEqual(testText.length);
+                    expect(text).toEqual(testText);
+                    sentSay = true;
                 });
+
+            // make sure the AS sends an ACK of the request as a notice in the admin
+            // room
+            let sdk = env.clientMock._client(botUserId);
+            sdk.sendEvent.and.callFake(function(roomId, type, content) {
+                return Promise.resolve();
+            });
 
             // trigger the request to change the nick
             yield env.mockAppService._trigger("type:m.room.message", {
@@ -519,39 +448,42 @@ describe("Admin rooms", function() {
                     body: "!nick " + roomMapping.server + " " + newNick,
                     msgtype: "m.text"
                 },
-                user_id: userId,
+                sender: userId,
                 room_id: adminRoomId,
                 type: "m.room.message"
             });
 
-            // trigger a display name change
-            yield env.mockAppService._trigger("type:m.room.member", {
+            // disconnect the user
+            let cli = yield env.ircMock._findClientAsync(roomMapping.server, newNick);
+            cli.emit("error", {command: "err_testsezno"});
+
+            // wait a bit for reconnect timers
+            setImmediate(function() {
+                jasmine.clock().tick(1000 * 11);
+            });
+
+
+            // trigger the message which should use the new nick
+            yield env.mockAppService._trigger("type:m.room.message", {
                 content: {
-                    membership: "join",
-                    avatar_url: null,
-                    displayname: displayName
+                    body: testText,
+                    msgtype: "m.text"
                 },
-                state_key: userId,
-                user_id: userId,
+                sender: userId,
                 room_id: roomMapping.roomId,
-                type: "m.room.member",
+                type: "m.room.message"
             });
 
             // make sure everything was called
-            expect(sentNickCommand).toBe(true, "sent nick IRC command");
-            expect(sentNick).toBe(false, "sent nick IRC command on displayname change");
+            expect(sentNickCommand).toBe(true, "Client did not send nick IRC command");
+            expect(sentSay).toBe(true, "Client did not send message as new nick");
         }));
 
-    it("should propagate a display name change as a nick change when no custom nick is set",
+    it("should be able to change their nick using !nick and have it persist " +
+        "when changing the display name",
     test.coroutine(function*() {
-        const newNick = "Blurple";
-
-        const sdk = env.clientMock._client(botUserId);
-        sdk.getProfileInfo.and.callFake(async (reqUserId, type) => {
-            expect(reqUserId).toEqual(userId);
-            expect(type).toEqual("displayname");
-            return {displayname: newNick};
-        });
+        let newNick = "Blurple";
+        let displayName = "Durple";
 
         // make sure that the nick command is sent
         let sentNickCommand = false;
@@ -560,55 +492,10 @@ describe("Admin rooms", function() {
                 expect(client.nick).toEqual(userIdNick, "use the old nick on /nick");
                 expect(client.addr).toEqual(roomMapping.server);
                 expect(command).toEqual("NICK");
-                expect(arg).toEqual('M-' + newNick);
+                expect(arg).toEqual(newNick);
+                client._changeNick(userIdNick, newNick);
                 sentNickCommand = true;
             });
-
-        env.ircMock._whenClient(roomMapping.server, userIdNick, "whois", (client, whoisNick) => {
-            expect(whoisNick).toEqual('M-' + newNick);
-            client.emit("error", {
-                commandType: "error",
-                command: "err_nosuchnick",
-                args: [undefined, 'M-' + newNick]
-            });
-        });
-    
-        // trigger a display name change
-        yield env.mockAppService._trigger("type:m.room.member", {
-            content: {
-                membership: "join",
-                avatar_url: null,
-                displayname: newNick
-            },
-            state_key: userId,
-            user_id: userId,
-            room_id: roomMapping.roomId,
-            type: "m.room.member",
-        });
-
-        // make sure everything was called
-        expect(sentNickCommand).toBe(true, "sent nick IRC command");
-    }));
-
-    it("should reject !nick changes for IRC errors",
-    test.coroutine(function*() {
-        let newNick = "Blurple";
-        let testText = "I don't know what colour I am.";
-
-        // make sure that the nick command is sent
-        let sentNickCommand = false;
-        env.ircMock._whenClient(roomMapping.server, userIdNick, "send",
-        function(client, command, arg) {
-            expect(client.nick).toEqual(userIdNick, "use the old nick on /nick");
-            expect(client.addr).toEqual(roomMapping.server);
-            expect(command).toEqual("NICK");
-            expect(arg).toEqual(newNick);
-            client.emit("error", {
-                commandType: "error",
-                command: "err_nicktoofast"
-            })
-            sentNickCommand = true;
-        });
 
         env.ircMock._whenClient(roomMapping.server, userIdNick, "whois", (client, whoisNick) => {
             expect(whoisNick).toEqual(newNick);
@@ -619,29 +506,12 @@ describe("Admin rooms", function() {
             });
         });
 
-        // make sure that when a message is sent it uses the old nick
-        let sentSay = false;
-        env.ircMock._whenClient(roomMapping.server, userIdNick, "say",
-        function(client, channel, text) {
-            expect(client.nick).toEqual(userIdNick, "use the new nick on /say");
-            expect(client.addr).toEqual(roomMapping.server);
-            expect(channel).toEqual(roomMapping.channel);
-            expect(text.length).toEqual(testText.length);
-            expect(text).toEqual(testText);
-            sentSay = true;
-        });
-
-        // make sure the AS sends an ACK of the request as a notice in the admin
-        // room
-        let sentAckNotice = false;
-        let sdk = env.clientMock._client(botUserId);
-        sdk.sendEvent.and.callFake(function(roomId, type, content) {
-            expect(roomId).toEqual(adminRoomId);
-            expect(content.msgtype).toEqual("m.notice");
-            expect(content.body.indexOf("err_nicktoofast")).not.toEqual(-1);
-            sentAckNotice = true;
-            return Promise.resolve();
-        });
+        // make sure that a display name change is not propagated
+        let sentNick = false;
+        env.ircMock._whenClient(roomMapping.server, newNick, "send",
+            function(client, channel, text) {
+                sentNick = true;
+            });
 
         // trigger the request to change the nick
         yield env.mockAppService._trigger("type:m.room.message", {
@@ -649,26 +519,156 @@ describe("Admin rooms", function() {
                 body: "!nick " + roomMapping.server + " " + newNick,
                 msgtype: "m.text"
             },
-            user_id: userId,
+            sender: userId,
             room_id: adminRoomId,
             type: "m.room.message"
         });
-        // trigger the message which should use the OLD nick
-        yield env.mockAppService._trigger("type:m.room.message", {
+
+        // trigger a display name change
+        yield env.mockAppService._trigger("type:m.room.member", {
             content: {
-                body: testText,
-                msgtype: "m.text"
+                membership: "join",
+                avatar_url: null,
+                displayname: displayName
             },
-            user_id: userId,
+            state_key: userId,
+            sender: userId,
             room_id: roomMapping.roomId,
-            type: "m.room.message"
+            type: "m.room.member",
         });
 
         // make sure everything was called
         expect(sentNickCommand).toBe(true, "sent nick IRC command");
-        expect(sentAckNotice).toBe(true, "sent ACK m.notice");
-        expect(sentSay).toBe(true, "sent say IRC command");
+        expect(sentNick).toBe(false, "sent nick IRC command on displayname change");
     }));
+
+    it("should propagate a display name change as a nick change when no custom nick is set",
+        test.coroutine(function*() {
+            const newNick = "Blurple";
+
+            const sdk = env.clientMock._client(botUserId);
+            sdk.getProfileInfo.and.callFake(async (reqUserId, type) => {
+                expect(reqUserId).toEqual(userId);
+                expect(type).toEqual("displayname");
+                return {displayname: newNick};
+            });
+
+            // make sure that the nick command is sent
+            let sentNickCommand = false;
+            env.ircMock._whenClient(roomMapping.server, userIdNick, "send",
+                function(client, command, arg) {
+                    expect(client.nick).toEqual(userIdNick, "use the old nick on /nick");
+                    expect(client.addr).toEqual(roomMapping.server);
+                    expect(command).toEqual("NICK");
+                    expect(arg).toEqual('M-' + newNick);
+                    sentNickCommand = true;
+                });
+
+            env.ircMock._whenClient(roomMapping.server, userIdNick, "whois", (client, whoisNick) => {
+                expect(whoisNick).toEqual('M-' + newNick);
+                client.emit("error", {
+                    commandType: "error",
+                    command: "err_nosuchnick",
+                    args: [undefined, 'M-' + newNick]
+                });
+            });
+    
+            // trigger a display name change
+            yield env.mockAppService._trigger("type:m.room.member", {
+                content: {
+                    membership: "join",
+                    avatar_url: null,
+                    displayname: newNick
+                },
+                state_key: userId,
+                sender: userId,
+                room_id: roomMapping.roomId,
+                type: "m.room.member",
+            });
+
+            // make sure everything was called
+            expect(sentNickCommand).toBe(true, "sent nick IRC command");
+        }));
+
+    it("should reject !nick changes for IRC errors",
+        test.coroutine(function*() {
+            let newNick = "Blurple";
+            let testText = "I don't know what colour I am.";
+
+            // make sure that the nick command is sent
+            let sentNickCommand = false;
+            env.ircMock._whenClient(roomMapping.server, userIdNick, "send",
+                function(client, command, arg) {
+                    expect(client.nick).toEqual(userIdNick, "use the old nick on /nick");
+                    expect(client.addr).toEqual(roomMapping.server);
+                    expect(command).toEqual("NICK");
+                    expect(arg).toEqual(newNick);
+                    client.emit("error", {
+                        commandType: "error",
+                        command: "err_nicktoofast"
+                    })
+                    sentNickCommand = true;
+                });
+
+            env.ircMock._whenClient(roomMapping.server, userIdNick, "whois", (client, whoisNick) => {
+                expect(whoisNick).toEqual(newNick);
+                client.emit("error", {
+                    commandType: "error",
+                    command: "err_nosuchnick",
+                    args: [undefined, newNick]
+                });
+            });
+
+            // make sure that when a message is sent it uses the old nick
+            let sentSay = false;
+            env.ircMock._whenClient(roomMapping.server, userIdNick, "say",
+                function(client, channel, text) {
+                    expect(client.nick).toEqual(userIdNick, "use the new nick on /say");
+                    expect(client.addr).toEqual(roomMapping.server);
+                    expect(channel).toEqual(roomMapping.channel);
+                    expect(text.length).toEqual(testText.length);
+                    expect(text).toEqual(testText);
+                    sentSay = true;
+                });
+
+            // make sure the AS sends an ACK of the request as a notice in the admin
+            // room
+            let sentAckNotice = false;
+            let sdk = env.clientMock._client(botUserId);
+            sdk.sendEvent.and.callFake(function(roomId, type, content) {
+                expect(roomId).toEqual(adminRoomId);
+                expect(content.msgtype).toEqual("m.notice");
+                expect(content.body.indexOf("err_nicktoofast")).not.toEqual(-1);
+                sentAckNotice = true;
+                return Promise.resolve();
+            });
+
+            // trigger the request to change the nick
+            yield env.mockAppService._trigger("type:m.room.message", {
+                content: {
+                    body: "!nick " + roomMapping.server + " " + newNick,
+                    msgtype: "m.text"
+                },
+                sender: userId,
+                room_id: adminRoomId,
+                type: "m.room.message"
+            });
+            // trigger the message which should use the OLD nick
+            yield env.mockAppService._trigger("type:m.room.message", {
+                content: {
+                    body: testText,
+                    msgtype: "m.text"
+                },
+                sender: userId,
+                room_id: roomMapping.roomId,
+                type: "m.room.message"
+            });
+
+            // make sure everything was called
+            expect(sentNickCommand).toBe(true, "sent nick IRC command");
+            expect(sentAckNotice).toBe(true, "sent ACK m.notice");
+            expect(sentSay).toBe(true, "sent say IRC command");
+        }));
 
     it("should timeout !nick changes after 10 seconds", test.coroutine(function*() {
         let newNick = "Blurple";
@@ -676,18 +676,18 @@ describe("Admin rooms", function() {
         // make sure that the NICK command is sent
         let sentNickCommand = false;
         env.ircMock._whenClient(roomMapping.server, userIdNick, "send",
-        function(client, command, arg) {
-            expect(client.nick).toEqual(userIdNick, "use the old nick on /nick");
-            expect(client.addr).toEqual(roomMapping.server);
-            expect(command).toEqual("NICK");
-            expect(arg).toEqual(newNick);
-            // don't emit anything.. and speed up time
-            setImmediate(function() {
-                jasmine.clock().tick(1000 * 11);
-            });
+            function(client, command, arg) {
+                expect(client.nick).toEqual(userIdNick, "use the old nick on /nick");
+                expect(client.addr).toEqual(roomMapping.server);
+                expect(command).toEqual("NICK");
+                expect(arg).toEqual(newNick);
+                // don't emit anything.. and speed up time
+                setImmediate(function() {
+                    jasmine.clock().tick(1000 * 11);
+                });
 
-            sentNickCommand = true;
-        });
+                sentNickCommand = true;
+            });
 
         env.ircMock._whenClient(roomMapping.server, userIdNick, "whois", (client, whoisNick) => {
             expect(whoisNick).toEqual(newNick);
@@ -716,7 +716,7 @@ describe("Admin rooms", function() {
                 body: "!nick " + roomMapping.server + " " + newNick,
                 msgtype: "m.text"
             },
-            user_id: userId,
+            sender: userId,
             room_id: adminRoomId,
             type: "m.room.message"
         });
@@ -732,13 +732,13 @@ describe("Admin rooms", function() {
         // make sure that the NICK command not is sent
         let sentNickCommand = false;
         env.ircMock._whenClient(roomMapping.server, userIdNick, "send",
-        function(client, command, arg) {
-            expect(client.nick).toEqual(userIdNick, "use the old nick on /nick");
-            expect(client.addr).toEqual(roomMapping.server);
-            expect(command).toEqual("NICK");
-            expect(arg).toEqual(newNick);
-            sentNickCommand = true;
-        });
+            function(client, command, arg) {
+                expect(client.nick).toEqual(userIdNick, "use the old nick on /nick");
+                expect(client.addr).toEqual(roomMapping.server);
+                expect(command).toEqual("NICK");
+                expect(arg).toEqual(newNick);
+                sentNickCommand = true;
+            });
 
         env.ircMock._whenClient(roomMapping.server, userIdNick, "whois", (client, whoisNick, callback) => {
             expect(whoisNick).toEqual(newNick);
@@ -767,7 +767,7 @@ describe("Admin rooms", function() {
                 body: `!nick ${roomMapping.server} ${newNick}`,
                 msgtype: "m.text"
             },
-            user_id: userId,
+            sender: userId,
             room_id: adminRoomId,
             type: "m.room.message"
         });
@@ -778,371 +778,371 @@ describe("Admin rooms", function() {
     });
 
     it("should be able to join a channel with !join if they are on the whitelist",
-    test.coroutine(function*() {
-        let newChannel = "#awooga";
-        let newRoomId = "!aasifuhawei:efjkwehfi";
-        let serverConfig = env.config.ircService.servers[roomMapping.server];
-        let serverShouldPublishRooms = serverConfig.dynamicChannels.published;
-        let serverJoinRule = serverConfig.dynamicChannels.joinRule;
+        test.coroutine(function*() {
+            let newChannel = "#awooga";
+            let newRoomId = "!aasifuhawei:efjkwehfi";
+            let serverConfig = env.config.ircService.servers[roomMapping.server];
+            let serverShouldPublishRooms = serverConfig.dynamicChannels.published;
+            let serverJoinRule = serverConfig.dynamicChannels.joinRule;
 
-        // let the bot join the irc channel
-        let joinedChannel = false;
-        env.ircMock._whenClient(roomMapping.server, roomMapping.botNick, "join",
-        function(client, chan, cb) {
-            if (chan === newChannel) {
-                joinedChannel = true;
-                if (cb) { cb(); }
-            }
-        });
+            // let the bot join the irc channel
+            let joinedChannel = false;
+            env.ircMock._whenClient(roomMapping.server, roomMapping.botNick, "join",
+                function(client, chan, cb) {
+                    if (chan === newChannel) {
+                        joinedChannel = true;
+                        if (cb) { cb(); }
+                    }
+                });
 
-        // let the user join the IRC channel because of membership syncing
-        env.ircMock._whenClient(roomMapping.server, userIdNick, "join",
-        function(client, chan, cb) {
-            if (chan === newChannel && cb) { cb(); }
-        });
+            // let the user join the IRC channel because of membership syncing
+            env.ircMock._whenClient(roomMapping.server, userIdNick, "join",
+                function(client, chan, cb) {
+                    if (chan === newChannel && cb) { cb(); }
+                });
 
-        // make sure the AS creates a new PRIVATE matrix room.
-        let createdMatrixRoom = false;
-        let sdk = env.clientMock._client(botUserId);
-        sdk.createRoom.and.callFake(function(opts) {
-            expect(opts.visibility).toEqual(serverShouldPublishRooms ? "public" : "private");
-            expect(
-                opts.initial_state.find(
-                    (s)=> s.type === 'm.room.join_rules'
-                ).content.join_rule
-            ).toEqual(serverJoinRule);
-            expect(opts.invite).toEqual([userId]);
-            createdMatrixRoom = true;
-            return Promise.resolve({
-                room_id: newRoomId
+            // make sure the AS creates a new PRIVATE matrix room.
+            let createdMatrixRoom = false;
+            let sdk = env.clientMock._client(botUserId);
+            sdk.createRoom.and.callFake(function(opts) {
+                expect(opts.visibility).toEqual(serverShouldPublishRooms ? "public" : "private");
+                expect(
+                    opts.initial_state.find(
+                        (s)=> s.type === 'm.room.join_rules'
+                    ).content.join_rule
+                ).toEqual(serverJoinRule);
+                expect(opts.invite).toEqual([userId]);
+                createdMatrixRoom = true;
+                return Promise.resolve({
+                    room_id: newRoomId
+                });
             });
-        });
 
-        // trigger the request to join a channel
-        yield env.mockAppService._trigger("type:m.room.message", {
-            content: {
-                body: "!join " + roomMapping.server + " " + newChannel,
-                msgtype: "m.text"
-            },
-            user_id: userId,
-            room_id: adminRoomId,
-            type: "m.room.message"
-        });
+            // trigger the request to join a channel
+            yield env.mockAppService._trigger("type:m.room.message", {
+                content: {
+                    body: "!join " + roomMapping.server + " " + newChannel,
+                    msgtype: "m.text"
+                },
+                sender: userId,
+                room_id: adminRoomId,
+                type: "m.room.message"
+            });
 
-        // make sure everything was called
-        expect(createdMatrixRoom).toBe(true, "Did not create matrix room");
-        expect(joinedChannel).toBe(true, "Bot didn't join channel");
-    }));
+            // make sure everything was called
+            expect(createdMatrixRoom).toBe(true, "Did not create matrix room");
+            expect(joinedChannel).toBe(true, "Bot didn't join channel");
+        }));
 
     it("should be able to join a channel with !join and a key",
-    test.coroutine(function*() {
-        let newChannel = "#awooga";
-        let newRoomId = "!aasifuhawei:efjkwehfi";
-        let key = "secret";
-        let serverConfig = env.config.ircService.servers[roomMapping.server];
-        let serverShouldPublishRooms = serverConfig.dynamicChannels.published;
-        let serverJoinRule = serverConfig.dynamicChannels.joinRule;
+        test.coroutine(function*() {
+            let newChannel = "#awooga";
+            let newRoomId = "!aasifuhawei:efjkwehfi";
+            let key = "secret";
+            let serverConfig = env.config.ircService.servers[roomMapping.server];
+            let serverShouldPublishRooms = serverConfig.dynamicChannels.published;
+            let serverJoinRule = serverConfig.dynamicChannels.joinRule;
 
-        // let the bot join the irc channel
-        let joinedChannel = false;
-        env.ircMock._whenClient(roomMapping.server, roomMapping.botNick, "join",
-        function(client, chan, cb) {
-            if (chan === (newChannel + " " + key)) {
-                joinedChannel = true;
-                if (cb) { cb(); }
-            }
-        });
+            // let the bot join the irc channel
+            let joinedChannel = false;
+            env.ircMock._whenClient(roomMapping.server, roomMapping.botNick, "join",
+                function(client, chan, cb) {
+                    if (chan === (newChannel + " " + key)) {
+                        joinedChannel = true;
+                        if (cb) { cb(); }
+                    }
+                });
 
-        // Because we gave a key, we expect the user to be joined (with the key)
-        // immediately.
-        env.ircMock._whenClient(roomMapping.server, userIdNick, "join",
-        function(client, chan, cb) {
-            if (chan === (newChannel + " " + key)) {
-                joinedChannel = true;
-                if (cb) { cb(); }
-            }
-        });
+            // Because we gave a key, we expect the user to be joined (with the key)
+            // immediately.
+            env.ircMock._whenClient(roomMapping.server, userIdNick, "join",
+                function(client, chan, cb) {
+                    if (chan === (newChannel + " " + key)) {
+                        joinedChannel = true;
+                        if (cb) { cb(); }
+                    }
+                });
 
-        // make sure the AS creates a new PRIVATE matrix room.
-        let createdMatrixRoom = false;
-        let sdk = env.clientMock._client(botUserId);
-        sdk.createRoom.and.callFake(function(opts) {
-            expect(opts.visibility).toEqual(serverShouldPublishRooms ? "public" : "private");
-            expect(
-                opts.initial_state.find(
-                    (s)=> s.type === 'm.room.join_rules'
-                ).content.join_rule
-            ).toEqual(serverJoinRule);
-            expect(opts.invite).toEqual([userId]);
-            createdMatrixRoom = true;
-            return Promise.resolve({
-                room_id: newRoomId
+            // make sure the AS creates a new PRIVATE matrix room.
+            let createdMatrixRoom = false;
+            let sdk = env.clientMock._client(botUserId);
+            sdk.createRoom.and.callFake(function(opts) {
+                expect(opts.visibility).toEqual(serverShouldPublishRooms ? "public" : "private");
+                expect(
+                    opts.initial_state.find(
+                        (s)=> s.type === 'm.room.join_rules'
+                    ).content.join_rule
+                ).toEqual(serverJoinRule);
+                expect(opts.invite).toEqual([userId]);
+                createdMatrixRoom = true;
+                return Promise.resolve({
+                    room_id: newRoomId
+                });
             });
-        });
 
-        // trigger the request to join a channel
-        yield env.mockAppService._trigger("type:m.room.message", {
-            content: {
-                body: "!join " + roomMapping.server + " " + newChannel + " " + key,
-                msgtype: "m.text"
-            },
-            user_id: userId,
-            room_id: adminRoomId,
-            type: "m.room.message"
-        })
+            // trigger the request to join a channel
+            yield env.mockAppService._trigger("type:m.room.message", {
+                content: {
+                    body: "!join " + roomMapping.server + " " + newChannel + " " + key,
+                    msgtype: "m.text"
+                },
+                sender: userId,
+                room_id: adminRoomId,
+                type: "m.room.message"
+            })
 
-        // make sure everything was called
-        expect(createdMatrixRoom).toBe(true, "Did not create matrix room");
-        expect(joinedChannel).toBe(true, "Bot didn't join channel");
-    }));
+            // make sure everything was called
+            expect(createdMatrixRoom).toBe(true, "Did not create matrix room");
+            expect(joinedChannel).toBe(true, "Bot didn't join channel");
+        }));
 
     it("should allow arbitrary IRC commands to be issued",
-    test.coroutine(function*() {
-        let newChannel = "#coffee";
+        test.coroutine(function*() {
+            let newChannel = "#coffee";
 
-        // Expect the following commands to be sent in order
-        let recvCommands = ["JOIN", "TOPIC", "PART", "STUPID"];
+            // Expect the following commands to be sent in order
+            let recvCommands = ["JOIN", "TOPIC", "PART", "STUPID"];
 
-        let cmdIx = 0;
-        env.ircMock._whenClient(roomMapping.server, userIdNick, "send",
-        function(client) {
-            let args = Array.from(arguments).splice(1);
-            let keyword = args[0];
+            let cmdIx = 0;
+            env.ircMock._whenClient(roomMapping.server, userIdNick, "send",
+                function(client) {
+                    let args = Array.from(arguments).splice(1);
+                    let keyword = args[0];
 
-            expect(keyword).toBe(recvCommands[cmdIx]);
-            cmdIx++;
-        });
+                    expect(keyword).toBe(recvCommands[cmdIx]);
+                    cmdIx++;
+                });
 
-        // 5 commands should be executed
-        // rubbishserver should not be accepted
-        let commands = [
-            `!cmd ${roomMapping.server} JOIN ${newChannel}`,
-            `!cmd ${roomMapping.server} TOPIC ${newChannel} :some new fancy topic`,
-            `!cmd ${roomMapping.server} PART ${newChannel}`,
-            `!cmd ${roomMapping.server} STUPID COMMANDS`,
-            `!cmd rubbishserver SOME COMMAND`];
+            // 5 commands should be executed
+            // rubbishserver should not be accepted
+            let commands = [
+                `!cmd ${roomMapping.server} JOIN ${newChannel}`,
+                `!cmd ${roomMapping.server} TOPIC ${newChannel} :some new fancy topic`,
+                `!cmd ${roomMapping.server} PART ${newChannel}`,
+                `!cmd ${roomMapping.server} STUPID COMMANDS`,
+                `!cmd rubbishserver SOME COMMAND`];
 
-        for (let i = 0; i < commands.length; i++) {
+            for (let i = 0; i < commands.length; i++) {
             // send commands
-            yield env.mockAppService._trigger("type:m.room.message", {
-                content: {
-                    body: commands[i],
-                    msgtype: "m.text"
-                },
-                user_id: userId,
-                room_id: adminRoomId,
-                type: "m.room.message"
-            });
-        }
+                yield env.mockAppService._trigger("type:m.room.message", {
+                    content: {
+                        body: commands[i],
+                        msgtype: "m.text"
+                    },
+                    sender: userId,
+                    room_id: adminRoomId,
+                    type: "m.room.message"
+                });
+            }
 
-        expect(cmdIx).toBe(recvCommands.length);
-    }));
+            expect(cmdIx).toBe(recvCommands.length);
+        }));
 
     it("should allow arbitrary IRC commands to be issued when server has not been set",
-    test.coroutine(function*() {
-        let newChannel = "#coffee";
+        test.coroutine(function*() {
+            let newChannel = "#coffee";
 
-        // Expect the following commands to be sent in order
-        let recvCommands = ["JOIN", "TOPIC", "PART", "STUPID"];
+            // Expect the following commands to be sent in order
+            let recvCommands = ["JOIN", "TOPIC", "PART", "STUPID"];
 
-        let cmdIx = 0;
-        env.ircMock._whenClient(roomMapping.server, userIdNick, "send",
-        function(client) {
-            let args = Array.from(arguments).splice(1);
-            let keyword = args[0];
+            let cmdIx = 0;
+            env.ircMock._whenClient(roomMapping.server, userIdNick, "send",
+                function(client) {
+                    let args = Array.from(arguments).splice(1);
+                    let keyword = args[0];
 
-            expect(keyword).toBe(recvCommands[cmdIx]);
-            cmdIx++;
-        });
+                    expect(keyword).toBe(recvCommands[cmdIx]);
+                    cmdIx++;
+                });
 
-        let commands = [
-            `!cmd JOIN ${newChannel}`,
-            `!cmd TOPIC ${newChannel} :some new fancy topic`,
-            `!cmd PART ${newChannel}`,
-            `!cmd STUPID COMMANDS`];
+            let commands = [
+                `!cmd JOIN ${newChannel}`,
+                `!cmd TOPIC ${newChannel} :some new fancy topic`,
+                `!cmd PART ${newChannel}`,
+                `!cmd STUPID COMMANDS`];
 
-        for (let i = 0; i < commands.length; i++) {
+            for (let i = 0; i < commands.length; i++) {
             // send commands
+                yield env.mockAppService._trigger("type:m.room.message", {
+                    content: {
+                        body: commands[i],
+                        msgtype: "m.text"
+                    },
+                    sender: userId,
+                    room_id: adminRoomId,
+                    type: "m.room.message"
+                });
+            }
+
+            expect(cmdIx).toBe(recvCommands.length);
+        }));
+
+    it("should reject malformed commands (new form)",
+        test.coroutine(function*() {
+            let cmdCount = 0;
+            env.ircMock._whenClient(roomMapping.server, userIdNick, "send",
+                function(client) {
+                    cmdCount++;
+                });
+
+            let command = `!cmd M4LF0RM3D command`;
+
+            // send command
             yield env.mockAppService._trigger("type:m.room.message", {
                 content: {
-                    body: commands[i],
+                    body: command,
                     msgtype: "m.text"
                 },
-                user_id: userId,
+                sender: userId,
                 room_id: adminRoomId,
                 type: "m.room.message"
             });
-        }
 
-        expect(cmdIx).toBe(recvCommands.length);
-    }));
-
-    it("should reject malformed commands (new form)",
-    test.coroutine(function*() {
-        let cmdCount = 0;
-        env.ircMock._whenClient(roomMapping.server, userIdNick, "send",
-        function(client) {
-            cmdCount++;
-        });
-
-        let command = `!cmd M4LF0RM3D command`;
-
-        // send command
-        yield env.mockAppService._trigger("type:m.room.message", {
-            content: {
-                body: command,
-                msgtype: "m.text"
-            },
-            user_id: userId,
-            room_id: adminRoomId,
-            type: "m.room.message"
-        });
-
-        expect(cmdCount).toBe(0);
-    }));
+            expect(cmdCount).toBe(0);
+        }));
 
     it("should reject PROTOCTL commands",
-    test.coroutine(function*() {
-        let cmdCount = 0;
-        env.ircMock._whenClient(roomMapping.server, userIdNick, "send",
-        function(client) {
-            cmdCount++;
-        });
+        test.coroutine(function*() {
+            let cmdCount = 0;
+            env.ircMock._whenClient(roomMapping.server, userIdNick, "send",
+                function(client) {
+                    cmdCount++;
+                });
 
-        let command = `!cmd PROTOCTL command`;
+            let command = `!cmd PROTOCTL command`;
 
-        // send command
-        yield env.mockAppService._trigger("type:m.room.message", {
-            content: {
-                body: command,
-                msgtype: "m.text"
-            },
-            user_id: userId,
-            room_id: adminRoomId,
-            type: "m.room.message"
-        });
+            // send command
+            yield env.mockAppService._trigger("type:m.room.message", {
+                content: {
+                    body: command,
+                    msgtype: "m.text"
+                },
+                sender: userId,
+                room_id: adminRoomId,
+                type: "m.room.message"
+            });
 
-        expect(cmdCount).toBe(0);
-    }));
+            expect(cmdCount).toBe(0);
+        }));
 
     it("mx bot should be kicked when there are > 2 users in room and a message is sent",
-    test.coroutine(function*() {
+        test.coroutine(function*() {
 
-        let sdk = env.clientMock._client(botUserId);
-        sdk.roomState.and.callFake(
-            function (roomId) {
-                expect(roomId).toBe(adminRoomId, 'Room state returned should be for admin room');
-                return Promise.resolve([
-                    {
-                        content: {membership: "join"},
-                        type: "m.room.member",
-                        state_key: "fake bot state"
-                    },
-                    {
-                        content: {membership: "join"},
-                        type: "m.room.member",
-                        state_key: "fake user1 state"
-                    },
-                    {content:
+            let sdk = env.clientMock._client(botUserId);
+            sdk.roomState.and.callFake(
+                function (roomId) {
+                    expect(roomId).toBe(adminRoomId, 'Room state returned should be for admin room');
+                    return Promise.resolve([
+                        {
+                            content: {membership: "join"},
+                            type: "m.room.member",
+                            state_key: "fake bot state"
+                        },
+                        {
+                            content: {membership: "join"},
+                            type: "m.room.member",
+                            state_key: "fake user1 state"
+                        },
+                        {content:
                         {membership: "join"},
                         type: "m.room.member",
                         state_key: "fake user2 state"
-                    }
-                ]);
-            }
-        );
+                        }
+                    ]);
+                }
+            );
 
-        let botLeft = false
-        sdk.leave.and.callFake(function(roomId) {
-            expect(roomId).toBe(adminRoomId, 'Bot did not leave admin room');
-            botLeft = true;
-            return Promise.resolve();
-        });
+            let botLeft = false
+            sdk.leave.and.callFake(function(roomId) {
+                expect(roomId).toBe(adminRoomId, 'Bot did not leave admin room');
+                botLeft = true;
+                return Promise.resolve();
+            });
 
-        yield env.mockAppService._trigger("type:m.room.member", {
-            content: {
-                membership: "join",
-            },
-            state_key: botUserId,
-            user_id: "@user1:localhost",
-            room_id: adminRoomId,
-            type: "m.room.member"
-        });
+            yield env.mockAppService._trigger("type:m.room.member", {
+                content: {
+                    membership: "join",
+                },
+                state_key: botUserId,
+                sender: "@user1:localhost",
+                room_id: adminRoomId,
+                type: "m.room.member"
+            });
 
-        yield env.mockAppService._trigger("type:m.room.member", {
-            content: {
-                membership: "join",
-            },
-            state_key: botUserId,
-            user_id: "@user2:localhost",
-            room_id: adminRoomId,
-            type: "m.room.member"
-        });
+            yield env.mockAppService._trigger("type:m.room.member", {
+                content: {
+                    membership: "join",
+                },
+                state_key: botUserId,
+                sender: "@user2:localhost",
+                room_id: adminRoomId,
+                type: "m.room.member"
+            });
 
-        // trigger the bot to leave
-        yield env.mockAppService._trigger("type:m.room.message", {
-            content: {
-                body: "ping",
-                msgtype: "m.text"
-            },
-            user_id: "@user2:localhost",
-            room_id: adminRoomId,
-            type: "m.room.message"
-        }).then(
-            () => {
-                expect(botLeft).toBe(true);
-            },
-            (err) => {console.log(err)}
-        );
-    }));
+            // trigger the bot to leave
+            yield env.mockAppService._trigger("type:m.room.message", {
+                content: {
+                    body: "ping",
+                    msgtype: "m.text"
+                },
+                sender: "@user2:localhost",
+                room_id: adminRoomId,
+                type: "m.room.message"
+            }).then(
+                () => {
+                    expect(botLeft).toBe(true);
+                },
+                (err) => {console.log(err)}
+            );
+        }));
 
     it("mx bot should NOT be kicked when there are 2 users in room and a message is sent",
-    test.coroutine(function*() {
+        test.coroutine(function*() {
 
-        let sdk = env.clientMock._client(botUserId);
-        sdk.roomState.and.callFake(
-            function (roomId) {
-                expect(roomId).toBe(adminRoomId, 'Room state returned should be for admin room');
-                return Promise.resolve([
-                    {content: {membership: "join"}, type: "m.room.member", state_key: ":)"},
-                    {content: {membership: "join"}, type: "m.room.member", state_key: ";)"}
-                ]);
-            }
-        );
+            let sdk = env.clientMock._client(botUserId);
+            sdk.roomState.and.callFake(
+                function (roomId) {
+                    expect(roomId).toBe(adminRoomId, 'Room state returned should be for admin room');
+                    return Promise.resolve([
+                        {content: {membership: "join"}, type: "m.room.member", state_key: ":)"},
+                        {content: {membership: "join"}, type: "m.room.member", state_key: ";)"}
+                    ]);
+                }
+            );
 
-        let botLeft = false
-        sdk.leave.and.callFake(function(roomId) {
-            expect(roomId).toBe(adminRoomId, 'Bot did not leave admin room');
-            botLeft = true;
-            return Promise.resolve();
-        });
+            let botLeft = false
+            sdk.leave.and.callFake(function(roomId) {
+                expect(roomId).toBe(adminRoomId, 'Bot did not leave admin room');
+                botLeft = true;
+                return Promise.resolve();
+            });
 
-        yield env.mockAppService._trigger("type:m.room.member", {
-            content: {
-                membership: "join",
-            },
-            state_key: botUserId,
-            user_id: "@user1:localhost",
-            room_id: adminRoomId,
-            type: "m.room.member"
-        });
+            yield env.mockAppService._trigger("type:m.room.member", {
+                content: {
+                    membership: "join",
+                },
+                state_key: botUserId,
+                sender: "@user1:localhost",
+                room_id: adminRoomId,
+                type: "m.room.member"
+            });
 
-        // trigger the bot to leave
-        yield env.mockAppService._trigger("type:m.room.message", {
-            content: {
-                body: "ping",
-                msgtype: "m.text"
-            },
-            user_id: "@user2:localhost",
-            room_id: adminRoomId,
-            type: "m.room.message"
-        }).then(
-            () => {
-                expect(botLeft).toBe(false);
-            },
-            (err) => {console.log(err)}
-        );
-    }));
+            // trigger the bot to leave
+            yield env.mockAppService._trigger("type:m.room.message", {
+                content: {
+                    body: "ping",
+                    msgtype: "m.text"
+                },
+                sender: "@user2:localhost",
+                room_id: adminRoomId,
+                type: "m.room.message"
+            }).then(
+                () => {
+                    expect(botLeft).toBe(false);
+                },
+                (err) => {console.log(err)}
+            );
+        }));
 
     it("should respond with a feature status for !feature", function(done) {
         const sdk = env.clientMock._client(botUserId);
@@ -1159,7 +1159,7 @@ describe("Admin rooms", function() {
                 body: "!feature mentions",
                 msgtype: "m.text"
             },
-            user_id: userId,
+            sender: userId,
             room_id: adminRoomId,
             type: "m.room.message"
         });
@@ -1179,7 +1179,7 @@ describe("Admin rooms", function() {
                         body: "!feature mentions",
                         msgtype: "m.text"
                     },
-                    user_id: userId,
+                    sender: userId,
                     room_id: adminRoomId,
                     type: "m.room.message"
                 });
@@ -1198,7 +1198,7 @@ describe("Admin rooms", function() {
                 body: "!feature mentions true",
                 msgtype: "m.text"
             },
-            user_id: userId,
+            sender: userId,
             room_id: adminRoomId,
             type: "m.room.message"
         });
@@ -1225,7 +1225,7 @@ describe("Admin rooms", function() {
                     body,
                     msgtype: "m.text"
                 },
-                user_id: userId,
+                sender: userId,
                 room_id: adminRoomId,
                 type: "m.room.message"
             });
@@ -1246,7 +1246,7 @@ describe("Admin rooms", function() {
                         body: "!feature mentions",
                         msgtype: "m.text"
                     },
-                    user_id: userId,
+                    sender: userId,
                     room_id: adminRoomId,
                     type: "m.room.message"
                 });
@@ -1265,10 +1265,27 @@ describe("Admin rooms", function() {
                 body: "!feature mentions bacon",
                 msgtype: "m.text"
             },
-            user_id: userId,
+            sender: userId,
             room_id: adminRoomId,
             type: "m.room.message"
         });
+    });
+
+    it("should reconnect when using !reconnect", async function() {
+        const sdk = env.clientMock._client(botUserId);
+        const disconnectPromise = env.ircMock._whenClient(roomMapping.server, userIdNick, "disconnect", () => { });
+        const connectPromise = env.ircMock._whenClient(roomMapping.server, userIdNick, "connect", () => { });
+        await env.mockAppService._trigger("type:m.room.message", {
+            content: {
+                body: "!reconnect",
+                msgtype: "m.text"
+            },
+            sender: userId,
+            room_id: adminRoomId,
+            type: "m.room.message"
+        });
+        await disconnectPromise;
+        await connectPromise;
     });
 
     it("should be able to store a password with !storepass", async function() {
@@ -1283,21 +1300,19 @@ describe("Admin rooms", function() {
             return {};
         });
 
-        const disconnectPromise = env.ircMock._whenClient(roomMapping.server, userIdNick, "disconnect", () => { });
-        const connectPromise = env.ircMock._whenClient(roomMapping.server, userIdNick, "connect", () => { });
+        // Ensure that the user reconnects
         await env.mockAppService._trigger("type:m.room.message", {
             content: {
                 body: "!storepass foobar",
                 msgtype: "m.text"
             },
-            user_id: userId,
+            sender: userId,
             room_id: adminRoomId,
             type: "m.room.message"
         });
         await sendPromise;
-        // Ensure that the user reconnects
-        await disconnectPromise;
-        await connectPromise;
+        const userCfg = await env.ircBridge.getStore().getIrcClientConfig(userId, roomMapping.server);
+        expect(userCfg.getPassword()).toEqual("foobar");
     });
 
     it("should be able to store a username:password with !storepass", async function() {
@@ -1312,24 +1327,18 @@ describe("Admin rooms", function() {
             );
             return {};
         });
-        const disconnectPromise = env.ircMock._whenClient(roomMapping.server, userIdNick, "disconnect", () => { });
-        const connectPromise = env.ircMock._whenClient(roomMapping.server, userIdNick, "connect", (client) => {
-            const opts = client.opts;
-            expect(opts.password).toBe(password);
-        });
-
         await env.mockAppService._trigger("type:m.room.message", {
             content: {
                 body: `!storepass ${password}`,
                 msgtype: "m.text"
             },
-            user_id: userId,
+            sender: userId,
             room_id: adminRoomId,
             type: "m.room.message"
         });
         await sendPromise;
-        await disconnectPromise;
-        await connectPromise;
+        const userCfg = await env.ircBridge.getStore().getIrcClientConfig(userId, roomMapping.server);
+        expect(userCfg.getPassword()).toEqual(password);
     });
 
 
@@ -1350,7 +1359,7 @@ describe("Admin rooms", function() {
                 body: "!storepass foobar",
                 msgtype: "m.text"
             },
-            user_id: userId,
+            sender: userId,
             room_id: adminRoomId,
             type: "m.room.message"
         });
@@ -1367,7 +1376,7 @@ describe("Admin rooms", function() {
                 body: "!removepass",
                 msgtype: "m.text"
             },
-            user_id: userId,
+            sender: userId,
             room_id: adminRoomId,
             type: "m.room.message"
         });

--- a/spec/integ/admin-rooms.spec.js
+++ b/spec/integ/admin-rooms.spec.js
@@ -1278,7 +1278,7 @@ describe("Admin rooms", function() {
             expect(roomId).toEqual(adminRoomId);
             expect(content.msgtype).toEqual("m.notice");
             expect(content.body).toEqual(
-                "Successfully stored password for irc.example. You will now be reconnected to IRC."
+                "Successfully stored password for irc.example. Use !reconnect to use this password now."
             );
             return {};
         });
@@ -1308,7 +1308,7 @@ describe("Admin rooms", function() {
             expect(roomId).toEqual(adminRoomId);
             expect(content.msgtype).toEqual("m.notice");
             expect(content.body).toEqual(
-                "Successfully stored password for irc.example. You will now be reconnected to IRC."
+                "Successfully stored password for irc.example. Use !reconnect to use this password now."
             );
             return {};
         });
@@ -1340,7 +1340,7 @@ describe("Admin rooms", function() {
             expect(roomId).toEqual(adminRoomId);
             expect(content.msgtype).toEqual("m.notice");
             expect(content.body).toEqual(
-                "Successfully stored password for irc.example. You will now be reconnected to IRC."
+                "Successfully stored password for irc.example. Use !reconnect to use this password now."
             );
             return {};
         });

--- a/src/bridge/AdminRoomHandler.ts
+++ b/src/bridge/AdminRoomHandler.ts
@@ -493,8 +493,7 @@ export class AdminRoomHandler {
                 config.setUsername(username);
                 await this.ircBridge.getStore().storeIrcClientConfig(config);
                 notice = new MatrixAction(
-                    "notice", `Successfully stored username for ${domain} for future connections. `
-                    + "Use !reconnect to use this username now."
+                    "notice", `Successfully stored username for ${domain}. Use !reconnect to use this username now.`
                 );
             }
         }

--- a/src/irc/IdentGenerator.ts
+++ b/src/irc/IdentGenerator.ts
@@ -27,7 +27,7 @@ export class IdentGenerator {
     // The max length of <realname> in USER commands
     private static readonly MAX_REAL_NAME_LENGTH = 48;
     // The max length of <username> in USER commands
-    private static readonly MAX_USER_NAME_LENGTH = 10;
+    public static readonly MAX_USER_NAME_LENGTH = 10;
     // The delimiter of the username.
     private static readonly USER_NAME_DELIMITER = "_";
     // The delimiter of the username.
@@ -221,7 +221,7 @@ export class IdentGenerator {
         throw Error("Ran out of entries: " + username);
     }
 
-    private static sanitiseUsername(username: string, replacementChar = "") {
+    public static sanitiseUsername(username: string, replacementChar = "") {
         username = username.toLowerCase();
         // strip illegal chars according to RFC 1459 Sect 2.3.1
         // (technically it's any <nonwhite> ascii for <user> but meh)


### PR DESCRIPTION
Additionally, this also:

- Adds metadata handlers for various sasl loggedin/loggedout/error events (requires https://github.com/matrix-org/node-irc/pull/62)
- Adds a `!reconnect` command to be used after setting a username / password.
- Stops `!storepass` from automatically reconnecting you, instead prompting you to reconnect.

This should hopefully improve the process wrt authenticating with services over the bridge, esepcially freenode and libera.chat which would prefer us to use SASL PLAIN over the PASS command.