### PR TITLE
Add an in-tree documentation link to the !help command

### DIFF
--- a/changelog.d/1402.misc
+++ b/changelog.d/1402.misc
@@ -1,0 +1,1 @@
+Add a link referring to the in-tree documentation to the admin room help text.

--- a/src/bridge/AdminRoomHandler.ts
+++ b/src/bridge/AdminRoomHandler.ts
@@ -723,7 +723,10 @@ export class AdminRoomHandler {
 
     private showHelp(userPermission: string|undefined): MatrixAction {
         let body = "This is an IRC admin room for controlling your IRC connection and sending " +
-        "commands directly to IRC. The following commands are available:<br/><ul>";
+        "commands directly to IRC.<br/>" +
+        "See the <a href=\"https://matrix-org.github.io/matrix-appservice-irc/latest/usage.html\">" +
+        "Matrix IRC Bridge Usage Guide</a> on how to control the IRC bridge using this room.<br/>" +
+        "The following commands are available:<br/><ul>";
         for (const [key, command] of Object.entries(COMMANDS)) {
             if ("heading" in command) {
                 body += `</ul>\n<h3>${key}</h3>\n<ul>`;


### PR DESCRIPTION
This may be a seen as an alternative fix for #1361.

This is a  drive-through contribution / my first interaction with this repository and I do not know (yet?) how to test the actual formatting created by this code. In case it is wrong please let me know.