### PR TITLE
Remove legacy group chat check

### DIFF
--- a/changelog.d/1506.removal
+++ b/changelog.d/1506.removal
@@ -1,0 +1,2 @@
+The bridge will no longer treat invites without a `is_direct: true` as DM invites (and will henceforth reject group room invites). This may break some Matrix
+clients that do not supply this metadata when creating a room.

--- a/src/bridge/MatrixHandler.ts
+++ b/src/bridge/MatrixHandler.ts
@@ -450,7 +450,7 @@ export class MatrixHandler {
         // invite yet!)
         this.processingInvitesForRooms[event.room_id + event.state_key] = req.getPromise();
         req.getPromise().finally(() => {
-            delete this.processingsForRooms[event.room_id + event.state_key];
+            delete this.processingInvitesForRooms[event.room_id + event.state_key];
         });
 
         // Check if this room is known to us.

--- a/src/bridge/MatrixHandler.ts
+++ b/src/bridge/MatrixHandler.ts
@@ -245,14 +245,7 @@ export class MatrixHandler {
         req.log.info("Joined %s to room %s", invitedUser.getId(), event.room_id);
 
         // check if this room is a PM room or not.
-
-        let isPmRoom = event.content.is_direct === true;
-        if (isPmRoom !== true) {
-            // Legacy check
-            const joinedMembers = await this.ircBridge.getAppServiceBridge().getIntent().matrixClient
-                .getJoinedRoomMembers(event.room_id);
-            isPmRoom = joinedMembers.length === 2 && joinedMembers.includes(event.sender);
-        }
+        const isPmRoom = event.content.is_direct === true;
 
         if (isPmRoom) {
             // nick is the channel
@@ -457,7 +450,7 @@ export class MatrixHandler {
         // invite yet!)
         this.processingInvitesForRooms[event.room_id + event.state_key] = req.getPromise();
         req.getPromise().finally(() => {
-            delete this.processingInvitesForRooms[event.room_id + event.state_key];
+            delete this.processing#sForRooms[event.room_id + event.state_key];
         });
 
         // Check if this room is known to us.

--- a/src/bridge/MatrixHandler.ts
+++ b/src/bridge/MatrixHandler.ts
@@ -450,7 +450,7 @@ export class MatrixHandler {
         // invite yet!)
         this.processingInvitesForRooms[event.room_id + event.state_key] = req.getPromise();
         req.getPromise().finally(() => {
-            delete this.processing#sForRooms[event.room_id + event.state_key];
+            delete this.processingsForRooms[event.room_id + event.state_key];
         });
 
         // Check if this room is known to us.


### PR DESCRIPTION
Fixes #1505 

This will break behaviors for clients which don't support `is_direct`, but this flag has been around for eons now and rejecting invites from large group rooms can reduce load on the HS.