### PR TITLE
Fix IRC channel joins never completing.

### DIFF
--- a/changelog.d/1394.bugfix
+++ b/changelog.d/1394.bugfix
@@ -1,0 +1,1 @@
+Fix an issue where a Matrix user's IRC connection is stuck and unable to join some channels.

--- a/package-lock.json
+++ b/package-lock.json
@@ -3146,9 +3146,9 @@
       }
     },
     "matrix-org-irc": {
-      "version": "1.0.0-alpha4",
-      "resolved": "https://registry.npmjs.org/matrix-org-irc/-/matrix-org-irc-1.0.0-alpha4.tgz",
-      "integrity": "sha512-2wKzQSpITrG9vChfw9d0goDcQZgKdaL7hgPzQwaybO9NF96HLarXFhznaFtngJiaaBAN52jkEetsQKV/lEfPqA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/matrix-org-irc/-/matrix-org-irc-1.0.0.tgz",
+      "integrity": "sha512-DZO/yx7KoNfjOvm4ln9VzXBKwKpBCcLvC2vTphDzvq+qx/EXxbAqOi4Rs+F6hguxkKYe3DNT3MQFg3TldXU6TQ==",
       "requires": {
         "chardet": "^1.3.0",
         "iconv-lite": "^0.6.2",

--- a/src/irc/BridgedClient.ts
+++ b/src/irc/BridgedClient.ts
@@ -957,6 +957,7 @@ export class BridgedClient extends EventEmitter {
         const failTimeout = setTimeout(() => {
             if (!defer.promise.isPending()) {
                 // We either failed or completed this action, so do not do anything.
+                return;
             }
             if (this.state.status !== BridgedClientStatus.CONNECTED) {
                 // We would have expected this to fail above but for typing purposes

--- a/src/irc/BridgedClient.ts
+++ b/src/irc/BridgedClient.ts
@@ -1027,7 +1027,7 @@ export class BridgedClient extends EventEmitter {
                     this, `Could not join ${channel} on '${this.server.domain}': ${err.command}`, true
                 );
             }
-            // Otherwise, not a failure we recognise. This will eventually timeout.
+            // Otherwise, not a failure we recognise. This will eventually time out.
         }
         client.on("error", failFn);
 


### PR DESCRIPTION
Previously, it was possible for `_joinChannel` to never resolve/reject the promise if the join timed out. This was introduced in one of our PRs that changed how we handled deferred joins. This should hopefully fix the issue where we can have users who are unable to connect to channels.