### PR TITLE
Do not attempt to sync membership from a room we can't access

### DIFF
--- a/src/bridge/MemberListSyncer.ts
+++ b/src/bridge/MemberListSyncer.ts
@@ -185,6 +185,10 @@ export class MemberListSyncer {
                     }
                     catch (err) {
                         log.error(`Failed to getJoinedMembers in room ${roomId}: ${err}`);
+                        if (err.data?.errcode === "M_FORBIDDEN") {
+                            // If we're not allowed to, just give up.
+                            return;
+                        }
                         await Bluebird.delay(3000); // wait a bit before retrying
                     }
                 }


### PR DESCRIPTION
If the bridge cannot join a room, it will repeatedly fail to sync the room and cause the membership sync to fail. We should just ignore these in the membership sync stage.