### PR TITLE
Allow passing any secure opts to the IRC connection

### DIFF
--- a/changelog.d/1375.feature
+++ b/changelog.d/1375.feature
@@ -1,0 +1,1 @@
+Add `tlsOptions` key to the config to override the IRC connection parameters.

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -81,11 +81,17 @@ ircService:
       # Whether to allow expired certs when connecting to the IRC server.
       # Usually this should be off. Default: false.
       allowExpiredCerts: false
-      # A specific CA to trust instead of the default CAs. Optional.
-      #ca: |
-      #  -----BEGIN CERTIFICATE-----
-      #  ...
-      #  -----END CERTIFICATE-----
+      # Set additional TLS options for the connections to the IRC server.
+      tlsOptions:
+        # A specific CA to trust instead of the default CAs. Optional.
+        #ca: |
+        #  -----BEGIN CERTIFICATE-----
+        #  ...
+        #  -----END CERTIFICATE-----
+        # Server name for the SNI (Server Name Indication) TLS extension. If the address you
+        # are using does not report the correct certificate name, you can override it here.
+        # servername: real.server.name
+        # ...or any options in https://nodejs.org/api/tls.html#tls_tls_connect_options_callback
 
       #
       # The connection password to send for all clients as a PASS (or SASL, if enabled above) command. Optional.

--- a/config.schema.yml
+++ b/config.schema.yml
@@ -162,6 +162,10 @@ properties:
                                 type: "string"
                         ssl:
                             type: "boolean"
+                        ca:
+                            type: "string"
+                        tlsOptions:
+                            type: "object"
                         sslselfsign:
                             type: "boolean"
                         sasl:

--- a/src/irc/ConnectionInstance.ts
+++ b/src/irc/ConnectionInstance.ts
@@ -381,7 +381,7 @@ export class ConnectionInstance {
             family: (server.getIpv6Prefix() || server.getIpv6Only() ? 6 : null) as 6|null,
             bustRfc3484: true,
             sasl: opts.password ? server.useSasl() : false,
-            secure: server.useSsl() ? { ca: server.getCA() } : undefined,
+            secure: server.useSsl() ? server.getSecureOptions() : undefined,
             encodingFallback: opts.encodingFallback
         };
 

--- a/src/irc/IrcServer.ts
+++ b/src/irc/IrcServer.ts
@@ -34,6 +34,9 @@ export interface IrcServerConfig {
     ssl?: boolean;
     sslselfsign?: boolean;
     sasl?: boolean;
+    tlsOptions?: {
+
+    };
     password?: string;
     allowExpiredCerts?: boolean;
     additionalAddresses?: string[];
@@ -320,8 +323,8 @@ export class IrcServer {
         return this.config.dynamicChannels.whitelist.includes(userId);
     }
 
-    public getCA() {
-        return this.config.ca;
+    public getSecureOptions() {
+        return this.config.tlsOptions;
     }
 
     public useSsl() {
@@ -754,6 +757,15 @@ export class IrcServer {
 
     public reconfigure(config: IrcServerConfig, expiryTimeSeconds = 0) {
         log.info(`Reconfiguring ${this.domain}`);
+
+        if (config.ca) {
+            log.warn("** The IrcServer.ca is now deprecated, please use tlsOptions.ca. **");
+            config.tlsOptions = {
+                ...config.tlsOptions,
+                ca: config.ca,
+            };
+        }
+
         this.config = config;
         this.expiryTimeSeconds = expiryTimeSeconds;
         // This ensures that legacy mappings still work, but we prod the user to update.

--- a/src/irc/IrcServer.ts
+++ b/src/irc/IrcServer.ts
@@ -34,9 +34,7 @@ export interface IrcServerConfig {
     ssl?: boolean;
     sslselfsign?: boolean;
     sasl?: boolean;
-    tlsOptions?: {
-
-    };
+    tlsOptions?: {};
     password?: string;
     allowExpiredCerts?: boolean;
     additionalAddresses?: string[];

--- a/src/irc/IrcServer.ts
+++ b/src/irc/IrcServer.ts
@@ -34,7 +34,7 @@ export interface IrcServerConfig {
     ssl?: boolean;
     sslselfsign?: boolean;
     sasl?: boolean;
-    tlsOptions?: {};
+    tlsOptions?: Record<string, unknown>;
     password?: string;
     allowExpiredCerts?: boolean;
     additionalAddresses?: string[];


### PR DESCRIPTION
Which will allow us to use `servername` to force the correct server address. To avoid some duplication, this PR deprecates the top level `ca` key and instead includes it inside the tlsOptions object.