### PR TITLE
Ensure admin room is created with the is_direct flag

### DIFF
--- a/changelog.d/1372.bugfix
+++ b/changelog.d/1372.bugfix
@@ -1,0 +1,1 @@
+Admin rooms are now correctly created as DMs, and only one will be created per-user.

--- a/src/bridge/IrcHandler.ts
+++ b/src/bridge/IrcHandler.ts
@@ -1062,12 +1062,13 @@ export class IrcHandler {
                                     `letting you control the connection. Type !help for more information`
                     const notice = new MatrixAction("notice", newRoomMsg);
                     await this.ircBridge.sendMatrixAction(adminRoom, botUser, notice);
+                    // This is stored now so we can delete the promise.
+                    this.pendingAdminRooms.delete(userId);
                     return adminRoom;
                 })();
                 this.pendingAdminRooms.set(client.userId, adminRoomNewPromise);
                 adminRoom = await adminRoomNewPromise;
             }
-
         }
         else {
             adminRoom = fetchedAdminRoom;

--- a/src/bridge/IrcHandler.ts
+++ b/src/bridge/IrcHandler.ts
@@ -1059,7 +1059,7 @@ export class IrcHandler {
                                     `'${client.server.domain}', where you ` +
                                     `are now connected as ${client.nick}. ` +
                                     `This room shows any errors or status messages from IRC, as well as ` +
-                                    `letting you control the connection. Type !help for more information`
+                                    `letting you control the connection. Type !help for more information.`
                     const notice = new MatrixAction("notice", newRoomMsg);
                     await this.ircBridge.sendMatrixAction(adminRoom, botUser, notice);
                     // This is stored now so we can delete the promise.

--- a/src/bridge/IrcHandler.ts
+++ b/src/bridge/IrcHandler.ts
@@ -1040,6 +1040,7 @@ export class IrcHandler {
                             "the connection. ",
                     preset: "trusted_private_chat",
                     visibility: "private",
+                    is_direct: true,
                     invite: [client.userId]
                 }
             });

--- a/src/bridge/IrcHandler.ts
+++ b/src/bridge/IrcHandler.ts
@@ -1046,7 +1046,7 @@ export class IrcHandler {
                             name: `${client.server.getReadableName()} IRC Bridge status`,
                             topic:  `This room shows any errors or status messages from ` +
                                     `${client.server.domain}, as well as letting you control ` +
-                                    "the connection. ",
+                                    "the connection.",
                             preset: "trusted_private_chat",
                             visibility: "private",
                             is_direct: true,


### PR DESCRIPTION
Fixes #1370 

This:
- Marks the admin room as a DM
- Linearlises the admin room creation code to avoid duplicates