### PR TITLE
Do not generate a unique username for IPv6 bridges

### DIFF
--- a/changelog.d/1446.misc
+++ b/changelog.d/1446.misc
@@ -1,0 +1,1 @@
+Do not generate a unique username for users on a IPv6 bridge, as it's unnessacery.

--- a/spec/unit/IdentGenerator.spec.js
+++ b/spec/unit/IdentGenerator.spec.js
@@ -15,6 +15,7 @@ describe("Username generation", function() {
     let ircClientConfigsUsernames;
     const serverMock = {
         getRealNameFormat: () => "mxid",
+        getIpv6Only: () => false,
     };
 
     beforeEach(function() {
@@ -68,6 +69,7 @@ describe("Username generation", function() {
         var userId = "@myreallylonguseridhere:localhost";
         const info = await identGenerator.getIrcNames(ircClientConfig, {
             getRealNameFormat: () => "reverse-mxid",
+            getIpv6Only: () => false
         }, new MatrixUser(userId));
         expect(info.realname).toEqual("localhost:myreallylonguseridhere");
     });
@@ -138,5 +140,20 @@ describe("Username generation", function() {
                 expect(result.username).toBe(`${"longprefix".substr(0, 8 - 1 - (i).toString().length)}_${i}`);
             }
         }
+    });
+
+    it("should not generate a unique username for IPv6 enabled bridges", async function() {
+        const userId = "@-myname:localhost";
+        const uname = "M-myname";
+        const ipv6Mock = {
+            getRealNameFormat: () => "mxid",
+            getIpv6Only: () => true,
+        }
+        // This ensures that we will always return a result for whatever username it picks.
+        storeMock.getMatrixUserByUsername = async () => ({
+            getId: () => ({userId})
+        });
+        const info = await identGenerator.getIrcNames(ircClientConfig, ipv6Mock, new MatrixUser(userId));
+        expect(info.username).toEqual(uname);
     });
 });

--- a/src/irc/IdentGenerator.ts
+++ b/src/irc/IdentGenerator.ts
@@ -101,7 +101,7 @@ export class IdentGenerator {
                     ircClientConfig: ircClientConfig,
                     // IPv6 bridges do not need a unique username, as each user will
                     // have their own IPv6 address.
-                    unique: server.getIpv6Only(),
+                    unique: !server.getIpv6Only(),
                 }) as string;
                 return {
                     username: uname,

--- a/src/irc/IdentGenerator.ts
+++ b/src/irc/IdentGenerator.ts
@@ -33,14 +33,14 @@ export class IdentGenerator {
     // The delimiter of the username.
     private static readonly MAX_USER_NAME_SUFFIX = 9999;
 
-    private queue: Queue<{ matrixUser: MatrixUser; ircClientConfig: IrcClientConfig}>;
+    private queue: Queue<{ matrixUser: MatrixUser; ircClientConfig: IrcClientConfig, unique: boolean}>;
     constructor (private readonly dataStore: DataStore) {
         // Queue of ident generation requests.
         // We need to queue them because otherwise 2 clashing user_ids could be assigned
         // the same ident value (won't be in the database yet)
         this.queue = new Queue((item) => {
-            const {matrixUser, ircClientConfig} = item;
-            return this.process(matrixUser, ircClientConfig);
+            const {matrixUser, ircClientConfig, unique} = item;
+            return this.process(matrixUser, ircClientConfig, unique);
         });
     }
 
@@ -98,7 +98,10 @@ export class IdentGenerator {
                 )
                 const uname = await this.queue.enqueue(matrixUser.getId(), {
                     matrixUser: matrixUser,
-                    ircClientConfig: ircClientConfig
+                    ircClientConfig: ircClientConfig,
+                    // IPv6 bridges do not need a unique username, as each user will
+                    // have their own IPv6 address.
+                    unique: server.getIpv6Only(),
                 }) as string;
                 return {
                     username: uname,
@@ -129,10 +132,21 @@ export class IdentGenerator {
         return `IdentGenerator queue length=${this.queue.size}`
     }
 
-    private async process (matrixUser: MatrixUser, ircClientConfig: IrcClientConfig) {
+    private async process (matrixUser: MatrixUser, ircClientConfig: IrcClientConfig, unique: boolean) {
         const configDomain = ircClientConfig.getDomain();
         log.debug("Generating username for %s on %s", matrixUser.getId(), configDomain);
-        const uname = await this.generateIdentUsername(configDomain, matrixUser.getId());
+        let uname;
+        if (unique) {
+            uname = await this.generateIdentUsername(configDomain, matrixUser.getId());
+        }
+        else {
+            // If the bridge is an IPv6 bridge, we just want to generate a valid username
+            // rather than worrying too much about it being unique. The IPv6 address
+            // ensures that the hostmask will be unique.
+            uname = IdentGenerator.sanitiseUsername(
+                matrixUser.getId().substring(1)
+            ).substring(0, IdentGenerator.MAX_USER_NAME_LENGTH);
+        }
         const existingConfig = await this.dataStore.getIrcClientConfig(matrixUser.getId(), configDomain);
         const config = existingConfig ? existingConfig : ircClientConfig;
         config.setUsername(uname);


### PR DESCRIPTION
Fixes https://github.com/matrix-org/matrix-appservice-irc/issues/1209
Fixes #1445 

This PR makes it so that bridges that exclusively use IPv6 addresses for users will no longer attempt to generate unique usernames, instead favouring to pick a sanitised version of the userID. This should help cases where unique usernames were hard to generate (E.g. Slack / TG identifiers)