### PR TITLE
Bump matrix-org-irc to 1.0.0

### DIFF
--- a/changelog.d/1388.bugfix
+++ b/changelog.d/1388.bugfix
@@ -1,0 +1,1 @@
+Update `matrix-org-irc` to `1.0.0` to fix a bug where the bridge can crash.

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "matrix-appservice": "^0.8.0",
     "matrix-appservice-bridge": "^2.6.1",
     "matrix-lastactive": "^0.1.5",
-    "matrix-org-irc": "1.0.0-alpha4",
+    "matrix-org-irc": "1.0.0",
     "nedb": "^1.1.2",
     "nodemon": "^2.0.7",
     "nopt": "^3.0.1",


### PR DESCRIPTION
This fixes a bug which can cause the bridge to crash (https://github.com/matrix-org/node-irc/pull/69) so we will need it for RC3.