### PR TITLE
Fix expecting advanced to be defined when hot reloading config

### DIFF
--- a/changelog.d/1383.bugfix
+++ b/changelog.d/1383.bugfix
@@ -1,0 +1,1 @@
+Fix an issue where a hot reload would fail if `advanced` was not defined in the original config.

--- a/src/bridge/IrcBridge.ts
+++ b/src/bridge/IrcBridge.ts
@@ -209,7 +209,7 @@ export class IrcBridge {
 
         this.appservice = new AppService({
             homeserverToken,
-            httpMaxSizeBytes: (this.config.advanced || { }).maxTxnSize || TXN_SIZE_DEFAULT,
+            httpMaxSizeBytes: this.config.advanced?.maxTxnSize ?? TXN_SIZE_DEFAULT,
         });
         this.roomConfigs = new RoomConfig(this.bridge, this.config.ircService.perRoomConfig);
     }
@@ -218,8 +218,8 @@ export class IrcBridge {
         log.info(`Bridge config was reloaded, applying changes`);
         const oldConfig = this.config;
 
-            const maxSockets = (newConfig.advanced || {maxHttpSockets: 1000}).maxHttpSockets;
         if (oldConfig.advanced?.maxHttpSockets !== newConfig.advanced?.maxHttpSockets) {
+            const maxSockets = newConfig.advanced?.maxHttpSockets ?? 1000
             gAHTTP.maxSockets = maxSockets;
             gAHTTPS.maxSockets = maxSockets;
             log.info(`Adjusted max sockets to ${maxSockets}`);

--- a/src/bridge/IrcBridge.ts
+++ b/src/bridge/IrcBridge.ts
@@ -218,8 +218,8 @@ export class IrcBridge {
         log.info(`Bridge config was reloaded, applying changes`);
         const oldConfig = this.config;
 
-        if (oldConfig.advanced.maxHttpSockets !== newConfig.advanced.maxHttpSockets) {
             const maxSockets = (newConfig.advanced || {maxHttpSockets: 1000}).maxHttpSockets;
+        if (oldConfig.advanced?.maxHttpSockets !== newConfig.advanced?.maxHttpSockets) {
             gAHTTP.maxSockets = maxSockets;
             gAHTTPS.maxSockets = maxSockets;
             log.info(`Adjusted max sockets to ${maxSockets}`);

--- a/src/config/BridgeConfig.ts
+++ b/src/config/BridgeConfig.ts
@@ -66,7 +66,7 @@ export interface BridgeConfig {
         environment?: string;
         serverName?: string;
     };
-    advanced: {
+    advanced?: {
         maxHttpSockets: number;
         maxTxnSize?: number;
     };

--- a/src/main.ts
+++ b/src/main.ts
@@ -100,7 +100,7 @@ export async function runBridge(port: number, config: BridgeConfig, reg: AppServ
         ident.run();
     }
 
-    const maxSockets = (config.advanced || {maxHttpSockets: 1000}).maxHttpSockets;
+    const maxSockets = config.advanced?.maxHttpSockets ?? 1000;
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     require("http").globalAgent.maxSockets = maxSockets;
     // eslint-disable-next-line @typescript-eslint/no-var-requires


### PR DESCRIPTION
Fixes an issue where hot reloads would fail if advanced was not defined.