### PR TITLE
Hs/improve blocking

### DIFF
--- a/changelog.d/1368.misc
+++ b/changelog.d/1368.misc
@@ -1,1 +1,0 @@
-Improve blocked room feature, and add metrics to track.

--- a/changelog.d/1368.misc
+++ b/changelog.d/1368.misc
@@ -1,0 +1,1 @@
+Improve blocked room feature, and add metrics to track.

--- a/changelog.d/1369.misc
+++ b/changelog.d/1369.misc
@@ -1,0 +1,1 @@
+Improve blocked room feature (such as kicking users who cannot get connected to the channel), and add metrics to track.

--- a/src/bridge/IrcBridge.ts
+++ b/src/bridge/IrcBridge.ts
@@ -375,9 +375,9 @@ export class IrcBridge {
             labels: ["method"]
         });
 
-        const ircHandlerBlockedRooms = metrics.addGauge({
-            name: "irchandler_blocked_rooms",
-            help: "Track number of blocked rooms",
+        const ircBlockedRooms = metrics.addGauge({
+            name: "irc_blocked_rooms",
+            help: "Track number of blocked rooms for I->M traffic",
             labels: ["method"]
         });
 
@@ -445,7 +445,7 @@ export class IrcBridge {
                     this.memberListSyncers[server].getUsersWaitingToJoin()
                 );
             });
