### PR TITLE
Exclusively allow additional addresses when connecting to IRC

### DIFF
--- a/changelog.d/1376.feature
+++ b/changelog.d/1376.feature
@@ -1,0 +1,1 @@
+Allow only using the `additionalAddresses` field when connecting to IRC.

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -55,8 +55,13 @@ ircService:
       # It is also used in the Third Party Lookup API as the instance `desc`
       # property, where each server is an instance.
       name: "ExampleNet"
-
+      # Additional addresses to connect to, used for load balancing between IRCDs.
       additionalAddresses: [ "irc2.example.com" ]
+      # Typically additionalAddresses would be in addition to the address key given above,
+      # but some configurations wish to exclusively use additional addresses while reserving
+      # the top key for identification purposes. Set this to true to exclusively use the
+      # additionalAddresses array when connecting to servers.
+      onlyAdditionalAddresses: false
       #
       # [DEPRECATED] Use `name`, above, instead.
       # A human-readable description string

--- a/config.schema.yml
+++ b/config.schema.yml
@@ -160,6 +160,8 @@ properties:
                             type: "array"
                             items:
                                 type: "string"
+                        onlyAdditionalAddresses:
+                            type: "boolean"
                         ssl:
                             type: "boolean"
                         sslselfsign:

--- a/src/irc/IrcServer.ts
+++ b/src/irc/IrcServer.ts
@@ -37,6 +37,7 @@ export interface IrcServerConfig {
     password?: string;
     allowExpiredCerts?: boolean;
     additionalAddresses?: string[];
+    onlyAdditionalAddresses?: boolean;
     dynamicChannels: {
         enabled: boolean;
         published: boolean;
@@ -678,6 +679,7 @@ export class IrcServer {
     public static get DEFAULT_CONFIG(): IrcServerConfig {
         return {
             sendConnectionMessages: true,
+            onlyAdditionalAddresses: false,
             quitDebounce: {
                 enabled: false,
                 quitsPerSecond: 5,
@@ -770,7 +772,10 @@ export class IrcServer {
         }
 
         this.addresses = config.additionalAddresses || [];
-        this.addresses.push(this.domain);
+        // Don't include the original domain if not configured to.
+        if (!config.onlyAdditionalAddresses) {
+            this.addresses.push(this.domain);
+        }
         this.excludedUsers = config.excludedUsers.map((excluded) => {
             return {
                 ...excluded,

--- a/src/irc/IrcServer.ts
+++ b/src/irc/IrcServer.ts
@@ -37,7 +37,7 @@ export interface IrcServerConfig {
     password?: string;
     allowExpiredCerts?: boolean;
     additionalAddresses?: string[];
-    onlyAdditionalAddresses?: boolean;
+    onlyAdditionalAddresses: boolean;
     dynamicChannels: {
         enabled: boolean;
         published: boolean;
@@ -775,6 +775,8 @@ export class IrcServer {
         // Don't include the original domain if not configured to.
         if (!config.onlyAdditionalAddresses) {
             this.addresses.push(this.domain);
+        } else if (this.addresses.length === 0) {
+            throw Error("onlyAdditionalAddresses is true, but no additional addresses are provided in the config");
         }
         this.excludedUsers = config.excludedUsers.map((excluded) => {
             return {


### PR DESCRIPTION
This is so that we can connect to `irc.matrix.libera.chat` exclusively while retaining the same config key and name in bridge messages.