### PR TITLE
Fix user -> bot invites getting ignored

### DIFF
--- a/src/bridge/MatrixHandler.ts
+++ b/src/bridge/MatrixHandler.ts
@@ -169,19 +169,13 @@ export class MatrixHandler {
 
         // Do not create an admin room if the room is marked as 'plumbed'
         const matrixClient = this.ircBridge.getAppServiceBridge().getIntent();
-
-        try {
-            const plumbedState = await matrixClient.getStateEvent(event.room_id, 'm.room.plumbing');
-            if (plumbedState.status === "enabled") {
-                req.log.info(
-                    'This room is marked for plumbing (m.room.plumbing.status = "enabled"). ' +
-                    'Not treating room as admin room.'
-                );
-                return;
-            }
-        }
-        catch (err) {
-            req.log.debug(`Not a plumbed room: Error retrieving m.room.plumbing (${err.data.error})`);
+        const plumbedState = await matrixClient.getStateEvent(event.room_id, 'm.room.plumbing', '', true);
+        if (plumbedState?.status === "enabled") {
+            req.log.info(
+                'This room is marked for plumbing (m.room.plumbing.status = "enabled"). ' +
+                'Not treating room as admin room.'
+            );
+            return;
         }
 
         // clobber any previous admin room ID


### PR DESCRIPTION
If `plumbedState` wasn't set, the code would throw and the invite would not be handled.