### PR TITLE
Fallback to sending an invite as a bot if the regular invite fails

### DIFF
--- a/changelog.d/1467.bugfix
+++ b/changelog.d/1467.bugfix
@@ -1,0 +1,1 @@
+Fallback to sending an invite as a bot if the regular invite fails

--- a/src/bridge/IrcHandler.ts
+++ b/src/bridge/IrcHandler.ts
@@ -406,7 +406,15 @@ export class IrcHandler {
                 virtualMatrixUser.getId()
             ).invite(
                 room.getId(), invitee
-            );
+            ).catch(err => {
+                req.log.warn(
+                    `Failed to invite %s as the inviter user (reason: ${err}),
+                    inviting as a bot as fallback`
+                );
+                // TODO Note the original inviter in the reason
+                // once MSC 2367 stabilizes and is implemented by the SDK
+                return this.ircBridge.getAppServiceBridge().getIntent().invite(room.getId(), invitee);
+            });
         });
         await Promise.all(invitePromises);
         return undefined;

--- a/src/bridge/IrcHandler.ts
+++ b/src/bridge/IrcHandler.ts
@@ -408,7 +408,7 @@ export class IrcHandler {
                 room.getId(), invitee
             ).catch(err => {
                 req.log.warn(
-                    `Failed to invite %s as the inviter user (reason: ${err}),
+                    `Failed to invite ${invitee} as the inviter user (reason: ${err}),
                     inviting as a bot as fallback`
                 );
                 // TODO Note the original inviter in the reason

--- a/src/bridge/IrcHandler.ts
+++ b/src/bridge/IrcHandler.ts
@@ -411,9 +411,12 @@ export class IrcHandler {
                     `Failed to invite ${invitee} as the inviter user (reason: ${err}),
                     inviting as a bot as fallback`
                 );
-                // TODO Note the original inviter in the reason
-                // once MSC 2367 stabilizes and is implemented by the SDK
-                return this.ircBridge.getAppServiceBridge().getIntent().invite(room.getId(), invitee);
+                return this.ircBridge.getAppServiceBridge().getIntent().sendStateEvent(
+                    room.getId(), "m.room.member", invitee, {
+                        membership: "invite",
+                        reason: `Invited by ${virtualMatrixUser.getDisplayName()} (${virtualMatrixUser.getId()})`,
+                    }
+                );
             });
         });
         await Promise.all(invitePromises);


### PR DESCRIPTION
This works around an issue where an invite is sent before the room is
fully configured, and the power level of the actual inviter is not yet
know and set.

Fixes GH-1466.