### PR TITLE
Await leaving users before removing the bridge bot

### DIFF
--- a/changelog.d/1382.bugfix
+++ b/changelog.d/1382.bugfix
@@ -1,0 +1,1 @@
+Fix a bug where the bridge user would rejoin shortly after unbridging a room.

--- a/src/bridge/MemberListSyncer.ts
+++ b/src/bridge/MemberListSyncer.ts
@@ -433,7 +433,7 @@ export class MemberListSyncer {
 
     public addToLeavePool(userIds: string[], roomId: string) {
         this.usersToLeave += userIds.length;
-        this.leaveUsersInRoom({
+        return this.leaveUsersInRoom({
             roomId,
             userIds
         });

--- a/src/provisioning/Provisioner.ts
+++ b/src/provisioning/Provisioner.ts
@@ -930,10 +930,14 @@ export class Provisioner {
             throw new Error(`Provisioned room mapping does not exist (${mappingLogId})`);
         }
         await this.ircBridge.getStore().removeRoom(roomId, ircDomain, ircChannel, 'provision');
+
         // Leaving rooms should not cause unlink to fail
-        await this.leaveIfUnprovisioned(req, roomId, server, ircChannel).catch((ex) => {
-            req.log.error(`Failed to cleanup after unlinking:`, ex);
-        });
+        try {
+            await this.leaveIfUnprovisioned(req, roomId, server, ircChannel);
+        }
+        catch (err) {
+            req.log.error(`Failed to cleanup after unlinking:`, err);
+        }
     }
 
     // Force the bot to leave both sides of a provisioned mapping if there are no more mappings that


### PR DESCRIPTION
Fixes https://github.com/matrix-org/matrix-appservice-irc/issues/1323

The provisioner unbridges all IRC ghosts from a room and will unset the powerlevels for those users upon a unlink request, while also removing the bridge bot from the room. However, it would not await the removal of the ghost users / PL unset before trying to remove the bot user.
This lead to the bot rejoining the room as it would then try to set the PLs after leaving. Typically this meant a lot of users would find that the bridge bot became wedged in the room forever, meaning they could not then bridge to other networks.

