### PR TITLE
Add automated dockerhub builds

### DIFF
--- a/.github/workflows/docker-hub-latest.yml
+++ b/.github/workflows/docker-hub-latest.yml
@@ -8,6 +8,8 @@ on:
 env:
   DOCKER_NAMESPACE: matrixdotorg
   PLATFORMS: linux/amd64
+  # Only push if this is develop, otherwise we just want to build
+  PUSH: ${{ github.ref == 'refs/heads/develop' }}
 
 jobs:
   docker-latest:
@@ -27,6 +29,6 @@ jobs:
           context: .
           file: ./Dockerfile
           platforms: ${{ env.PLATFORMS }}
-          push: true
+          push: ${{ env.PUSH }}
           tags: |
-            ${{ env.DOCKER_NAMESPACE }}/matrix-appservice-irc:latest-test
+            ${{ env.DOCKER_NAMESPACE }}/matrix-appservice-irc:latest

--- a/.github/workflows/docker-hub-latest.yml
+++ b/.github/workflows/docker-hub-latest.yml
@@ -1,0 +1,32 @@
+# Based on https://github.com/matrix-org/dendrite/blob/master/.github/workflows/docker-hub.yml
+
+name: "Docker Hub - Latest"
+
+on:
+  push:
+
+env:
+  DOCKER_NAMESPACE: matrixdotorg
+  PLATFORMS: linux/amd64
+
+jobs:
+  docker-latest:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+
+      - name: Build image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: ${{ env.PLATFORMS }}
+          push: true
+          tags: |
+            ${{ env.DOCKER_NAMESPACE }}/matrix-appservice-irc:latest-test

--- a/.github/workflows/docker-hub-release.yml
+++ b/.github/workflows/docker-hub-release.yml
@@ -1,0 +1,35 @@
+# Based on https://github.com/matrix-org/dendrite/blob/master/.github/workflows/docker-hub.yml
+
+name: "Docker Hub - Release"
+
+on:
+  release:
+    types: [published]
+
+env:
+  DOCKER_NAMESPACE: matrixdotorg
+  PLATFORMS: linux/amd64
+
+jobs:
+  docker-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Get release tag
+        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+
+      - name: Build image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: ${{ env.PLATFORMS }}
+          push: true
+          tags: |
+            ${{ env.DOCKER_NAMESPACE }}/matrix-appservice-irc:release-${{ env.RELEASE_VERSION }}

--- a/changelog.d/1456.misc
+++ b/changelog.d/1456.misc
@@ -1,0 +1,1 @@
+Docker images are now automatically build and published via GitHub Actions, replacing DockerHub Autobuilds.


### PR DESCRIPTION
Fixes #1452 
This PR adds workflows to build our Dockerimages in GitHub actions.

Incidentally...the dockerhub builds have inexplicably started working again but I'm actually happy to still do the work because:
- It broke before, it might break again
- Dockerhub is always slloooow
- We already pay for GH actions somehow, might as well keep using it.
- GH actions blend nicely into the GH UI
- We can switch away to using a different repository for docker images at our own leisure.