### PR TITLE
Docs: migrate list of bridges from wiki, add libera.chat

### DIFF
--- a/changelog.d/1416.doc
+++ b/changelog.d/1416.doc
@@ -1,0 +1,3 @@
+Migrate the list of bridged IRC networks from the deprecated github wiki to the hosted documentation (https://matrix-org.github.io/matrix-appservice-irc/latest/).
+
+Add libera.chat to the list.

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -6,6 +6,7 @@
   - [Room Commands](./room_commands.md)
   - [Room Configuration](./room_configuration.md)
   - [IRC Modes](./irc_modes.md)
+- [Bridged Networks](./bridged_networks.md)
 - [Setup](./bridge_setup.md)
 - [Administrators Guide](./administrators_guide.md)
 - [IRC Operators](./irc_operators.md)

--- a/docs/bridged_networks.md
+++ b/docs/bridged_networks.md
@@ -85,6 +85,13 @@ A wishlist of IRC networks to be bridged is being collected [in a github issue](
         <td>#irc:matrix.org</td>
         <td>Matrix.org</td>
     </tr>
+    <tr>
+        <td>libera.chat</td>
+        <td>#channame:libera.chat</td>
+        <td>@appservice:libera.chat</td>
+        <td>#libera-matrix:libera.chat</td>
+        <td>Matrix.org</td>
+    </tr>
 </table>
 
 ### Footnotes

--- a/docs/bridged_networks.md
+++ b/docs/bridged_networks.md
@@ -1,108 +1,57 @@
 A wishlist of IRC networks to be bridged is being collected [in a github issue](https://github.com/matrix-org/matrix-appservice-irc/issues/208).
 
-<table>
-    <tr>
-        <th>Network Name</th>
-        <th>Room alias format</th>
-        <th>Appservice user</th>
-        <th>Room for Support</th>
-        <th>Operator</th>
-    </tr>
-    <tr>
-        <td>darkfasel</td>
-        <td>#channame:darkfasel.net</td>
-        <td>@IRC-Darkfasel:darkfasel.net</td>
-        <td>#darkfasel:darkfasel.net</td>
-        <td>darkfasel</td>
-    </tr>
-    <tr>
-        <td>fc00</td>
-        <td>#fc00-irc_#channame:m.trnsz.com</td>
-        <td>@fc00ircmtx:m.trnsz.com</td>
-        <td>None</td>
-        <td></td>
-    </tr>
-    <tr>
-        <td>freenode<a href="#user-content-foot1"><sup>[1]</sup></a></td>
-        <td>#freenode_#channame:matrix.org</td>
-        <td>@appservice-irc:matrix.org<a href="#user-content-foot2"><sup>[2]</sup></a></td>
-        <td>#irc:matrix.org</td>
-        <td>Matrix.org</td>
-    </tr>
-    <tr>
-        <td>GIMPNet<a href="#user-content-foot3"><sup>[3]</sup></a></td>
-        <td>#_gimpnet_#channame:gnome.org</td>
-        <td>@gimpnet-irc:gnome.org<a href="#user-content-foot4"><sup>[4]</sup></a></td>
-        <td>#irc:matrix.org</td>
-        <td>Matrix.org / Gnome.org </td>
-    </tr>
-    <tr>
-        <td>IRCnet</td>
-        <td>#_ircnet_#channame:irc.snt.utwente.nl</td>
-        <td>@ircnet:irc.snt.utwente.nl</td>
-        <td>#ircnet:utwente.io</td>
-        <td>SNT</td>
-    </tr>
-    <tr>
-        <td>OFTC</td>
-        <td>#_oftc_#channame:matrix.org</td>
-        <td>@oftc-irc:matrix.org</td>
-        <td>#irc:matrix.org</td>
-        <td>Matrix.org</td>
-    </tr>
-    <tr>
-        <td>PirateIRC</td>
-        <td>#pirateirc_#channame:diasp.in</td>
-        <td>@pirateirc:diasp.in</td>
-        <td>#diasp.in:diasp.in</td>
-        <td>Indian Pirates</td>
-    </tr>
-    <tr>
-        <td>Snoonet</td>
-        <td>#_snoonet_#channame:matrix.org</td>
-        <td>@snoonet-irc:matrix.org</td>
-        <td>#irc:matrix.org</td>
-        <td>Matrix.org</td>
-    </tr>
-    <tr>
-        <td>Tweakers.net</td>
-        <td>#_tweakers_#channame:irc.snt.utwente.nl</td>
-        <td>@tweakers:irc.snt.utwente.nl</td>
-        <td>#tweakers-irc:utwente.io</td>
-        <td>SNT</td>
-    </tr>
-    <tr>
-        <td>irchighway</td>
-        <td>#irchighway_#channame:eggy.cc</td>
-        <td>@appservice-irc:eggy.cc</td>
-        <td>#eggster:eggy.cc</td>
-        <td>Eggy</td>
-    </tr>
-    <tr>
-        <td>W3C</td>
-        <td>#_w3c_#channame:matrix.org</td>
-        <td>@w3c-irc:matrix.org</td>
-        <td>#irc:matrix.org</td>
-        <td>Matrix.org</td>
-    </tr>
-    <tr>
-        <td>libera.chat</td>
-        <td>#channame:libera.chat</td>
-        <td>@appservice:libera.chat</td>
-        <td>#libera-matrix:libera.chat</td>
-        <td>Matrix.org</td>
-    </tr>
-</table>
+| Network Name | Room alias format                         | Appservice user                    | Room for Support               | Operator                                  |
+|--------------|-------------------------------------------|------------------------------------|--------------------------------|-------------------------------------------|
+| darkfasel    | `#channame:darkfasel.net`                 | [`@IRC-Darkfasel:darkfasel.net`]   | [`#darkfasel:darkfasel.net`]   | [darkfasel](https://www.darkfasel.net/)   |
+| fc00         | `#fc00-irc_#channame:m.trnsz.com`         | [`@fc00ircmtx:m.trnsz.com`]        | None                           |                                           |
+| freenode[^1] | `#freenode_#channame:matrix.org`          | [`@appservice-irc:matrix.org`][^2] | [`#irc:matrix.org`]            | [Matrix.org]                              |
+| GIMPNet[^3]  | `#_gimpnet_#channame:gnome.org`           | [`@gimpnet-irc:gnome.org`][^4]     | [`#irc:matrix.org`]            | [Matrix.org] / [Gnome.org]                |
+| IRCnet       | `#_ircnet_#channame:irc.snt.utwente.nl`   | [`@ircnet:irc.snt.utwente.nl`]     | [`#ircnet:utwente.io`]         | [SNT]                                     |
+| OFTC         | `#_oftc_#channame:matrix.org`             | [`@oftc-irc:matrix.org`]           | [`#irc:matrix.org`]            | [Matrix.org]                              |
+| PirateIRC    | `#pirateirc_#channame:diasp.in`           | [`@pirateirc:diasp.in`]            | [`#diasp.in:diasp.in`]         | [Indian Pirates](https://pirates.org.in/) |
+| Snoonet      | `#_snoonet_#channame:matrix.org`          | [`@snoonet-irc:matrix.org`]        | [`#irc:matrix.org`]            | [Matrix.org]                              |
+| Tweakers.net | `#_tweakers_#channame:irc.snt.utwente.nl` | [`@tweakers:irc.snt.utwente.nl`]   | [`#tweakers-irc:utwente.io`]   | [SNT]                                     |
+| irchighway   | `#irchighway_#channame:eggy.cc`           | [`@appservice-irc:eggy.cc`]        | [`#eggster:eggy.cc`]           | [Eggy](http://eggy.cc/)                   |
+| W3C          | `#_w3c_#channame:matrix.org`              | [`@w3c-irc:matrix.org`]            | [`#irc:matrix.org`]            | [Matrix.org]                              |
+| libera.chat  | `#channame:libera.chat`                   | [`@appservice:libera.chat`]        | [`#libera-matrix:libera.chat`] | [Matrix.org]                              |
 
-### Footnotes
+[`@IRC-Darkfasel:darkfasel.net`]: https://matrix.to/#/@IRC-Darkfasel:darkfasel.net
+[`@fc00ircmtx:m.trnsz.com`]: https://matrix.to/#/@fc00ircmtx:m.trnsz.com
+[`@appservice-irc:matrix.org`]: https://matrix.to/#/@appservice-irc:matrix.org
+[`@gimpnet-irc:gnome.org`]: https://matrix.to/#/@gimpnet-irc:gnome.org
+[`@ircnet:irc.snt.utwente.nl`]: https://matrix.to/#/@ircnet:irc.snt.utwente.nl
+[`@oftc-irc:matrix.org`]: https://matrix.to/#/@oftc-irc:matrix.org
+[`@pirateirc:diasp.in`]: https://matrix.to/#/@pirateirc:diasp.in
+[`@snoonet-irc:matrix.org`]: https://matrix.to/#/@snoonet-irc:matrix.org
+[`@tweakers:irc.snt.utwente.nl`]: https://matrix.to/#/@tweakers:irc.snt.utwente.nl
+[`@appservice-irc:eggy.cc`]: https://matrix.to/#/@appservice-irc:eggy.cc
+[`@w3c-irc:matrix.org`]: https://matrix.to/#/@w3c-irc:matrix.org
+[`@appservice:libera.chat`]: https://matrix.to/#/@appservice:libera.chat
 
-1. <a name="foot1"></a>Freenode doesn't have the leading `_` as it is older than the practice of putting the underscore to the beginning.
-2. <a name="foot2"></a>This appservice user doesn't have "freenode" in its name because in the past it was used for _all_ matrix.org-hosted bridges.
-3. <a name="foot3"></a>This includes both irc.gimp.org and irc.gnome.org, as they are the same thing.
-4. <a name="foot6"></a>The bridge has moved from matrix.org to gnome.org.
+[`#irc:matrix.org`]: https://matrix.to/#/%23irc:matrix.org
+[`#darkfasel:darkfasel.net`]: https://matrix.to/#/%23darkfasel:darkfasel.net
+[`#ircnet:utwente.io`]: https://matrix.to/#/%23ircnet:utwente.io
+[`#diasp.in:diasp.in`]: https://matrix.to/#/%23diasp.in:diasp.in
+[`#tweakers-irc:utwente.io`]: https://matrix.to/#/%23tweakers-irc:utwente.io
+[`#eggster:eggy.cc`]: https://matrix.to/#/%23eggster:eggy.cc
+[`#libera-matrix:libera.chat`]: https://matrix.to/#/%23libera-matrix:libera.chat
+
+[Matrix.org]: https://matrix.org/
+[Gnome.org]: https://gnome.org/
+[SNT]: https://snt.utwente.nl/en/
 
 * Hackint [closed their Matrix bridge](https://hackint.org/archive#20181028_Matrix_Bridging_Sunset) on 2018-12-31.
 * Random.sh is no longer contactable. Status of the bridge is unknown.
 * Foonetic IRC has shut down. #xkcd channels [moved to slashnet](https://web.archive.org/web/20190824061533/http://wiki.xkcd.com/irc/Main_Page#Channel_Migration)
-* The espernet bridge was shut down after the 2019 matrix.org network breach.
-* The Moznet IRC network has been shut down. They now run their own Matrix homeserver at chat.mozilla.org 🎉
+* The Espernet bridge was shut down after the 2019 matrix.org network breach.
+* The Moznet IRC network has been shut down. They now run their own Matrix homeserver at [chat.mozilla.org](https://chat.mozilla.org/) 🎉
+
+### Footnotes
+
+[^1]: Freenode doesn't have the leading `_` as it is older than the practice of putting the underscore to the beginning.
+
+[^2]: This appservice user doesn't have "freenode" in its name because in the past it was used for _all_ matrix.org-hosted bridges.
+
+[^3]: This includes both irc.gimp.org and irc.gnome.org, as they are the same thing.
+
+[^4]: The bridge has moved from matrix.org to gnome.org.

--- a/docs/bridged_networks.md
+++ b/docs/bridged_networks.md
@@ -1,0 +1,101 @@
+A wishlist of IRC networks to be bridged is being collected [in a github issue](https://github.com/matrix-org/matrix-appservice-irc/issues/208).
+
+<table>
+    <tr>
+        <th>Network Name</th>
+        <th>Room alias format</th>
+        <th>Appservice user</th>
+        <th>Room for Support</th>
+        <th>Operator</th>
+    </tr>
+    <tr>
+        <td>darkfasel</td>
+        <td>#channame:darkfasel.net</td>
+        <td>@IRC-Darkfasel:darkfasel.net</td>
+        <td>#darkfasel:darkfasel.net</td>
+        <td>darkfasel</td>
+    </tr>
+    <tr>
+        <td>fc00</td>
+        <td>#fc00-irc_#channame:m.trnsz.com</td>
+        <td>@fc00ircmtx:m.trnsz.com</td>
+        <td>None</td>
+        <td></td>
+    </tr>
+    <tr>
+        <td>freenode<a href="#user-content-foot1"><sup>[1]</sup></a></td>
+        <td>#freenode_#channame:matrix.org</td>
+        <td>@appservice-irc:matrix.org<a href="#user-content-foot2"><sup>[2]</sup></a></td>
+        <td>#irc:matrix.org</td>
+        <td>Matrix.org</td>
+    </tr>
+    <tr>
+        <td>GIMPNet<a href="#user-content-foot3"><sup>[3]</sup></a></td>
+        <td>#_gimpnet_#channame:gnome.org</td>
+        <td>@gimpnet-irc:gnome.org<a href="#user-content-foot4"><sup>[4]</sup></a></td>
+        <td>#irc:matrix.org</td>
+        <td>Matrix.org / Gnome.org </td>
+    </tr>
+    <tr>
+        <td>IRCnet</td>
+        <td>#_ircnet_#channame:irc.snt.utwente.nl</td>
+        <td>@ircnet:irc.snt.utwente.nl</td>
+        <td>#ircnet:utwente.io</td>
+        <td>SNT</td>
+    </tr>
+    <tr>
+        <td>OFTC</td>
+        <td>#_oftc_#channame:matrix.org</td>
+        <td>@oftc-irc:matrix.org</td>
+        <td>#irc:matrix.org</td>
+        <td>Matrix.org</td>
+    </tr>
+    <tr>
+        <td>PirateIRC</td>
+        <td>#pirateirc_#channame:diasp.in</td>
+        <td>@pirateirc:diasp.in</td>
+        <td>#diasp.in:diasp.in</td>
+        <td>Indian Pirates</td>
+    </tr>
+    <tr>
+        <td>Snoonet</td>
+        <td>#_snoonet_#channame:matrix.org</td>
+        <td>@snoonet-irc:matrix.org</td>
+        <td>#irc:matrix.org</td>
+        <td>Matrix.org</td>
+    </tr>
+    <tr>
+        <td>Tweakers.net</td>
+        <td>#_tweakers_#channame:irc.snt.utwente.nl</td>
+        <td>@tweakers:irc.snt.utwente.nl</td>
+        <td>#tweakers-irc:utwente.io</td>
+        <td>SNT</td>
+    </tr>
+    <tr>
+        <td>irchighway</td>
+        <td>#irchighway_#channame:eggy.cc</td>
+        <td>@appservice-irc:eggy.cc</td>
+        <td>#eggster:eggy.cc</td>
+        <td>Eggy</td>
+    </tr>
+    <tr>
+        <td>W3C</td>
+        <td>#_w3c_#channame:matrix.org</td>
+        <td>@w3c-irc:matrix.org</td>
+        <td>#irc:matrix.org</td>
+        <td>Matrix.org</td>
+    </tr>
+</table>
+
+### Footnotes
+
+1. <a name="foot1"></a>Freenode doesn't have the leading `_` as it is older than the practice of putting the underscore to the beginning.
+2. <a name="foot2"></a>This appservice user doesn't have "freenode" in its name because in the past it was used for _all_ matrix.org-hosted bridges.
+3. <a name="foot3"></a>This includes both irc.gimp.org and irc.gnome.org, as they are the same thing.
+4. <a name="foot6"></a>The bridge has moved from matrix.org to gnome.org.
+
+* Hackint [closed their Matrix bridge](https://hackint.org/archive#20181028_Matrix_Bridging_Sunset) on 2018-12-31.
+* Random.sh is no longer contactable. Status of the bridge is unknown.
+* Foonetic IRC has shut down. #xkcd channels [moved to slashnet](https://web.archive.org/web/20190824061533/http://wiki.xkcd.com/irc/Main_Page#Channel_Migration)
+* The espernet bridge was shut down after the 2019 matrix.org network breach.
+* The Moznet IRC network has been shut down. They now run their own Matrix homeserver at chat.mozilla.org 🎉


### PR DESCRIPTION
The wiki has been deprecated with #1309, but the list of IRC bridges (https://github.com/matrix-org/matrix-appservice-irc/wiki/Bridged-IRC-networks) doesn't have a new home yet. I mostly copied the wiki page over as-is, only slightly editing the footnotes to make them consistent with the content again.

This also fixes one part of #1415.