### PR TITLE
Fix CLI Error: undefined when error happens

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,6 +1,7 @@
 "use strict";
 const Cli = require("matrix-appservice-bridge").Cli;
 const log = require("./lib/logging").get("CLI");
+const {logErr} = require("./lib/logging");
 const main = require("./lib/main");
 const path = require("path");
 
@@ -58,7 +59,7 @@ new Cli({
             bridge = resultBridge;
         }).catch(function(err) {
             log.error("Failed to run bridge.");
-            log.error(err);
+            logErr(log, err);
             process.exit(1);
         });
 

--- a/changelog.d/1333.bugfix
+++ b/changelog.d/1333.bugfix
@@ -1,0 +1,1 @@
+Fix "CLI undefined" being spit out from cli on generic errors


### PR DESCRIPTION
Seems related to https://github.com/winstonjs/winston/issues/1415 which says errors don't get stringified in simple formatter

The logErr function doesn't seem to be used anywhere, so it might be better to `log.err(err.stack || err.message || JSON.stringify(err))`

From:

```
2021-05-24 15:03:08 ERROR:CLI Failed to run bridge.
2021-05-24 15:03:08 ERROR:CLI undefined
```

To:
```
2021-05-24 15:01:27 ERROR:CLI Failed to run bridge.
2021-05-24 15:01:27 ERROR:CLI Error: {}
2021-05-24 15:01:27 ERROR:CLI Error: No IRC servers specified.
    at IrcBridge.run (/home/halkeye/go/src/github.com/matrix-org/matrix-appservice-irc/lib/bridge/IrcBridge.js:479:19)
    at processTicksAndRejections (internal/process/task_queues.js:93:5)
    at async Object.runBridge (/home/halkeye/go/src/github.com/matrix-org/matrix-appservice-irc/lib/main.js:132:5)
```