### PR TITLE
Support splitting users from different homeservers into different IPv6 blocks

### DIFF
--- a/changelog.d/1707.feature
+++ b/changelog.d/1707.feature
@@ -1,0 +1,1 @@
+Support splitting users from different homeservers into different IPv6 blocks.

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -368,8 +368,15 @@ ircService:
           # Older kernels will need IP_FREEBIND, which requires an LD_PRELOAD with the library
           # https://github.com/matrix-org/freebindfree as Node does not expose setsockopt.
           # prefix: "2001:0db8:85a3::"  # modify appropriately
+  
+          # Optional. Define blocks of IPv6 addresses for different homeservers
+          # which can be used to restrict users of those homeservers to a given
+          # IP. These blocks should be considered immutable once set, as changing
+          # the startFrom value will NOT adjust existing IP addresses. 
+          # Changing the startFrom value to a lower value may conflict with existing clients.
+          # Multiple homeservers may NOT share blocks.
           blocks:
-            - homeserver: fosdem.org
+            - homeserver: another-server.org
               startFrom: '10:0000'
         #
         # The maximum amount of time in seconds that the client can exist

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -368,6 +368,9 @@ ircService:
           # Older kernels will need IP_FREEBIND, which requires an LD_PRELOAD with the library
           # https://github.com/matrix-org/freebindfree as Node does not expose setsockopt.
           # prefix: "2001:0db8:85a3::"  # modify appropriately
+          blocks:
+            - homeserver: fosdem.org
+              startFrom: '10:0000'
         #
         # The maximum amount of time in seconds that the client can exist
         # without sending another message before being disconnected. Use 0 to

--- a/config.schema.yml
+++ b/config.schema.yml
@@ -427,7 +427,7 @@ properties:
                                             properties:
                                                 startFrom:
                                                     type: "string"
-                                                    pattern: "(?:[0-9abcdef]{1,4}:)*[0-9abcdef]{1,4}"
+                                                    pattern: "(?:[0-9a-f]{1,4}:)*[0-9a-f]{1,4}"
                                                 homeserver:
                                                     type: "string"
                                             required: ["startFrom", "homeserver"]

--- a/config.schema.yml
+++ b/config.schema.yml
@@ -430,7 +430,7 @@ properties:
                                                     pattern: "(?:[0-9abcdef]{1,4}:)*[0-9abcdef]{1,4}"
                                                 homeserver:
                                                     type: "string"
-                                            required: ["string", "homeserver"]
+                                            required: ["startFrom", "homeserver"]
                                 lineLimit:
                                     type: "integer"
                                 userModes:

--- a/config.schema.yml
+++ b/config.schema.yml
@@ -422,6 +422,15 @@ properties:
                                             pattern: "[ABCDEFabcdef0123456789:]+"
                                         only:
                                             type: "boolean"
+                                        blocks:
+                                            type: "array"
+                                            properties:
+                                                startFrom:
+                                                    type: "string"
+                                                    pattern: "(?:[0-9abcdef]{1,4}:)*[0-9abcdef]{1,4}"
+                                                homeserver:
+                                                    type: "string"
+                                            required: ["string", "homeserver"]
                                 lineLimit:
                                     type: "integer"
                                 userModes:

