### PR TITLE
Inline "err_nononreg" errors for PMing a user

### DIFF
--- a/changelog.d/1380.misc
+++ b/changelog.d/1380.misc
@@ -1,0 +1,1 @@
+Show an error in the PM room when the IRC user has blocked unregistered users from messaging.


### PR DESCRIPTION
When a Matrix user attempts to PM a IRC user and that user has unregistered PMs turned off, the error would propagate to their admin room but not inline in the DM. This basically needs us to add this error type as a inlineable error.