### PR TITLE
Add support for headers in the admin help text

### DIFF
--- a/changelog.d/1381.misc
+++ b/changelog.d/1381.misc
@@ -1,0 +1,1 @@
+Add headers to the admin room help text.


### PR DESCRIPTION
This PR adds headers to the help text to distinguish between commands, since our command list has grown somewhat:

![image](https://user-images.githubusercontent.com/2072976/121348536-61178580-c920-11eb-8d09-2f69b2f0dec0.png)

I've also alphabetically ordered the list as it was bugging @Twi1ightSparkle that we didn't do that :)