### PR TITLE
Add buckets to irc-connection-times

### DIFF
--- a/changelog.d/1426.bugfix
+++ b/changelog.d/1426.bugfix
@@ -1,0 +1,1 @@
+Ensure the `irc_connection_time_ms` histrogram metric uses sensible bucket sizes.

--- a/src/bridge/IrcBridge.ts
+++ b/src/bridge/IrcBridge.ts
@@ -281,7 +281,6 @@ export class IrcBridge {
         }
 
         const { userActivityThresholdHours, remoteUserAgeBuckets } = this.config.ircService.metrics;
-
         const usingRemoteMetrics = !!this.config.ircService.metrics.port;
 
         const metrics = this.bridge.getPrometheusMetrics(!usingRemoteMetrics, registry);
@@ -339,9 +338,11 @@ export class IrcBridge {
                 help: "Histogram of processing durations of received remote messages",
                 labels: ["outcome"],
             }),
-            irc_connection_time_ms: metrics.addTimer({
+            irc_connection_time_ms: new Histogram({
+                registers: [registry],
                 name: "irc_connection_time_ms",
                 help: "The time it took the user to receive the welcome message",
+                buckets: [100, 500, 1000, 2500, 10000, 30000],
             }),
         };
 


### PR DESCRIPTION
Because by default prom-client does intervals up to 10, which is unhelpful.
```
# HELP bridge_irc_connection_time_ms The time it took the user to receive the welcome message
# TYPE bridge_irc_connection_time_ms histogram
bridge_irc_connection_time_ms_bucket{le="0.005"} 0
bridge_irc_connection_time_ms_bucket{le="0.01"} 0
bridge_irc_connection_time_ms_bucket{le="0.025"} 0
bridge_irc_connection_time_ms_bucket{le="0.05"} 0
bridge_irc_connection_time_ms_bucket{le="0.1"} 0
bridge_irc_connection_time_ms_bucket{le="0.25"} 0
bridge_irc_connection_time_ms_bucket{le="0.5"} 0
bridge_irc_connection_time_ms_bucket{le="1"} 0
bridge_irc_connection_time_ms_bucket{le="2.5"} 0
bridge_irc_connection_time_ms_bucket{le="5"} 0
bridge_irc_connection_time_ms_bucket{le="10"} 0
bridge_irc_connection_time_ms_bucket{le="+Inf"} 17070
bridge_irc_connection_time_ms_sum 125757350
bridge_irc_connection_time_ms_count 17070
```