### PR TITLE
Fallback to generic profile displayname if we can't get the bot to join the proper room

### DIFF
--- a/changelog.d/1479.bugfix
+++ b/changelog.d/1479.bugfix
@@ -1,0 +1,1 @@
+Fix an edgecase where an nickname was not always set right for matrix users in PMs


### PR DESCRIPTION
This happens if a matrix users PMs an IRC user
while not being in any channel.