### PR TITLE
Allow a longer username to be specified in the admin room

### DIFF
--- a/changelog.d/1345.bugfix
+++ b/changelog.d/1345.bugfix
@@ -1,0 +1,1 @@
+Fix an issue where the IRC username was incorrectly required to be 10 characters or less.

--- a/src/bridge/AdminRoomHandler.ts
+++ b/src/bridge/AdminRoomHandler.ts
@@ -30,6 +30,9 @@ import { IdentGenerator } from "../irc/IdentGenerator";
 
 const log = logging("AdminRoomHandler");
 
+// This is just a length to avoid silly long usernames
+const SANE_USERNAME_LENGTH = 64;
+
 const COMMANDS: {[command: string]: {example: string; summary: string; requiresPermission?: string}} = {
     "!join": {
         example: `!join [irc.example.net] #channel [key]`,
@@ -471,10 +474,10 @@ export class AdminRoomHandler {
                     "or '!username irc.server.name username'\n"
                 );
             }
-            else if (username.length > IdentGenerator.MAX_USER_NAME_LENGTH) {
+            else if (username.length > SANE_USERNAME_LENGTH) {
                 notice = new MatrixAction(
                     "notice",
-                    `Username is longer than the maximum permitted by IRC (${IdentGenerator.MAX_USER_NAME_LENGTH}).`
+                    `Username is longer than the maximum permitted by the bridge (${SANE_USERNAME_LENGTH}).`
                 );
             }
             else if (IdentGenerator.sanitiseUsername(username) !== username) {

--- a/src/irc/IdentGenerator.ts
+++ b/src/irc/IdentGenerator.ts
@@ -87,10 +87,8 @@ export class IdentGenerator {
                     ircClientConfig.getUsername(), matrixUser.getId(), ircClientConfig.getDomain()
                 );
                 return {
-                    username:IdentGenerator.sanitiseUsername(username).substring(
-                        0, IdentGenerator.MAX_USER_NAME_LENGTH
-                    ),
-                    realname: realname,
+                    username,
+                    realname,
                 };
             }
             try {


### PR DESCRIPTION
As the username can be longer for SASL but will be truncated by the IRCd, which is fine and expected.