### PR TITLE
Make sure message diffs are not longer than the new message would be

### DIFF
--- a/changelog.d/1477.bugfix
+++ b/changelog.d/1477.bugfix
@@ -1,0 +1,1 @@
+Make sure message diffs are not longer than the new message would be

--- a/changelog.d/1477.bugfix
+++ b/changelog.d/1477.bugfix
@@ -1,1 +1,1 @@
-Make sure message diffs are not longer than the new message would be
+Matrix message edits no longer bridge as a diff if it's longer than the new message

--- a/spec/unit/MessageDiff.spec.js
+++ b/spec/unit/MessageDiff.spec.js
@@ -26,7 +26,7 @@ describe('messageDiff', function() {
         ],
         [
             'should not use diffs with newlines in them',
-            'a\nb\nc', 'bla\nbleh\nc',
+            'a\nb\ncontinuing...', 'bla\nbleh\ncontinuing...',
             's/a/bla/, s/b/bleh/',
         ],
         [
@@ -48,6 +48,12 @@ describe('messageDiff', function() {
             'should show word removals as s/foo//',
             'I gotta go clean up my filthy room', 'I gotta go clean up my room',
             's/filthy//'
+        ],
+        [
+            'Do not emit a diff if it ends up longer than the new message (https://github.com/matrix-org/matrix-appservice-irc/issues/1477)',
+            'Lorem ipsu dolor sit - an arbitrary amount of trailing text will be duplicated in the sed expression, even though it should only include a few words of context',
+            'Lorem ipsum dolor sit amet - an arbitrary amount of trailing text will be duplicated in the sed expression, even though it should only include a few words of context',
+            undefined,
         ],
     ].forEach(c => it(c[0], () => {
         const result = messageDiff(c[1], c[2]);

--- a/spec/unit/MessageDiff.spec.js
+++ b/spec/unit/MessageDiff.spec.js
@@ -50,8 +50,11 @@ describe('messageDiff', function() {
             's/filthy//'
         ],
         [
+            // eslint-disable-next-line max-len
             'Do not emit a diff if it ends up longer than the new message (https://github.com/matrix-org/matrix-appservice-irc/issues/1477)',
+            // eslint-disable-next-line max-len
             'Lorem ipsu dolor sit - an arbitrary amount of trailing text will be duplicated in the sed expression, even though it should only include a few words of context',
+            // eslint-disable-next-line max-len
             'Lorem ipsum dolor sit amet - an arbitrary amount of trailing text will be duplicated in the sed expression, even though it should only include a few words of context',
             undefined,
         ],

--- a/src/util/MessageDiff.ts
+++ b/src/util/MessageDiff.ts
@@ -103,6 +103,9 @@ export function messageDiff(from: string, to: string): string|undefined {
         diffs => !diffs.find(diff => diff.match(/\n/))
     ).map(
         diffs => diffs.join(', ')
+    ).filter(
+        // a diff longer than the new message is worthless
+        diff => diff.length < to.length
     ).sort(
         // prefer shorter overall length
         (a, b) => a.length - b.length


### PR DESCRIPTION
Partially fixes #1477 – better diff detection would be better eventually, but this at least reduces the annoyance now