### PR TITLE
Always return empty object when handing secure opts

### DIFF
--- a/changelog.d/1384.bugfix
+++ b/changelog.d/1384.bugfix
@@ -1,0 +1,1 @@
+Fix an issue introduced in 0.27.0-rc1 where the SSL option would not work without also providing a `tlsOptions` value.

--- a/src/irc/IrcServer.ts
+++ b/src/irc/IrcServer.ts
@@ -323,7 +323,8 @@ export class IrcServer {
     }
 
     public getSecureOptions() {
-        return this.config.tlsOptions;
+        // Return undefined here, as a falsy secure opts will disable SSL.
+        return this.config.tlsOptions ?? {};
     }
 
     public useSsl() {

--- a/src/irc/IrcServer.ts
+++ b/src/irc/IrcServer.ts
@@ -323,7 +323,7 @@ export class IrcServer {
     }
 
     public getSecureOptions() {
-        // Return undefined here, as a falsy secure opts will disable SSL.
+        // Return an empty object here if not defined, as a falsy secure opts will disable SSL.
         return this.config.tlsOptions ?? {};
     }
 


### PR DESCRIPTION
Ref #1375 

A falsey value of secureOpts turns off SSL, which is not what we want to be doing and was a breaking behaviour.