### PR TITLE
Block IRC messages appearing in Matrix rooms if Matrix user(s) cannot be joined.

### DIFF
--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -243,6 +243,13 @@ ircService:
             # Make virtual matrix clients join and leave rooms as their real IRC
             # counterparts join/part channels. Default: false.
             incremental: false
+            # Should the bridge check if all Matrix users are connected to IRC and
+            # joined to the channel before relaying messages into the room.
+            #
+            # This is considered a safety net to avoid any leakages by the bridge to
+            # unconnected users, but given it ignores all IRC messages while users
+            # are still connecting it may be overkill.
+            requireMatrixJoined: false
 
           matrixToIrc:
             # Get a snapshot of all real Matrix users in the room and join all of
@@ -266,6 +273,7 @@ ircService:
             ircToMatrix:
               initial: false
               incremental: false
+              requireMatrixJoined: false
 
         # Should the bridge ignore users which are not considered active on the bridge
         # during startup
@@ -552,6 +560,13 @@ ircService:
     enabled: false
     # The maximum number that can be set for the `lineLimit` configuration option
     # lineLimitMax: 5
+    # Allow matrix admins to disable or require Matrix users to be connected to the
+    # channel before any messages can be bridged. i.e. this is the per room
+    # version of `membershipLists.[].ircToMatrix.requireMatrixJoined`.
+    # 
+    # If this is true, configuration in the room state will take priority over
+    # the configuration in the config file.
+    # allowUnconnectedMatrixUsers: true
 
 # Options here are generally only applicable to large-scale bridges and may have
 # consequences greater than other options in this configuration file.

--- a/config.schema.yml
+++ b/config.schema.yml
@@ -139,6 +139,15 @@ properties:
                 additionalProperties:
                     type: "string"
                     enum: ["admin"]
+            perRoomConfig:
+                type: "object"
+                properties:
+                    enabled:
+                        type: "boolean"
+                    lineLimitMax:
+                        type: "number"
+                    allowUnconnectedMatrixUsers:
+                        type: "boolean"
             servers:
                 type: "object"
                 # all properties must follow the following
@@ -244,6 +253,8 @@ properties:
                                                     type: "boolean"
                                                 incremental:
                                                     type: "boolean"
+                                                requireMatrixJoined:
+                                                    type: "boolean"
                                         matrixToIrc:
                                             type: "object"
                                             properties:
@@ -282,6 +293,8 @@ properties:
                                                     initial:
                                                         type: "boolean"
                                                     incremental:
+                                                        type: "boolean"
+                                                    requireMatrixJoined:
                                                         type: "boolean"
                                         additionalProperties: false
                         dynamicChannels:

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "escape-string-regexp": "^2.0.0",
     "extend": "^2.0.0",
     "he": "^1.1.1",
-    "matrix-org-irc": "1.0.0-alpha2",
+    "matrix-org-irc": "1.0.0-alpha3",
     "js-yaml": "^3.14.0",
     "logform": "^2.2.0",
     "matrix-appservice": "^0.8.0",

--- a/src/bridge/IrcBridge.ts
+++ b/src/bridge/IrcBridge.ts
@@ -800,6 +800,21 @@ export class IrcBridge {
         await promiseutil.allSettled(promises);
     }
 
+    /**
+     * Get a cached copy of all Matrix (not IRC) users in a room.
+     * @param roomId The Matrix room to inspect.
+     * @returns An array of Matrix userIDs.
+     */
+    public async getMatrixUsersForRoom(roomId: string) {
+        const bot = this.bridge.getBot();
+        let members = this.membershipCache.getMembersForRoom(roomId, "join");
+        if (!members) {
+            members = Object.keys(await this.bridge.getBot().getJoinedMembers(roomId));
+        }
+        return members.filter(m => !bot.isRemoteUser(m));
+
+    }
+
     public async sendMatrixAction(room: MatrixRoom, from: MatrixUser, action: MatrixAction): Promise<void> {
         const intent = this.bridge.getIntent(from.userId);
         const extraContent: Record<string, unknown> = {};

--- a/src/bridge/RoomConfig.ts
+++ b/src/bridge/RoomConfig.ts
@@ -91,4 +91,23 @@ export class RoomConfig {
         }
         return Math.min(roomState.lineLimit, this.config?.lineLimitMax ?? roomState.lineLimit);
     }
