### PR TITLE
Require explicit server selection for !storepass when more than one possibility exists

### DIFF
--- a/changelog.d/1363.bugfix
+++ b/changelog.d/1363.bugfix
@@ -1,0 +1,3 @@
+Require explicit server selection for !storepass when more than one possibility exists.
+
+This makes the command a bit more verbose, but avoids the situation where a password could've been accidentally specified for the wrong server.


### PR DESCRIPTION
This avoids the situation described in #1363 when a password could've
been accidentally set (and used) with the wrong server due to the
command parser trying to be too helpful.