### PR TITLE
Remove index for unique usernames

### DIFF
--- a/changelog.d/1455.bugfix
+++ b/changelog.d/1455.bugfix
@@ -1,0 +1,1 @@
+Remove `client_config_domain_username_idx` which would have required a unique username for IPv6 users.

--- a/src/datastore/postgres/PgDataStore.ts
+++ b/src/datastore/postgres/PgDataStore.ts
@@ -52,7 +52,7 @@ interface RoomRecord {
 export class PgDataStore implements DataStore {
     private serverMappings: {[domain: string]: IrcServer} = {};
 
-    public static readonly LATEST_SCHEMA = 5;
+    public static readonly LATEST_SCHEMA = 6;
     private pgPool: Pool;
     private hasEnded = false;
     private cryptoStore?: StringCrypto;

--- a/src/datastore/postgres/schema/v6.ts
+++ b/src/datastore/postgres/schema/v6.ts
@@ -2,6 +2,6 @@ import { PoolClient } from "pg";
 
 export async function runSchema(connection: PoolClient) {
     await connection.query(`
-    DROP INDEX client_config_domain_username_idx ON client_config (domain, (config->>'username'));
+    DROP INDEX client_config_domain_username_idx;
     `);
 }

--- a/src/datastore/postgres/schema/v6.ts
+++ b/src/datastore/postgres/schema/v6.ts
@@ -1,0 +1,7 @@
+import { PoolClient } from "pg";
+
+export async function runSchema(connection: PoolClient) {
+    await connection.query(`
+    DROP INDEX client_config_domain_username_idx ON client_config (domain, (config->>'username'));
+    `);
+}


### PR DESCRIPTION
We didn't remove this index when working on #1446, which would mean that the username would still be treated as unique. There should be supporting code to ensure that we don't create duplicate usernames.