### PR TITLE
Refactor/ovehaul AdminRoom command handling

### DIFF
--- a/changelog.d/1433.bugfix
+++ b/changelog.d/1433.bugfix
@@ -1,0 +1,1 @@
+Make sure that admin commands that don't need a server (like !help) don't require it


### PR DESCRIPTION
This makes them obtain information (like the IRC server or clientList)
lazily rather than eagerly, making sure that we don't require a server
to be specified for stuff that doesn't need it (like !help).

Also makes the command handler interface almost unified, in case this
comes in handy later on for some reason.

Fixes GH-1431.