--- a/src/bridge/IrcBridge.ts
+++ b/src/bridge/IrcBridge.ts
@@ -591,13 +591,15 @@ export class IrcBridge {
             if (!userStore || !roomStore || !userActivityStore) {
                 throw Error('Could not load user(Activity)Store or roomStore');
             }
-            this.dataStore = new NeDBDataStore(
+            const ndbDatastore = new NeDBDataStore(
                 userStore,
                 userActivityStore,
                 roomStore,
                 this.config.homeserver.domain,
                 pkeyPath,
             );
+            await ndbDatastore.runMigrations();
+            this.dataStore = ndbDatastore;
             if (this.config.ircService.debugApi.enabled) {
                 // monkey patch inspect() values to avoid useless NeDB
                 // struct spam on the debug API.

--- a/src/datastore/DataStore.ts
+++ b/src/datastore/DataStore.ts
@@ -135,9 +135,9 @@ export interface DataStore {
 
     removeConfigMappings(): Promise<void>;
 
-    getIpv6Counter(): Promise<number>;
+    getIpv6Counter(server: IrcServer, homeserver: string|null): Promise<number>;
 
-    setIpv6Counter(counter: number): Promise<void>;
+    setIpv6Counter(counter: number, server: IrcServer, homeserver: string|null): Promise<void>;
 
     getAdminRoomById(roomId: string): Promise<MatrixRoom|null>;
 

--- a/src/datastore/NedbDataStore.ts
+++ b/src/datastore/NedbDataStore.ts
@@ -84,12 +84,27 @@ export class NeDBDataStore implements DataStore {
             this.cryptoStore = new StringCrypto();
             this.cryptoStore.load(pkeyPath);
         }
-        // Cache as many mappings as possible for hot paths like message sending.
+    }
 
-        // TODO: cache IRC channel -> [room_id] mapping (only need to remove them in
-        //       removeRoom() which is infrequent)
-        // TODO: cache room_id -> [#channel] mapping (only need to remove them in
-        //       removeRoom() which is infrequent)
+
+    public async runMigrations() {
+        log.warn(`Migrating NeDB datastore ipv6 counters`);
+        const config = await this.userStore.getRemoteUser("config");
+        if (!config) {
+            // No migrations needed.
+            return;
+        }
+        const counter = config.get<number>("ipv6_counter");
+        if (!counter) {
+            // No migrations needed.
+            return;
+        }
+        const servers = Object.values(this.serverMappings).map(s => s.domain.replace(/\./g, '_'));
+        for (const server of servers) {
+            config.set(`ipv6_counter_${server}`, {'*': counter});
+        }
+        config.set("ipv6_counter", null);
+        await this.userStore.setRemoteUser(config);
     }
 
     public async setServerFromConfig(server: IrcServer, serverConfig: IrcServerConfig): Promise<void> {
@@ -437,23 +452,31 @@ export class NeDBDataStore implements DataStore {
         });
     }
 
-    public async getIpv6Counter(): Promise<number> {
+    public async getIpv6Counter(server: IrcServer, homeserver: string|null): Promise<number> {
+        const domain = server.domain.replace(/\./g, '_');
         let config = await this.userStore.getRemoteUser("config");
         if (!config) {
             config = new RemoteUser("config");
-            config.set("ipv6_counter", 0);
+        }
+        let counters = config.get<{[homeserver: string]: number}>(`ipv6_counter_${domain}`);
+        if (!counters) {
+            counters = {'*': 0};
+            config.set(`ipv6_counter_${domain}`, counters);
             await this.userStore.setRemoteUser(config);
         }
-        return config.get("ipv6_counter") as number;
+        return homeserver ? counters[homeserver] : counters['*'];
     }
 
 
-    public async setIpv6Counter(counter: number) {
+    public async setIpv6Counter(counter: number, server: IrcServer, homeserver: string|null) {
+        const domain = server.domain.replace(/\./g, '_');
         let config = await this.userStore.getRemoteUser("config");
         if (!config) {
             config = new RemoteUser("config");
         }
-        config.set("ipv6_counter", counter);
+        const counters = config.get<{[homeserver: string]: number}>(`ipv6_counter_${domain}`) || {};
+        counters[homeserver || '*'] = counter;
+        config.set(`ipv6_counter_${domain}`, counter);
         await this.userStore.setRemoteUser(config);
     }
 

--- a/src/datastore/postgres/PgDataStore.ts
+++ b/src/datastore/postgres/PgDataStore.ts
@@ -436,7 +436,7 @@ export class PgDataStore implements DataStore {
             "SELECT count FROM ipv6_counter WHERE server = $1 AND homeserver = $2",
             [server.domain, homeserver]
         );
-        return res ? parseInt(res.rows[0].count, 10) : 0;
+        return res.rows[0]?.count !== undefined ? parseInt(res.rows[0].count, 10) : 0;
     }
 
     public async setIpv6Counter(counter: number, server: IrcServer, homeserver: string|null): Promise<void> {

--- a/src/datastore/postgres/PgDataStore.ts
+++ b/src/datastore/postgres/PgDataStore.ts
@@ -432,6 +432,7 @@ export class PgDataStore implements DataStore {
     }
 
     public async getIpv6Counter(server: IrcServer, homeserver: string|null): Promise<number> {
+        homeserver = homeserver || "*";
         const res = await this.pgPool.query(
             "SELECT count FROM ipv6_counter WHERE server = $1 AND homeserver = $2",
             [server.domain, homeserver]
@@ -449,7 +450,7 @@ export class PgDataStore implements DataStore {
                     "server"
                 ],
             ),
-            [counter, server.domain, homeserver],
+            [counter, server.domain, homeserver || "*"],
         );
     }
 

--- a/src/datastore/postgres/PgDataStore.ts
+++ b/src/datastore/postgres/PgDataStore.ts
@@ -54,7 +54,7 @@ interface RoomRecord {
 export class PgDataStore implements DataStore {
     private serverMappings: {[domain: string]: IrcServer} = {};
 
-    public static readonly LATEST_SCHEMA = 7;
+    public static readonly LATEST_SCHEMA = 8;
     private pgPool: Pool;
     private hasEnded = false;
     private cryptoStore?: StringCrypto;
@@ -431,13 +431,26 @@ export class PgDataStore implements DataStore {
         await this.pgPool.query("DELETE FROM rooms WHERE origin = 'config'");
     }
 
-    public async getIpv6Counter(): Promise<number> {
-        const res = await this.pgPool.query("SELECT count FROM ipv6_counter");
+    public async getIpv6Counter(server: IrcServer, homeserver: string|null): Promise<number> {
+        const res = await this.pgPool.query(
+            "SELECT count FROM ipv6_counter WHERE server = $1 AND homeserver = $2",
+            [server.domain, homeserver]
+        );
         return res ? parseInt(res.rows[0].count, 10) : 0;
     }
 
-    public async setIpv6Counter(counter: number): Promise<void> {
-        await this.pgPool.query("UPDATE ipv6_counter SET count = $1", [counter]);
+    public async setIpv6Counter(counter: number, server: IrcServer, homeserver: string|null): Promise<void> {
+        await this.pgPool.query(
+            PgDataStore.BuildUpsertStatement(
+                "ipv6_counter",
+                "ON CONSTRAINT cons_ipv6_counter_unique", [
+                    "count",
+                    "homeserver",
+                    "server"
+                ],
+            ),
+            [counter, server.domain, homeserver],
+        );
     }
 
     public async upsertMatrixRoom(room: MatrixRoom): Promise<void> {

--- a/src/datastore/postgres/PgDataStore.ts
+++ b/src/datastore/postgres/PgDataStore.ts
@@ -450,7 +450,7 @@ export class PgDataStore implements DataStore {
                     "server"
                 ],
             ),
-            [counter, server.domain, homeserver || "*"],
+            [counter, homeserver || "*", server.domain],
         );
     }
 

--- a/src/datastore/postgres/schema/v8.ts
+++ b/src/datastore/postgres/schema/v8.ts
@@ -13,7 +13,7 @@ function domainSetToValues(domains: string[], count: number): [string, Array<str
             res += ", ";
         }
         res += `($${i+1}, $${i+2}, $${i+3})`;
-        values.push(count, null, domains[index]);
+        values.push(count, "*", domains[index]);
     }
     return [res, values];
 }

--- a/src/datastore/postgres/schema/v8.ts
+++ b/src/datastore/postgres/schema/v8.ts
@@ -1,0 +1,55 @@
+import { PoolClient } from "pg";
+import { Logging } from "matrix-appservice-bridge";
+
+const log = Logging.get('postgres/schema/v8');
+
+function domainSetToValues(domains: string[], count: number): [string, Array<string|number|null>] {
+    let res = "";
+    const values: Array<string|number|null> = [];
+    // VALUES ...
+    for (let index = 0; index < domains.length; index++) {
+        const i = index * 3;
+        if (res) {
+            res += ", ";
+        }
+        res += `($${i}, $${i+1}, $${i+2})`;
+        values.push(count, null, domains[index]);
+    }
+    return [res, values];
+}
+
+export async function runSchema(connection: PoolClient) {
+
+    await connection.query(`
+        ALTER TABLE ipv6_counter
+        ADD COLUMN homeserver TEXT,
+        ADD COLUMN server TEXT;
+        ALTER TABLE ipv6_counter
+        ADD CONSTRAINT cons_ipv6_counter_unique UNIQUE(homeserver, server);
+    `);
+
+
+    // Migrate data.
+    const existingCounterRes = await connection.query("SELECT count FROM ipv6_counter;");
+    const existingCounter = existingCounterRes ? parseInt(existingCounterRes.rows[0].count, 10) : 0;
+    if (existingCounter) {
+        // No need to migrate, no data.
+        const serverConfigsRes = await connection.query<{domain: string}>(
+            "SELECT DISTINCT domain FROM client_config WHERE config->>'ipv6' IS NOT NULL;"
+        );
+        if (serverConfigsRes.rowCount === 0) {
+            // No servers to migrate?
+            throw Error("No client_configs found with ipv6 addresses, but counter was found");
+        }
+        else if (serverConfigsRes.rowCount > 1) {
+            log.warn("More than one IPv6 server configured, starting both ipv6 counters from the same value.")
+        }
+        const [statement, values] = domainSetToValues(serverConfigsRes.rows.map(d => d.domain), existingCounter);
+        await connection.query(`INSERT INTO ipv6_counter (count, homeserver, server) VALUES ${statement}`, values);
+    }
+
+    await connection.query(`
+        DELETE FROM ipv6_counter WHERE server IS NULL;
+        ALTER TABLE ipv6_counter ALTER COLUMN server SET NOT NULL;
+    `);
+}

--- a/src/datastore/postgres/schema/v8.ts
+++ b/src/datastore/postgres/schema/v8.ts
@@ -43,7 +43,7 @@ export async function runSchema(connection: PoolClient) {
             throw Error("No client_configs found with ipv6 addresses, but counter was found");
         }
         else if (serverConfigsRes.rowCount > 1) {
-            log.warn("More than one IPv6 server configured, starting both ipv6 counters from the same value.")
+            log.warn("More than one IPv6 server configured, starting both ipv6 counters from the same value.");
         }
         // Because we cannot determine which IRC network(s) are using the existing counter
         // (owing to a bug where we treated the counter as global across all networks), this assumes

--- a/src/datastore/postgres/schema/v8.ts
+++ b/src/datastore/postgres/schema/v8.ts
@@ -12,7 +12,7 @@ function domainSetToValues(domains: string[], count: number): [string, Array<str
         if (res) {
             res += ", ";
         }
-        res += `($${i}, $${i+1}, $${i+2})`;
+        res += `($${i+1}, $${i+2}, $${i+3})`;
         values.push(count, null, domains[index]);
     }
     return [res, values];

--- a/src/irc/BridgedClient.ts
+++ b/src/irc/BridgedClient.ts
@@ -227,7 +227,7 @@ export class BridgedClient extends EventEmitter {
             if (ipv6Prefix) {
                 // side-effects setting the IPv6 address on the client config
                 await this.ipv6Generator.generate(
-                    ipv6Prefix, this.clientConfig
+                    ipv6Prefix, this.clientConfig, this.server,
                 );
             }
             this.log.info(

--- a/src/irc/Ipv6Generator.ts
+++ b/src/irc/Ipv6Generator.ts
@@ -35,10 +35,6 @@ export class Ipv6Generator {
         });
     }
 
-    // debugging: util.inspect()
-    public inspect () {
-    }
-
     public getCounterKey(userId: string|null, server: IrcServer) {
         if (!userId) {
             // Bot uses the global pool.

--- a/src/irc/Ipv6Generator.ts
+++ b/src/irc/Ipv6Generator.ts
@@ -43,13 +43,13 @@ export class Ipv6Generator {
     public getCounterKey(userId: string|null, server: IrcServer) {
         if (!userId) {
             // Bot uses the global pool.
-            return '*';
+            return server.domain;
         }
         const homeserver = new MatrixUser(userId).host;
         if (server.getIpv6BlockForHomeserver(homeserver)) {
             return `${server.domain}/${homeserver}`;
         }
-        return '*';
+        return server.domain;
     }
 
     /**
@@ -75,7 +75,7 @@ export class Ipv6Generator {
         const homeserver = userId && new MatrixUser(userId).host;
 
         if (!this.counter.has(counterKey)) {
-            log.info("Retrieving counter...");
+            log.info(`Retrieving counter ${counterKey}`);
             this.counter.set(counterKey, await this.dataStore.getIpv6Counter(server, homeserver));
         }
 
@@ -97,8 +97,8 @@ export class Ipv6Generator {
         const homeserver = userId && new MatrixUser(userId).host;
         const counterKey = this.getCounterKey(userId, server);
         let counter = this.counter.get(counterKey);
-        if (!counter) {
-            throw Error('No existing counter');
+        if (typeof counter !== "number") {
+            throw Error(`No existing counter '${counterKey}'`);
         }
         counter += 1;
         this.counter.set(counterKey, counter);

--- a/src/irc/Ipv6Generator.ts
+++ b/src/irc/Ipv6Generator.ts
@@ -88,7 +88,7 @@ export class Ipv6Generator {
         // We should be safe to pull out counter values here.
         if (typeof counter !== "number") {
             log.debug(`Retrieving counter ${counterKey}`);
-            counter = await this.dataStore.getIpv6Counter(server, homeserver);
+            counter = await this.dataStore.getIpv6Counter(server, isInBlock ? homeserver : null);
             this.counter.set(counterKey, counter);
         }
         counter += 1;

--- a/src/irc/Ipv6Generator.ts
+++ b/src/irc/Ipv6Generator.ts
@@ -18,24 +18,38 @@ import { Queue } from "../util/Queue";
 import { getLogger } from "../logging";
 import { DataStore } from "../datastore/DataStore";
 import { IrcClientConfig } from "../models/IrcClientConfig";
+import { IrcServer } from "./IrcServer";
+import { MatrixUser } from "matrix-appservice-bridge";
 
 const log = getLogger("Ipv6Generator");
 
 export class Ipv6Generator {
-    private counter = -1;
-    private queue: Queue<{prefix: string; ircClientConfig: IrcClientConfig}>;
+    private counter = new Map<string, number>();
+    private queue: Queue<{prefix: string; ircClientConfig: IrcClientConfig, server: IrcServer}>;
     constructor (private readonly dataStore: DataStore) {
         // Queue of ipv6 generation requests.
         // We need to queue them because otherwise 2 clashing user_ids could be assigned
         // the same ipv6 value (won't be in the database yet)
         this.queue = new Queue((item) => {
-            return this.process(item.prefix, item.ircClientConfig);
+            return this.process(item.prefix, item.ircClientConfig, item.server);
         });
     }
 
     // debugging: util.inspect()
     public inspect () {
         return `IPv6Counter=${this.counter},Queue.length=${this.queue.size}`;
+    }
+
+    public getCounterKey(userId: string|null, server: IrcServer) {
+        if (!userId) {
+            // Bot uses the global pool.
+            return '*';
+        }
+        const homeserver = new MatrixUser(userId).host;
+        if (server.getIpv6BlockForHomeserver(homeserver)) {
+            return `${server.domain}/${homeserver}`;
+        }
+        return '*';
     }
 
     /**
@@ -45,19 +59,24 @@ export class Ipv6Generator {
      * @return {Promise} Resolves to the IPv6 address generated; the IPv6 address will
      * already be set on the given config.
      */
-    public async generate (prefix: string, ircClientConfig: IrcClientConfig): Promise<string> {
+    public async generate (prefix: string, ircClientConfig: IrcClientConfig, server: IrcServer): Promise<string> {
         const existingAddress = ircClientConfig.getIpv6Address();
+        const userId = ircClientConfig.getUserId();
         if (existingAddress) {
             log.info(
                 "Using existing IPv6 address %s for %s",
                 existingAddress,
-                ircClientConfig.getUserId()
+                userId,
             );
             return existingAddress;
         }
-        if (this.counter === -1) {
+
+        const counterKey = this.getCounterKey(userId, server);
+        const homeserver = userId && new MatrixUser(userId).host;
+
+        if (!this.counter.has(counterKey)) {
             log.info("Retrieving counter...");
-            this.counter = await this.dataStore.getIpv6Counter();
+            this.counter.set(counterKey, await this.dataStore.getIpv6Counter(server, homeserver));
         }
 
         // the bot user will not have a user ID
@@ -68,22 +87,39 @@ export class Ipv6Generator {
         log.info("Enqueueing IPv6 generation request for %s", id);
         return (await this.queue.enqueue(id, {
             prefix: prefix,
-            ircClientConfig: ircClientConfig
+            ircClientConfig: ircClientConfig,
+            server: server,
         })) as string;
     }
 
-    public async process (prefix: string, ircClientConfig: IrcClientConfig) {
-        this.counter += 1;
+    public async process (prefix: string, ircClientConfig: IrcClientConfig, server: IrcServer) {
+        const userId = ircClientConfig.getUserId();
+        const homeserver = userId && new MatrixUser(userId).host;
+        const counterKey = this.getCounterKey(userId, server);
+        let counter = this.counter.get(counterKey);
+        if (!counter) {
+            throw Error('No existing counter');
+        }
+        counter += 1;
+        this.counter.set(counterKey, counter);
+
+        if (homeserver) {
+            // If this homeserver has been put in a special block, append
+            // the start range to the counter.
+            const block = server.getIpv6BlockForHomeserver(homeserver);
+            if (block) {
+                counter += parseInt(block.replace(/:/g, ''), 16);
+            }
+        }
 
         // insert : every 4 characters from the end of the string going to the start
         // e.g. 1a2b3c4d5e6 => 1a2:b3c4:d5e6
-        const suffix = this.counter.toString(16).replace(/\B(?=(.{4})+(?!.))/g, ':');
+        const suffix = counter.toString(16).replace(/\B(?=(.{4})+(?!.))/g, ':');
         const address = prefix + suffix;
 
         let config = ircClientConfig;
         config.setIpv6Address(address);
 
-        const userId = ircClientConfig.getUserId();
         // we only want to persist the IPv6 address for real matrix users
         if (userId) {
             const existingConfig = await this.dataStore.getIrcClientConfig(
@@ -98,7 +134,7 @@ export class Ipv6Generator {
             await this.dataStore.storeIrcClientConfig(config);
         }
 
-        await this.dataStore.setIpv6Counter(this.counter);
+        await this.dataStore.setIpv6Counter(counter, server, homeserver);
         return config.getIpv6Address();
     }
 }

--- a/src/irc/Ipv6Generator.ts
+++ b/src/irc/Ipv6Generator.ts
@@ -82,6 +82,7 @@ export class Ipv6Generator {
         const userId = ircClientConfig.getUserId();
         const homeserver = userId && new MatrixUser(userId).host;
         const counterKey = this.getCounterKey(userId, server);
+        const isInBlock = !!(homeserver && server.getIpv6BlockForHomeserver(homeserver));
         let counter = this.counter.get(counterKey);
         // This function should never be called asyncronously, as it's backed by a queue.
         // We should be safe to pull out counter values here.
@@ -124,7 +125,7 @@ export class Ipv6Generator {
             await this.dataStore.storeIrcClientConfig(config);
         }
 
-        await this.dataStore.setIpv6Counter(counter, server, homeserver);
+        await this.dataStore.setIpv6Counter(counter, server, isInBlock ? homeserver : null);
         return config.getIpv6Address();
     }
 }

--- a/src/irc/Ipv6Generator.ts
+++ b/src/irc/Ipv6Generator.ts
@@ -92,19 +92,19 @@ export class Ipv6Generator {
         }
         counter += 1;
         this.counter.set(counterKey, counter);
-
+        let ipv6CounterSuffix: number = counter;
         if (homeserver) {
             // If this homeserver has been put in a special block, append
             // the start range to the counter.
             const block = server.getIpv6BlockForHomeserver(homeserver);
             if (block) {
-                counter += parseInt(block.replace(/:/g, ''), 16);
+                ipv6CounterSuffix = counter + parseInt(block.replace(/:/g, ''), 16);
             }
         }
 
         // insert : every 4 characters from the end of the string going to the start
         // e.g. 1a2b3c4d5e6 => 1a2:b3c4:d5e6
-        const suffix = counter.toString(16).replace(/\B(?=(.{4})+(?!.))/g, ':');
+        const suffix = ipv6CounterSuffix.toString(16).replace(/\B(?=(.{4})+(?!.))/g, ':');
         const address = prefix + suffix;
 
         let config = ircClientConfig;

--- a/src/irc/IrcServer.ts
+++ b/src/irc/IrcServer.ts
@@ -94,6 +94,10 @@ export interface IrcServerConfig {
         ipv6: {
             only: boolean;
             prefix?: string;
+            blocks?: {
+                homeserver: string;
+                startFrom: string;
+            }[]
         };
         lineLimit: number;
         userModes?: string;
@@ -687,6 +691,14 @@ export class IrcServer {
         );
     }
 
+    public getIpv6BlockForHomeserver(homeserver: string): string|null {
+        const result = this.config.ircClients.ipv6.blocks?.find(block => block.homeserver === homeserver);
+        if (result) {
+            return result.startFrom;
+        }
+        return null;
+    }
+
     public static get DEFAULT_CONFIG(): IrcServerConfig {
         return {
             sendConnectionMessages: true,
@@ -774,6 +786,16 @@ export class IrcServer {
                 ...config.tlsOptions,
                 ca: config.ca,
             };
+        }
+
+        if (config.ircClients.ipv6.blocks) {
+            // Check those blocks
+            const invalidBlocks = config.ircClients.ipv6.blocks.filter( block =>
+                isNaN(parseInt(block.startFrom.replace(/:/g, ''), 16))
+            ).map(block => block.homeserver).join(', ');
+            if (invalidBlocks) {
+                throw Error(`Invalid ircClients.ipv6.blocks entry(s): ${invalidBlocks}`);
+            }
         }
 
         this.config = config;


### PR DESCRIPTION
This required a fairly large reworking of our ipv6 counter systems, to support both Postgres and NeDB. 