### PR TITLE
Handle failures during OPER command

### DIFF
--- a/changelog.d/1385.misc
+++ b/changelog.d/1385.misc
@@ -1,0 +1,2 @@
+Handle known error-codes when OPER command fails instead of disconnecting.
+

--- a/changelog.d/1385.misc
+++ b/changelog.d/1385.misc
@@ -1,2 +1,1 @@
 Handle known error-codes when OPER command fails instead of disconnecting.
-

--- a/src/irc/ConnectionInstance.ts
+++ b/src/irc/ConnectionInstance.ts
@@ -205,7 +205,8 @@ export class ConnectionInstance {
                 "err_banonchan", "err_nickcollision", "err_nicknameinuse",
                 "err_erroneusnickname", "err_nonicknamegiven", "err_eventnickchange",
                 "err_nicktoofast", "err_unknowncommand", "err_unavailresource",
-                "err_umodeunknownflag", "err_nononreg"
+                "err_umodeunknownflag", "err_nononreg",
+                "err_nooperhost", "err_passwdmismatch",
             ];
             if (err && err.command) {
                 if (failCodes.includes(err.command)) {


### PR DESCRIPTION
Issuing the OPER command with either incorrect O-line or wrong password will result in the following error codes being thrown and bridge being disconnected:

- err_nooperhost
- err_passwdmismatch

See attached logs:

````
...
Jun 10 12:00:47 matrix matrix-appservice-irc[3963607]: 2021-06-10 12:00:47 ERROR:client-connection Server: oslo.no.eu.neko-net.org (Nocab) Error: {"args":["Nocab","No O-lines for your host"],"commandType":"error","prefix":"oslo.no.eu.neko-net.org","server":"oslo.no.eu.neko-net.org","command":"err_nooperhost","rawCommand":"491"}
...
Jun 10 12:58:57 matrix matrix-appservice-irc[3963607]: 2021-06-10 12:58:57 ERROR:client-connection Server: oslo.no.eu.neko-net.org (Nocab) Error: {"args":["Nocab","Password Incorrect"],"commandType":"error","prefix":"oslo.no.eu.neko-net.org","server":"oslo.no.eu.neko-net.org","command":"err_passwdmismatch","rawCommand":"464"}
````

Disconnecting a oper trying to do his job is probably not the correct response, so lets add them to the exception-list :)