### PR TITLE
Merge libera develop changes back in

### DIFF
--- a/changelog.d/1368.misc
+++ b/changelog.d/1368.misc
@@ -1,0 +1,1 @@
+Improve blocked room feature, and add metrics to track.

--- a/src/bridge/IrcBridge.ts
+++ b/src/bridge/IrcBridge.ts
@@ -812,13 +812,10 @@ export class IrcBridge {
      * @returns An array of Matrix userIDs.
      */
     public async getMatrixUsersForRoom(roomId: string) {
+        // TODO: This needs caching.
         const bot = this.bridge.getBot();
-        let members = this.membershipCache.getMembersForRoom(roomId, "join");
-        if (!members) {
-            members = Object.keys(await this.bridge.getBot().getJoinedMembers(roomId));
-        }
+        const members = Object.keys(await this.bridge.getBot().getJoinedMembers(roomId));
         return members.filter(m => !bot.isRemoteUser(m));
-
     }
 
     public async sendMatrixAction(room: MatrixRoom, from: MatrixUser, action: MatrixAction): Promise<void> {
@@ -857,6 +854,31 @@ export class IrcBridge {
             return;
         }
         throw Error("Unknown action: " + action.type);
+    }
+
+    public async syncMembersInRoomToIrc(roomId: string, ircRoom: IrcRoom) {
+        const bot = this.getAppServiceBridge().getBot();
+        const members = await bot.getJoinedMembers(roomId);
+        log.info(
+            `Syncing Matrix users to ${ircRoom.server.domain} ${ircRoom.channel} (${Object.keys(members).length})`
+        );
+        for (const [userId, {display_name}] of Object.entries(members)) {
+            try {
+                if (bot.isRemoteUser(userId)) {
+                    // Don't bridge remote.
+                    continue;
+                }
+                const client = await this.getClientPool().getBridgedClient(ircRoom.server, userId, display_name);
+                if (client.inChannel(ircRoom.channel)) {
+                    continue;
+                }
+                await client.joinChannel(ircRoom.channel);
+                await new Promise(r => setTimeout(r, ircRoom.server.getMemberListFloodDelayMs()));
+            }
+            catch (ex) {
+                log.warn(`Failed to sync ${userId} to IRC channel`);
+            }
+        }
     }
 
     public uploadTextFile(fileName: string, plaintext: string) {

--- a/src/bridge/IrcBridge.ts
+++ b/src/bridge/IrcBridge.ts
@@ -372,6 +372,12 @@ export class IrcBridge {
             labels: ["method"]
         });
 
+        const ircHandlerBlockedRooms = metrics.addGauge({
+            name: "irchandler_blocked_rooms",
+            help: "Track number of blocked rooms",
+            labels: ["method"]
+        });
+
         const matrixHandlerConnFailureKicks = metrics.addCounter({
             name: "matrixhandler_connection_failure_kicks",
             help: "Track IRC connection failures resulting in kicks",
@@ -436,7 +442,7 @@ export class IrcBridge {
                     this.memberListSyncers[server].getUsersWaitingToJoin()
                 );
             });
-
+            ircHandlerBlockedRooms.set(this.ircHandler.blockedRoomCount);
             const ircMetrics = this.ircHandler.getMetrics();
             Object.entries(ircMetrics).forEach((kv) => {
                 ircHandlerCalls.inc({method: kv[0]}, kv[1]);

--- a/src/bridge/IrcHandler.ts
+++ b/src/bridge/IrcHandler.ts
@@ -513,15 +513,16 @@ export class IrcHandler {
      * @returns A promise, but it will always resolve.
      */
     private async setBlockedStateInRoom(req: BridgeRequest, roomId: string, ircRoom: IrcRoom, blocked: boolean) {
-        if (this.roomBlockedSet.has(ircRoom.getId()) === blocked) {
+        const key = roomId + ircRoom.getId();
+        if (this.roomBlockedSet.has(key) === blocked) {
             return;
         }
         if (blocked) {
-            this.roomBlockedSet.add(ircRoom.getId());
+            this.roomBlockedSet.add(key);
             req.log.warn(`${roomId} ${ircRoom.getId()} is now blocking IRC messages`);
         }
         else {
-            this.roomBlockedSet.delete(ircRoom.getId());
+            this.roomBlockedSet.delete(key);
             req.log.warn(`${roomId} ${ircRoom.getId()} has now unblocked IRC messages`);
         }
         try {

--- a/src/bridge/IrcHandler.ts
+++ b/src/bridge/IrcHandler.ts
@@ -91,6 +91,10 @@ export class IrcHandler {
         this.getMetrics();
     }
 
+    public get blockedRoomCount() {
+        return this.roomBlockedSet.size;
+    }
+
     public onMatrixMemberEvent(event: {room_id: string; state_key: string; content: {membership: MatrixMembership}}) {
         const priv = this.roomIdToPrivateMember[event.room_id];
         if (!priv) {


### PR DESCRIPTION
This PR attempts to bring `develop` up to speed with the changes on `develop-26-05-21-libera`.

Notably:
- We have a metric for blocked rooms
- We don't cache the member list at the moment for the room blocking feature
- Various fixes to the blocked room code.