+
+    /**
+     * Get the per-room configuration for the paste bin limit for a room.
+     * @param roomId The Matrix roomId
+     * @param ircRoom The IRC roomId. Optional.
+     * @returns Whether unconnected Matrix users are allowed in the room. Will return null if not set.
+     */
+    public async allowUnconnectedMatrixUsers(roomId: string, ircRoom?: IrcRoom) {
+        if (this.config?.allowUnconnectedMatrixUsers !== true) {
+            // If not allowed by config, return null.
+            return null;
+        }
+        const roomState = await this.getRoomState(roomId, ircRoom);
+        if (typeof roomState?.allowUnconnectedMatrixUsers !== "boolean") {
+            // If not set or null, return null.
+            return null;
+        }
+        return roomState.allowUnconnectedMatrixUsers;
+    }
 }

--- a/src/bridge/RoomConfig.ts
+++ b/src/bridge/RoomConfig.ts
@@ -5,11 +5,13 @@ import getLogger from "../logging";
 
 interface RoomConfigContent {
     lineLimit?: number;
+    allowUnconnectedMatrixUsers: boolean|null;
 }
 
 export interface RoomConfigConfig {
     enabled: boolean;
     lineLimitMax?: number;
+    allowUnconnectedMatrixUsers?: boolean;
 }
 
 const MAX_CACHE_SIZE = 512;

--- a/src/irc/IrcServer.ts
+++ b/src/irc/IrcServer.ts
@@ -120,6 +120,7 @@ export interface IrcServerConfig {
             ircToMatrix: {
                 initial: boolean;
                 incremental: boolean;
+                requireMatrixJoined: boolean;
             };
             matrixToIrc: {
                 initial: boolean;
@@ -131,6 +132,7 @@ export interface IrcServerConfig {
             ircToMatrix: {
                 initial: boolean;
                 incremental: boolean;
+                requireMatrixJoined: boolean;
             };
         }[];
         rooms: {
@@ -502,6 +504,23 @@ export class IrcServer {
         return shouldSync;
     }
 
+    /**
+     * Does the server/channel require all Matrix users to be joined.
+     * @param channel The IRC channel.
+     * @returns If the server requires all Matrix users to be joined.
+     */
+    public shouldRequireMatrixUserJoined(channel: string) {
+        let shouldSync = this.config.membershipLists.global.ircToMatrix.requireMatrixJoined;
+        console.log("shouldSync", shouldSync);
+        this.config.membershipLists.channels.forEach((chan) => {
+            if (chan.channel === channel && typeof chan.ircToMatrix?.requireMatrixJoined === "boolean") {
+                shouldSync = chan.ircToMatrix.requireMatrixJoined;
+            }
+            console.log("shouldSync", chan);
+        });
+        return shouldSync;
+    }
+
     public shouldJoinChannelsIfNoUsers() {
         return this.config.botConfig.joinChannelsIfNoUsers;
     }
@@ -711,7 +730,8 @@ export class IrcServer {
                 global: {
                     ircToMatrix: {
                         initial: false,
-                        incremental: false
+                        incremental: false,
+                        requireMatrixJoined: false,
                     },
                     matrixToIrc: {
                         initial: false,


### PR DESCRIPTION
Fixes #1332 

This feature will block IRC messages from appearing across the bridge if a Matrix user isn't connected to the IRC side. It's considered a tool of last resort by the bridge to ensure no history is leaked, as in theory the bridge should be vigilantly kicking users who cannot get connected.

This setting can be enforced on or off at a global level, and at a per-channel level. Optionally, bridge admins can also allow moderators of Matrix rooms to disable this setting at their own risk.