-            ircHandlerBlockedRooms.set(this.ircHandler.blockedRoomCount);
+            ircBlockedRooms.set(this.privacyProtection.blockedRoomCount);
             const ircMetrics = this.ircHandler.getMetrics();
             Object.entries(ircMetrics).forEach((kv) => {
                 ircHandlerCalls.inc({method: kv[0]}, kv[1]);

--- a/src/bridge/IrcBridge.ts
+++ b/src/bridge/IrcBridge.ts
@@ -812,13 +812,10 @@ export class IrcBridge {
      * @returns An array of Matrix userIDs.
      */
     public async getMatrixUsersForRoom(roomId: string) {
+        // TODO: This needs caching.
         const bot = this.bridge.getBot();
-        let members = this.membershipCache.getMembersForRoom(roomId, "join");
-        if (!members) {
-            members = Object.keys(await this.bridge.getBot().getJoinedMembers(roomId));
-        }
+        const members = Object.keys(await this.bridge.getBot().getJoinedMembers(roomId));
         return members.filter(m => !bot.isRemoteUser(m));
-
     }
 
     public async sendMatrixAction(room: MatrixRoom, from: MatrixUser, action: MatrixAction): Promise<void> {
@@ -857,6 +854,31 @@ export class IrcBridge {
             return;
         }
         throw Error("Unknown action: " + action.type);
+    }
+
+    public async syncMembersInRoomToIrc(roomId: string, ircRoom: IrcRoom) {
+        const bot = this.getAppServiceBridge().getBot();
+        const members = await bot.getJoinedMembers(roomId);
+        log.info(
+            `Syncing Matrix users to ${ircRoom.server.domain} ${ircRoom.channel} (${Object.keys(members).length})`
+        );
+        for (const [userId, {display_name}] of Object.entries(members)) {
+            try {
+                if (bot.isRemoteUser(userId)) {
+                    // Don't bridge remote.
+                    continue;
+                }
+                const client = await this.getClientPool().getBridgedClient(ircRoom.server, userId, display_name);
+                if (client.inChannel(ircRoom.channel)) {
+                    continue;
+                }
+                await client.joinChannel(ircRoom.channel);
+                await new Promise(r => setTimeout(r, ircRoom.server.getMemberListFloodDelayMs()));
+            }
+            catch (ex) {
+                log.warn(`Failed to sync ${userId} to IRC channel`);
+            }
+        }
     }
 
     public uploadTextFile(fileName: string, plaintext: string) {

--- a/src/bridge/IrcBridge.ts
+++ b/src/bridge/IrcBridge.ts
@@ -372,6 +372,12 @@ export class IrcBridge {
             labels: ["method"]
         });
 
+        const ircHandlerBlockedRooms = metrics.addGauge({
+            name: "irchandler_blocked_rooms",
+            help: "Track number of blocked rooms",
+            labels: ["method"]
+        });
+
         const matrixHandlerConnFailureKicks = metrics.addCounter({
             name: "matrixhandler_connection_failure_kicks",
             help: "Track IRC connection failures resulting in kicks",
@@ -436,7 +442,7 @@ export class IrcBridge {
                     this.memberListSyncers[server].getUsersWaitingToJoin()
                 );
             });
-
+            ircHandlerBlockedRooms.set(this.ircHandler.blockedRoomCount);
             const ircMetrics = this.ircHandler.getMetrics();
             Object.entries(ircMetrics).forEach((kv) => {
                 ircHandlerCalls.inc({method: kv[0]}, kv[1]);

--- a/src/bridge/IrcHandler.ts
+++ b/src/bridge/IrcHandler.ts
@@ -513,15 +513,16 @@ export class IrcHandler {
      * @returns A promise, but it will always resolve.
      */
     private async setBlockedStateInRoom(req: BridgeRequest, roomId: string, ircRoom: IrcRoom, blocked: boolean) {
-        if (this.roomBlockedSet.has(ircRoom.getId()) === blocked) {
+        const key = roomId + ircRoom.getId();
+        if (this.roomBlockedSet.has(key) === blocked) {
             return;
         }
         if (blocked) {
-            this.roomBlockedSet.add(ircRoom.getId());
+            this.roomBlockedSet.add(key);
             req.log.warn(`${roomId} ${ircRoom.getId()} is now blocking IRC messages`);
         }
         else {
-            this.roomBlockedSet.delete(ircRoom.getId());
+            this.roomBlockedSet.delete(key);
             req.log.warn(`${roomId} ${ircRoom.getId()} has now unblocked IRC messages`);
         }
         try {

--- a/src/bridge/IrcHandler.ts
+++ b/src/bridge/IrcHandler.ts
@@ -91,6 +91,10 @@ export class IrcHandler {
         this.getMetrics();
     }
 
+    public get blockedRoomCount() {
+        return this.roomBlockedSet.size;
+    }
+
     public onMatrixMemberEvent(event: {room_id: string; state_key: string; content: {membership: MatrixMembership}}) {
         const priv = this.roomIdToPrivateMember[event.room_id];
         if (!priv) {

--- a/src/bridge/IrcHandler.ts
+++ b/src/bridge/IrcHandler.ts
@@ -14,6 +14,7 @@ import { RoomOrigin } from "../datastore/DataStore";
 import QuickLRU from "quick-lru";
 import { IrcMessage } from "../irc/ConnectionInstance";
 import { trackChannelAndCreateRoom } from "../bridge/RoomCreation";
+import { PrivacyProtection } from "../irc/PrivacyProtection";
 const NICK_USERID_CACHE_MAX = 512;
 const PM_POWERLEVEL_MATRIXUSER = 10;
 const PM_POWERLEVEL_IRCUSER = 100;
@@ -85,7 +86,8 @@ export class IrcHandler {
     constructor (
         private readonly ircBridge: IrcBridge,
         config: IrcHandlerConfig = {},
-        private readonly membershipQueue: MembershipQueue) {
+        private readonly membershipQueue: MembershipQueue,
+        private readonly privacyProtection: PrivacyProtection,) {
         this.roomAccessSyncer = new RoomAccessSyncer(ircBridge);
         this.mentionMode = config.mapIrcMentionsToMatrix || "on";
         this.getMetrics();
@@ -456,89 +458,6 @@ export class IrcHandler {
     }
 
     /**
-     * If configured, check to see if the all Matrix users in a given room are
-     * joined to a channel. If they are not, drop the message.
-     * @param req The IRC request
-     * @param server The IRC server.
-     */
-    private async shouldRequireMatrixUserJoined(server: IrcServer, channel: string, roomId: string): Promise<boolean> {
-        // The room state takes priority.
-        const stateRequires =
-            await this.ircBridge.roomConfigs.allowUnconnectedMatrixUsers(roomId, new IrcRoom(server, channel));
-        if (stateRequires !== null) {
-            return stateRequires;
-        }
-        return server.shouldRequireMatrixUserJoined(channel);
-    }
-
-    /**
-     * See if every joined Matrix user is also joined to the IRC channel. If they are not,
-     * this returns false. A seperate mechanism should be use to join the user if this fails.
-     * @param req The IRC request
-     * @param server The IRC server
-     * @param channel The IRC channel
-     * @param roomId The Matrix room
-     * @returns True if all users are connected and joined, or false otherwise.
-     */
-    private async areAllMatrixUsersJoined(
-        req: BridgeRequest, server: IrcServer, channel: string, roomId: string): Promise<boolean> {
-        // Look for all the Matrix users in the room.
-        const members = await this.ircBridge.getMatrixUsersForRoom(roomId);
-        const pool = this.ircBridge.getClientPool();
-        for (const userId of members) {
-            if (userId === this.ircBridge.appServiceUserId) {
-                continue;
-            }
-            const client = pool.getBridgedClientByUserId(server, userId);
-            if (!client) {
-                req.log.warn(`${userId} has not connected to IRC yet, not bridging message`);
-                return false;
-            }
-            if (!client.inChannel(channel)) {
-                // TODO: Should we poke them into joining?
-                req.log.warn(`${userId} has not joined the channel yet, not bridging message`);
-                return false;
-            }
-        }
-        return true;
-    }
-
-    /**
-     * Send a `org.matrix.appservice-irc.connection` state event into the room when a channel
-     * is blocked or unblocked. Subsequent calls with the same state will no-op.
-     * @param req The IRC request
-     * @param roomId The Matrix room
-     * @param channel The IRC room
-     * @param blocked Is the channel blocked
-     * @returns A promise, but it will always resolve.
-     */
-    private async setBlockedStateInRoom(req: BridgeRequest, roomId: string, ircRoom: IrcRoom, blocked: boolean) {
-        const key = roomId + ircRoom.getId();
-        if (this.roomBlockedSet.has(key) === blocked) {
-            return;
-        }
-        if (blocked) {
-            this.roomBlockedSet.add(key);
-            req.log.warn(`${roomId} ${ircRoom.getId()} is now blocking IRC messages`);
-        }
-        else {
-            this.roomBlockedSet.delete(key);
-            req.log.warn(`${roomId} ${ircRoom.getId()} has now unblocked IRC messages`);
-        }
-        try {
-            const intent = this.ircBridge.getAppServiceBridge().getIntent();
-            // This is set *approximately* for when the room is unblocked, as we don't do when a new user joins.
-            await intent.sendStateEvent(roomId, "org.matrix.appservice-irc.connection", ircRoom.getId(), {
-                blocked,
-            });
-        }
-        catch (ex) {
-            req.log.warn(`Could not set org.matrix.appservice-irc.connection in room`, ex);
-        }
-    }
-
-
-    /**
      * Called when the AS receives an IRC topic event.
      * @param {IrcServer} server The sending IRC server.
      * @param {IrcUser} fromUser The sender.
@@ -624,21 +543,7 @@ export class IrcHandler {
 
         // Some setups require that we check all matrix users are joined before we bridge
         // messages.
-        const matrixRooms = await Promise.all((
-            await this.ircBridge.getStore().getMatrixRoomsForChannel(server, channel)
-        ).filter(async (room) => {
-            const required = await this.shouldRequireMatrixUserJoined(server, channel, room.roomId);
-            req.log.debug(`${room.roomId} ${required ? "requires" : "does not require"} Matrix users to be joined`);
-            if (!required) {
-                return true;
-            }
-            const allowed = await this.areAllMatrixUsersJoined(req, server, channel, room.roomId);
-            // Do so asyncronously, as we don't want to block message handling on this.
-            this.setBlockedStateInRoom(req, room.roomId, new IrcRoom(server, channel), !allowed);
-            return allowed;
-        }));
-
-
+        const matrixRooms = await this.privacyProtection.getSafeRooms(req, server, channel);
         if (matrixRooms.length === 0) {
             req.log.info(
                 "No mapped matrix rooms for IRC channel %s",

--- a/src/bridge/IrcHandler.ts
+++ b/src/bridge/IrcHandler.ts
@@ -76,8 +76,6 @@ export class IrcHandler {
 
     public readonly roomAccessSyncer: RoomAccessSyncer;
 
-    private readonly roomBlockedSet = new Set<string>();
-
     private callCountMetrics?: {
         [key in MetricNames]: number;
     };
@@ -91,10 +89,6 @@ export class IrcHandler {
         this.roomAccessSyncer = new RoomAccessSyncer(ircBridge);
         this.mentionMode = config.mapIrcMentionsToMatrix || "on";
         this.getMetrics();
-    }
-
-    public get blockedRoomCount() {
-        return this.roomBlockedSet.size;
     }
 
     public onMatrixMemberEvent(event: {room_id: string; state_key: string; content: {membership: MatrixMembership}}) {

--- a/src/irc/BridgedClient.ts
+++ b/src/irc/BridgedClient.ts
@@ -952,7 +952,7 @@ export class BridgedClient extends EventEmitter {
             const failCodes = [
                 "err_nosuchchannel", "err_toomanychannels", "err_channelisfull",
                 "err_inviteonlychan", "err_bannedfromchan", "err_badchannelkey",
-                "err_needreggednick"
+                "err_needreggednick", "err_useronchannel"
             ];
             this.log.error("Join channel %s : %s", channel, JSON.stringify(err));
             if (err.command && failCodes.includes(err.command) && err.args.includes(channel)) {

--- a/src/irc/BridgedClient.ts
+++ b/src/irc/BridgedClient.ts
@@ -948,14 +948,21 @@ export class BridgedClient extends EventEmitter {
         const client = this.state.client;
         // listen for failures to join a channel (e.g. +i, +k)
         const failFn = (err: IrcMessage) => {
-            if (!err || !err.args) { return; }
+            if (!err || !err.args || !err.args.includes(channel)) { return; }
             const failCodes = [
                 "err_nosuchchannel", "err_toomanychannels", "err_channelisfull",
                 "err_inviteonlychan", "err_bannedfromchan", "err_badchannelkey",
-                "err_needreggednick", "err_useronchannel"
+                "err_needreggednick",
             ];
             this.log.error("Join channel %s : %s", channel, JSON.stringify(err));
-            if (err.command && failCodes.includes(err.command) && err.args.includes(channel)) {
+            if (err.command === "err_useronchannel") {
+                // This error happens when a client is joined to the channel
+                this.log.info("Discovered already joined to channel %s", channel);
+                client.removeListener("error", failFn);
+                this.addChannel(channel);
+                defer.resolve(new IrcRoom(this.server, channel));
+            }
+            else if (err.command && failCodes.includes(err.command)) {
                 this.log.error("Cannot track channel %s: %s", channel, err.command);
                 client.removeListener("error", failFn);
                 defer.reject(new Error(err.command));
@@ -965,7 +972,7 @@ export class BridgedClient extends EventEmitter {
                 );
             }
         }
-        client.once("error", failFn);
+        client.on("error", failFn);
 
         // add a timeout to try joining again
         setTimeout(() => {

--- a/src/irc/PrivacyProtection.ts
+++ b/src/irc/PrivacyProtection.ts
@@ -1,0 +1,155 @@
+import { MatrixRoom } from "matrix-appservice-bridge";
+import { IrcBridge } from "../bridge/IrcBridge";
+import { BridgeRequest } from "../models/BridgeRequest";
+import { IrcRoom } from "../models/IrcRoom";
+import { IrcServer } from "./IrcServer";
+
+/**
+ * This class manages the visiblity of IRC messages on Matrix. It will check upon each IRC message
+ * that all Matrix users are connected to the channel to avoid messages leaking to the Matrix side.
+ *
+ */
+export class PrivacyProtection {
+    private roomBlockedSet = new Set<string>();
+    private memberListCache = new Map<string, string[]>();
+    constructor(private ircBridge: IrcBridge) {
+
+    }
+
+    /**
+     * Clear the membership cache for a room.
+     * @param roomId The Matrix room ID.
+     */
+    public clearRoomFromCache(roomId: string) {
+        this.memberListCache.delete(roomId);
+    }
+
+    /**
+     * Get a cached copy of all Matrix (not IRC) users in a room.
+     * @param roomId The Matrix room to inspect.
+     * @returns An array of Matrix userIDs.
+     */
+    private async getMatrixUsersForRoom(roomId: string) {
+        let members = this.memberListCache.get(roomId);
+        if (members) {
+            return members;
+        }
+        const bot = this.ircBridge.getAppServiceBridge().getBot();
+        members =
+            Object.keys(await bot.getJoinedMembers(roomId)).filter(m => !bot.isRemoteUser(m));
+        this.memberListCache.set(roomId, members)
+        return members;
+    }
+
+
+    /**
+     * If configured, check to see if the all Matrix users in a given room are
+     * joined to a channel. If they are not, drop the message.
+     * @param req The IRC request
+     * @param server The IRC server.
+     */
+    private async shouldRequireMatrixUserJoined(server: IrcServer, channel: string, roomId: string): Promise<boolean> {
+        // The room state takes priority.
+        const stateRequires =
+            await this.ircBridge.roomConfigs.allowUnconnectedMatrixUsers(roomId, new IrcRoom(server, channel));
+        if (stateRequires !== null) {
+            return stateRequires;
+        }
+        return server.shouldRequireMatrixUserJoined(channel);
+    }
+
+    /**
+     * See if every joined Matrix user is also joined to the IRC channel. If they are not,
+     * this returns false. A seperate mechanism should be use to join the user if this fails.
+     * @param req The IRC request
+     * @param server The IRC server
+     * @param channel The IRC channel
+     * @param roomId The Matrix room
+     * @returns True if all users are connected and joined, or false otherwise.
+     */
+    private async areAllMatrixUsersJoined(
+        req: BridgeRequest, server: IrcServer, channel: string, roomId: string): Promise<boolean> {
+        // Look for all the Matrix users in the room.
+        const members = await this.getMatrixUsersForRoom(roomId);
+        const pool = this.ircBridge.getClientPool();
+        let isMissingUsers = false;
+        for (const userId of members) {
+            if (userId === this.ircBridge.appServiceUserId) {
+                continue;
+            }
+            const client = pool.getBridgedClientByUserId(server, userId);
+            if (!client) {
+                req.log.warn(`${userId} has not connected to IRC yet, not bridging message`);
+                isMissingUsers = true;
+                continue;
+            }
+            if (!client.inChannel(channel)) {
+                req.log.warn(`${userId} has not joined the channel yet, not bridging message`);
+                isMissingUsers = true;
+            }
+        }
+        if (!isMissingUsers) {
+            return true;
+        }
+        // For the missing users, attempt to join them to the channel. Any that fail to join should be kicked.
+        this.ircBridge.syncMembersInRoomToIrc(req, roomId, new IrcRoom(server, channel), true);
+        return false;
+    }
+
+    /**
+     * Send a `org.matrix.appservice-irc.connection` state event into the room when a channel
+     * is blocked or unblocked. Subsequent calls with the same state will no-op.
+     * @param req The IRC request
+     * @param roomId The Matrix room
+     * @param channel The IRC room
+     * @param blocked Is the channel blocked
+     * @returns A promise, but it will always resolve.
+     */
+    private async setBlockedStateInRoom(req: BridgeRequest, roomId: string, ircRoom: IrcRoom, blocked: boolean) {
+        const key = roomId + ircRoom.getId();
+        if (this.roomBlockedSet.has(key) === blocked) {
+            return;
+        }
+        if (blocked) {
+            this.roomBlockedSet.add(key);
+            req.log.warn(`${roomId} ${ircRoom.getId()} is now blocking IRC messages`);
+        }
+        else {
+            this.roomBlockedSet.delete(key);
+            req.log.warn(`${roomId} ${ircRoom.getId()} has now unblocked IRC messages`);
+        }
+        try {
+            const intent = this.ircBridge.getAppServiceBridge().getIntent();
+            // This is set *approximately* for when the room is unblocked, as we don't do when a new user joins.
+            await intent.sendStateEvent(roomId, "org.matrix.appservice-irc.connection", ircRoom.getId(), {
+                blocked,
+            });
+        }
+        catch (ex) {
+            req.log.warn(`Could not set org.matrix.appservice-irc.connection in room`, ex);
+        }
+    }
+
+    /**
+     * Get rooms which are safe to bridge IRC messages to. 
+     * @param req The bridge request
+     * @param server The IRC server
+     * @param channel The IRC channel
+     * @returns An array of Matrix rooms
+     */
+    async getSafeRooms(req: BridgeRequest, server: IrcServer, channel: string): Promise<MatrixRoom[]> {
+        return await Promise.all((
+            await this.ircBridge.getStore().getMatrixRoomsForChannel(server, channel)
+        ).filter(async (room) => {
+            const required = await this.shouldRequireMatrixUserJoined(server, channel, room.roomId);
+            req.log.debug(`${room.roomId} ${required ? "requires" : "does not require"} Matrix users to be joined`);
+            if (!required) {
+                return true;
+            }
+            const allowed = await this.areAllMatrixUsersJoined(req, server, channel, room.roomId);
+            // Do so asyncronously, as we don't want to block message handling on this.
+            this.setBlockedStateInRoom(req, room.roomId, new IrcRoom(server, channel), !allowed);
+            return allowed;
+        }));
+    }
+}

--- a/src/irc/PrivacyProtection.ts
+++ b/src/irc/PrivacyProtection.ts
@@ -16,6 +16,10 @@ export class PrivacyProtection {
 
     }
 
+    public get blockedRoomCount() {
+        return this.roomBlockedSet.size;
+    }
+
     /**
      * Clear the membership cache for a room.
      * @param roomId The Matrix room ID.


### PR DESCRIPTION
This change supersedes #1368.

This PR merges the useful changes made to libera back into the `develop` branch (with the exception of #1339, #1356 which should be merged separately).

This PR adds:
- A metric for tracking which channels are blocked
- Kicking users from rooms when they fail to get connected to a IRC channel.
- Fixes a bug where only the first error would be caught for a IRC join failure, which could cause the join to hang indefinitely.
- Moves the privacy safety net into it's own class
- Adds caching of the member list to speed up slightly
- Handles `err_useronchannel` where we might try to join a channel and be told we are already in it.

