### PR TITLE
Make sure we don't exceed the line limit when trimming long messages

### DIFF
--- a/changelog.d/1459.bugfix
+++ b/changelog.d/1459.bugfix
@@ -1,0 +1,1 @@
+Make sure we don't exceed the line limit when trimming long messages

--- a/src/bridge/MatrixHandler.ts
+++ b/src/bridge/MatrixHandler.ts
@@ -1132,7 +1132,7 @@ export class MatrixHandler {
                 const explanation = renderTemplate(this.config.truncatedMessageTemplate, { url: httpUrl });
                 let messagePreview = trimString(
                     potentialMessages[0],
-                    ircClient.getMaxLineLength() - 4 /* "... " */ - explanation.length
+                    ircClient.getMaxLineLength() - 4 /* "... " */ - explanation.length - ircRoom.channel.length
                 );
                 if (potentialMessages.length > 1 || messagePreview.length < potentialMessages[0].length) {
                     messagePreview += '...';


### PR DESCRIPTION
getMaxLineLength() doesn't actually include the channel name in its
calculations (though it does add required spaces around it), so we need
to take care of that bit ourselves here.

The API could be a bit more helpful here perhaps, but this at least
fixes the issue for now.