### PR TITLE
Fix typo in registration documentation

### DIFF
--- a/changelog.d/1405.doc
+++ b/changelog.d/1405.doc
@@ -1,0 +1,2 @@
+Fix typo regarding examples of hostname and port in Bridge Setup documentation (4. Registration)
+

--- a/docs/bridge_setup.md
+++ b/docs/bridge_setup.md
@@ -78,10 +78,10 @@ homeserver which Matrix events the bridge should receive.
 Execute the following command:
 
 ```
-node app.js -r -f appservice-registration-irc.yaml -u "http://where.the.appservice.listens:9999" -c config.yaml -l my_bot
+node app.js -r -f appservice-registration-irc.yaml -u "http://localhost:9999" -c config.yaml -l my_bot
 ```
 
-Change `-u "http://localhost:8090"` to whereever your Matrix server can contact this IRC bridge.
+Change `-u "http://localhost:9999"` to whereever your Matrix server can contact this IRC bridge.
 By changing the option `-l my_bot` you can modify the localpart of the bridge bot user. It contacts
 Matrix users of your bridge to control their usage of the bridge (e.g. to change their nickname).
 


### PR DESCRIPTION
The text was referring to something other than the previous command, and this change attempts to fix the text and the command to make more sense in context.

From the context of the sample output, I'm guessing that it should be `http://localhost:9999`, but I cannot really know. Since I don't know the real answer here (just trying to follow instructions and noticed issues), please think about what would make most sense and change it accordingly. :)