### PR TITLE
Synchronise bridge with m.policy.rule.* updates

### DIFF
--- a/changelog.d/1532.feature
+++ b/changelog.d/1532.feature
@@ -1,1 +1,1 @@
-Add support for subscribing to moderation policy rules in order to enforce bans.
+Add support for subscribing to moderation policy. See http://matrix-org.github.io/matrix-appservice-irc/administrators_guide.html#subscribing-to-moderation-policys for more information.

--- a/changelog.d/1532.feature
+++ b/changelog.d/1532.feature
@@ -1,0 +1,1 @@
+Add support for subscribing to moderation policy rules in order to enforce bans.

--- a/changelog.d/1532.feature
+++ b/changelog.d/1532.feature
@@ -1,1 +1,1 @@
-Add support for subscribing to moderation policy. See http://matrix-org.github.io/matrix-appservice-irc/administrators_guide.html#subscribing-to-moderation-policys for more information.
+Add support for subscribing to moderation policy. See http://matrix-org.github.io/matrix-appservice-irc/administrators_guide.html#subscribing-to-moderation-policies for more information.

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -626,6 +626,13 @@ ircService:
     # the configuration in the config file.
     # allowUnconnectedMatrixUsers: true
 
+  # Options for hooking into Matrix moderation policy lists 
+  banLists:
+    # A list of rooms containing "m.policy.rule.*" events which can be used
+    # to identify banned users, rooms and servers.
+    rooms:
+      - "#matrix-org-coc-bl:matrix.org"
+
 # Options here are generally only applicable to large-scale bridges and may have
 # consequences greater than other options in this configuration file.
 advanced:

--- a/config.schema.yml
+++ b/config.schema.yml
@@ -176,6 +176,13 @@ properties:
                         type: "number"
                     allowUnconnectedMatrixUsers:
                         type: "boolean"
+            banLists:
+                type: "object"
+                properties:
+                    rooms:
+                        type: "array"
+                        items:
+                            pattern: "^(!|#).+:.+"
             servers:
                 type: "object"
                 # all properties must follow the following

--- a/docs/administrators_guide.md
+++ b/docs/administrators_guide.md
@@ -78,6 +78,28 @@ membershipLists:
 in the config. Users can choose to disable this on a per-room basis by modfiying their
 [room config](./room_configuration.md#allowunconnectedmatrixusers) options, if the bridge permits it.
 
+## Subscribing to Moderation policys
+
+Matrix has support for specifying [moderation policy lists](https://spec.matrix.org/v1.2/client-server-api/#moderation-policy-lists).
+Moderation policys are set by services such as [Mjolnir](https://github.com/matrix-org/mjolnir) and can be
+used to inform other services as to how to deal with content.
+
+The bridge can subscribe to rooms containing these policies and can then choose to filter out users and
+servers matching these rules.
+
+```yaml
+  banLists:
+    rooms:
+      - "#matrix-org-coc-bl:matrix.org" # The matrix.org code of conduct ban list
+```
+
+A `m.ban` rule will forcibly kill the connection of any user matching a ban, and will not
+allow them to reconnect. The rules are enforced on startup, when the ban list is modified
+and when the configuration file is reloaded.
+
+Administrators should beware that this configuration is very powerful, and any user caught
+on this list will not be able to use the bridge at all.
+
 ## Metrics / Grafana
 
 The bridge includes a prometheus compatible metrics endpoint which can be used to inspect

--- a/docs/administrators_guide.md
+++ b/docs/administrators_guide.md
@@ -97,7 +97,7 @@ A `m.ban` rule will forcibly kill the connection of any user matching a ban, and
 allow them to reconnect. The rules are enforced on startup, when the ban list is modified
 and when the configuration file is reloaded.
 
-Administrators should beware that this configuration is very powerful, and any user caught
+Administrators should beware that this configuration is **very** powerful, and any user caught
 on this list will not be able to use the bridge at all.
 
 ## Metrics / Grafana

--- a/docs/administrators_guide.md
+++ b/docs/administrators_guide.md
@@ -78,10 +78,10 @@ membershipLists:
 in the config. Users can choose to disable this on a per-room basis by modfiying their
 [room config](./room_configuration.md#allowunconnectedmatrixusers) options, if the bridge permits it.
 
-## Subscribing to Moderation policys
+## Subscribing to Moderation policies
 
 Matrix has support for specifying [moderation policy lists](https://spec.matrix.org/v1.2/client-server-api/#moderation-policy-lists).
-Moderation policys are set by services such as [Mjolnir](https://github.com/matrix-org/mjolnir) and can be
+Moderation policies are set by services such as [Mjolnir](https://github.com/matrix-org/mjolnir) and can be
 used to inform other services as to how to deal with content.
 
 The bridge can subscribe to rooms containing these policies and can then choose to filter out users and

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "he": "^1.2.0",
         "logform": "^2.4.0",
         "matrix-appservice-bridge": "^3.2.0",
+        "matrix-bot-sdk": "0.5.19",
         "matrix-org-irc": "^1.2.0",
         "nopt": "^3.0.1",
         "p-queue": "^6.6.2",
@@ -3848,6 +3849,41 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/matrix-bot-sdk": {
+      "version": "0.5.19",
+      "resolved": "https://registry.npmjs.org/matrix-bot-sdk/-/matrix-bot-sdk-0.5.19.tgz",
+      "integrity": "sha512-RIPyvQPkOVp2yTKeDgp5rcn6z/DiKdHb6E8c69K+utai8ypRGtfDRj0PGqP+1XzqC9Wb1OFrESCUB5t0ffdC9g==",
+      "dependencies": {
+        "@types/express": "^4.17.7",
+        "chalk": "^4.1.0",
+        "express": "^4.17.1",
+        "glob-to-regexp": "^0.4.1",
+        "hash.js": "^1.1.7",
+        "html-to-text": "^6.0.0",
+        "htmlencode": "^0.0.4",
+        "lowdb": "^1.0.0",
+        "lru-cache": "^6.0.0",
+        "mkdirp": "^1.0.4",
+        "morgan": "^1.10.0",
+        "request": "^2.88.2",
+        "request-promise": "^4.2.6",
+        "sanitize-html": "^2.3.2"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/matrix-bot-sdk/node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/matrix-js-sdk": {
@@ -9054,6 +9090,34 @@
           "requires": {
             "abbrev": "1"
           }
+        }
+      }
+    },
+    "matrix-bot-sdk": {
+      "version": "0.5.19",
+      "resolved": "https://registry.npmjs.org/matrix-bot-sdk/-/matrix-bot-sdk-0.5.19.tgz",
+      "integrity": "sha512-RIPyvQPkOVp2yTKeDgp5rcn6z/DiKdHb6E8c69K+utai8ypRGtfDRj0PGqP+1XzqC9Wb1OFrESCUB5t0ffdC9g==",
+      "requires": {
+        "@types/express": "^4.17.7",
+        "chalk": "^4.1.0",
+        "express": "^4.17.1",
+        "glob-to-regexp": "^0.4.1",
+        "hash.js": "^1.1.7",
+        "html-to-text": "^6.0.0",
+        "htmlencode": "^0.0.4",
+        "lowdb": "^1.0.0",
+        "lru-cache": "^6.0.0",
+        "mkdirp": "^1.0.4",
+        "morgan": "^1.10.0",
+        "request": "^2.88.2",
+        "request-promise": "^4.2.6",
+        "sanitize-html": "^2.3.2"
+      },
+      "dependencies": {
+        "mkdirp": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "logform": "^2.4.0",
     "matrix-appservice-bridge": "^3.2.0",
     "matrix-org-irc": "^1.2.0",
+    "matrix-bot-sdk": "0.5.19",
     "nopt": "^3.0.1",
     "p-queue": "^6.6.2",
     "pg": "^8.7.3",

--- a/spec/unit/MatrixBanSync.spec.js
+++ b/spec/unit/MatrixBanSync.spec.js
@@ -5,7 +5,7 @@ const BANNED_USER_STATE_EVENT = {
     type: "m.policy.rule.user",
     state_key: 'banned-user',
     content: {
-        reccomendation: 'm.ban',
+        recommendation: 'm.ban',
         entity: '@user:banned.com',
         reason: 'badly-behaved',
     }
@@ -21,7 +21,7 @@ const BANNED_SERVER_STATE_EVENT = {
     type: "m.policy.rule.server",
     state_key: 'banned-server',
     content: {
-        reccomendation: 'm.ban',
+        recommendation: 'm.ban',
         entity: 'banned-server.com',
         reason: 'badly-constructed',
     }
@@ -64,10 +64,10 @@ describe("MatrixBanSync", () => {
             expect(banSync.handleIncomingState(ev, '!valid:room')).toBeFalse();
             expect(banSync.bannedEntites.get(`!valid:room:banned-user`)).toBeUndefined();
         });
-        it("should skip unknown reccomendation", () => {
+        it("should skip unknown recommendation", () => {
             const ev = {...BANNED_USER_STATE_EVENT, content: {
                 ...BANNED_USER_STATE_EVENT.content,
-                reccomendation: 'm.tea-party',
+                recommendation: 'm.tea-party',
             }};
             expect(banSync.handleIncomingState(ev, '!valid:room')).toBeFalse();
             expect(banSync.bannedEntites.get(`!valid:room:banned-user`)).toBeUndefined();
@@ -121,7 +121,7 @@ describe("MatrixBanSync", () => {
                                 type: 'm.policy.rule.server',
                                 state_key: 'should-not-be-here',
                                 content: {
-                                    reccomendation: 'still-not-interested',
+                                    recommendation: 'still-not-interested',
                                     entity: 'foo.com',
                                     reason: 'foo',
                                 }

--- a/spec/unit/MatrixBanSync.spec.js
+++ b/spec/unit/MatrixBanSync.spec.js
@@ -1,0 +1,151 @@
+const { MatrixGlob } = require("matrix-bot-sdk");
+const { MatrixBanSync } = require("../../lib/bridge/MatrixBanSync");
+
+const BANNED_USER_STATE_EVENT = {
+    type: "m.policy.rule.user",
+    state_key: 'banned-user',
+    content: {
+        reccomendation: 'm.ban',
+        entity: '@user:banned.com',
+        reason: 'badly-behaved',
+    }
+};
+
+const BANNED_USER_ENTITY = {
+    matcher: new MatrixGlob(BANNED_USER_STATE_EVENT.content.entity),
+    entityType: BANNED_USER_STATE_EVENT.type,
+    reason: BANNED_USER_STATE_EVENT.content.reason
+};
+
+const BANNED_SERVER_STATE_EVENT = {
+    type: "m.policy.rule.server",
+    state_key: 'banned-server',
+    content: {
+        reccomendation: 'm.ban',
+        entity: 'banned-server.com',
+        reason: 'badly-constructed',
+    }
+};
+
+const BANNED_SERVER_ENTITY = {
+    matcher: new MatrixGlob(BANNED_SERVER_STATE_EVENT.content.entity),
+    entityType: BANNED_SERVER_STATE_EVENT.type,
+    reason: BANNED_SERVER_STATE_EVENT.content.reason
+};
+
+let banSync;
+
+describe("MatrixBanSync", () => {
+    beforeEach(() => {
+        banSync = new MatrixBanSync({ rooms: [] });
+        banSync.interestingRooms = new Set(["!valid:room"]);
+    })
+    describe("isUserBanned", () => {
+        it("should return false for a empty ban set", () => {
+            expect(banSync.isUserBanned('@foo:bar')).toBeFalse();
+        });
+        it("should return false for a empty ban set", () => {
+            banSync.bannedEntites.set('foo', BANNED_SERVER_ENTITY);
+            banSync.bannedEntites.set('bar', BANNED_USER_ENTITY);
+            expect(banSync.isUserBanned('@foo:bar')).toBeFalse();
+        });
+        it("should return a reason for a matching user ban", () => {
+            banSync.bannedEntites.set('foo', BANNED_USER_ENTITY);
+            expect(banSync.isUserBanned('@user:banned.com')).toEqual(BANNED_USER_ENTITY.reason);
+        });
+        it("should return a reason for a matching server ban", () => {
+            banSync.bannedEntites.set('foo', BANNED_SERVER_ENTITY);
+            expect(banSync.isUserBanned('@user:banned-server.com')).toEqual(BANNED_SERVER_ENTITY.reason);
+        });
+    });
+    describe("handleIncomingState", () => {
+        it("should skip unknown type", () => {
+            const ev = {...BANNED_USER_STATE_EVENT, type: 'not-a-real-type'};
+            expect(banSync.handleIncomingState(ev, '!valid:room')).toBeFalse();
+            expect(banSync.bannedEntites.get(`!valid:room:banned-user`)).toBeUndefined();
+        });
+        it("should skip unknown reccomendation", () => {
+            const ev = {...BANNED_USER_STATE_EVENT, content: {
+                ...BANNED_USER_STATE_EVENT.content,
+                reccomendation: 'm.tea-party',
+            }};
+            expect(banSync.handleIncomingState(ev, '!valid:room')).toBeFalse();
+            expect(banSync.bannedEntites.get(`!valid:room:banned-user`)).toBeUndefined();
+        });
+        it("should return true for new user ban event", () => {
+            expect(banSync.handleIncomingState(BANNED_USER_STATE_EVENT, '!valid:room')).toBeTrue();
+            expect(
+                banSync.bannedEntites.get(`!valid:room:banned-user`)
+            ).toEqual(BANNED_USER_ENTITY);
+        });
+        it("should return true for new user ban event", () => {
+            expect(banSync.handleIncomingState(BANNED_USER_STATE_EVENT, '!valid:room')).toBeTrue();
+            expect(
+                banSync.bannedEntites.get(`!valid:room:banned-user`)
+            ).toEqual(BANNED_USER_ENTITY);
+        });
+        it("should return true for new server ban event", () => {
+            expect(banSync.handleIncomingState(BANNED_SERVER_STATE_EVENT, '!valid:room')).toBeTrue();
+            expect(
+                banSync.bannedEntites.get(`!valid:room:banned-server`)
+            ).toEqual(BANNED_SERVER_ENTITY);
+        });
+        it("should delete old rules", () => {
+            expect(banSync.handleIncomingState(BANNED_SERVER_STATE_EVENT, '!valid:room')).toBeTrue();
+            expect(
+                banSync.bannedEntites.get(`!valid:room:banned-server`)
+            ).toEqual(BANNED_SERVER_ENTITY);
+            expect(banSync.handleIncomingState({
+                ...BANNED_SERVER_STATE_EVENT,
+                content: {},
+            }, '!valid:room')).toBeFalse();
+            expect(
+                banSync.bannedEntites.get(`!valid:room:banned-server`)
+            ).toBeUndefined();
+        });
+    });
+    describe("syncRules", () => {
+        it("should sync state from a set of rooms", async () => {
+            banSync.config.rooms = ["!valid:room", "#anothervalid:room", "!notvalid:room"];
+            const intent = {
+                join: async (roomOrAlias) => {
+                    if (roomOrAlias.includes('valid:room')) {
+                        return roomOrAlias.replace('#', '!');
+                    }
+                    throw Error('Room not known');
+                },
+                roomState: async (roomId) => {
+                    if (roomId === '!valid:room') {
+                        return [
+                            {
+                                type: 'm.policy.rule.server',
+                                state_key: 'should-not-be-here',
+                                content: {
+                                    reccomendation: 'still-not-interested',
+                                    entity: 'foo.com',
+                                    reason: 'foo',
+                                }
+                            },
+                            BANNED_SERVER_STATE_EVENT,
+                        ];
+                    }
+                    else if (roomId === '!anothervalid:room') {
+                        return [
+                            {type: 'not-interested'},
+                            BANNED_USER_STATE_EVENT,
+                        ];
+                    }
+                    throw Error('Unknown room');
+                },
+            }
+            await banSync.syncRules(intent);
+            expect(banSync.bannedEntites.size).toEqual(2);
+            expect(
+                banSync.bannedEntites.get(`!valid:room:banned-server`)
+            ).toEqual(BANNED_SERVER_ENTITY);
+            expect(
+                banSync.bannedEntites.get(`!anothervalid:room:banned-user`)
+            ).toEqual(BANNED_USER_ENTITY);
+        });
+    });
+});

--- a/spec/unit/MatrixBanSync.spec.js
+++ b/spec/unit/MatrixBanSync.spec.js
@@ -33,9 +33,8 @@ const BANNED_SERVER_ENTITY = {
     reason: BANNED_SERVER_STATE_EVENT.content.reason
 };
 
-let banSync;
-
 describe("MatrixBanSync", () => {
+    let banSync;
     beforeEach(() => {
         banSync = new MatrixBanSync({ rooms: [] });
         banSync.interestingRooms = new Set(["!valid:room"]);

--- a/src/bridge/IrcBridge.ts
+++ b/src/bridge/IrcBridge.ts
@@ -958,6 +958,17 @@ export class IrcBridge {
         );
         for (const [userId, {display_name}] of Object.entries(members)) {
             try {
+                // If the user is banned, skip any connection attempts and go straight for a kick.
+                const banReason = this.matrixBanSyncer?.isUserBanned(userId);
+                if (banReason) {
+                    req.log.debug(`Not syncing ${userId} - user banned (${banReason})`);
+                    this.membershipQueue.leave(
+                        roomId, userId, req, true,
+                        "You are banned from interacting with this bridge.",
+                        this.appServiceUserId
+                    );
+                    continue;
+                }
                 if (bot.isRemoteUser(userId)) {
                     // Don't bridge remote.
                     continue;

--- a/src/bridge/IrcBridge.ts
+++ b/src/bridge/IrcBridge.ts
@@ -964,7 +964,7 @@ export class IrcBridge {
                     req.log.debug(`Not syncing ${userId} - user banned (${banReason})`);
                     this.membershipQueue.leave(
                         roomId, userId, req, true,
-                        "You are banned from interacting with this bridge.",
+                        `You are banned: ${banReason}`,
                         this.appServiceUserId
                     );
                     continue;

--- a/src/bridge/IrcBridge.ts
+++ b/src/bridge/IrcBridge.ts
@@ -1108,7 +1108,7 @@ export class IrcBridge {
             this.roomConfigs.invalidateConfig(event.room_id, event.state_key);
         }
         else if (typeof event.state_key === 'string' && this.matrixBanSyncer?.isInterestedInRoom(event.room_id)) {
-            if (await this.matrixBanSyncer.handleIncomingState(event as WeakStateEvent)) {
+            if (await this.matrixBanSyncer.handleIncomingState(event as WeakStateEvent, event.room_id)) {
                 await this.clientPool.checkForBannedConnectedUsers();
             }
         }

--- a/src/bridge/IrcBridge.ts
+++ b/src/bridge/IrcBridge.ts
@@ -1107,7 +1107,7 @@ export class IrcBridge {
         else if (event.type === RoomConfig.STATE_EVENT_TYPE && typeof event.state_key === 'string') {
             this.roomConfigs.invalidateConfig(event.room_id, event.state_key);
         }
-        else if (typeof event.state_key === 'string' && this.matrixBanSyncer?.isInterestedInRoom(event.room_id)) {
+        else if (typeof event.state_key === 'string' && this.matrixBanSyncer?.isTrackingRoomState(event.room_id)) {
             if (await this.matrixBanSyncer.handleIncomingState(event as WeakStateEvent, event.room_id)) {
                 await this.clientPool.checkForBannedConnectedUsers();
             }

--- a/src/bridge/MatrixBanSync.ts
+++ b/src/bridge/MatrixBanSync.ts
@@ -1,0 +1,114 @@
+/**
+ * Synchronises Matrix `m.policy.rule` events with the bridge to filter specific
+ * users from using the service.
+ */
+
+import { Intent, MatrixUser, WeakStateEvent } from "matrix-appservice-bridge";
+import { MatrixGlob } from "matrix-bot-sdk";
+
+export interface MatrixBanSyncConfig {
+    rooms: string[];
+}
+
+enum BanEntityType {
+    Server = "m.policy.rule.server",
+    Room = "m.policy.rule.room",
+    User = "m.policy.rule.user"
+}
+
+interface BanEntity {
+    matcher: MatrixGlob;
+    entityType: BanEntityType;
+    reason: string;
+}
+
+interface MPolicyContent {
+    entity: string;
+    reason: string;
+    reccomendation: "m.ban";
+}
+
+function eventTypeToBanEntityType(eventType: string): BanEntityType|null {
+    switch (eventType) {
+        case "m.policy.rule.user":
+            return BanEntityType.User;
+        case "m.policy.rule.room":
+            return BanEntityType.Room;
+        case "m.policy.rule.server":
+            return BanEntityType.Server
+        default:
+            return null;
+    }
+}
+
+export class MatrixBanSync {
+    private bannedEntites = new Map<string, BanEntity>();
+    constructor(private config: MatrixBanSyncConfig) { }
+
+    public async syncRules(intent: Intent) {
+        this.bannedEntites.clear();
+        for (const roomId of this.config.rooms) {
+            await intent.join(await intent.resolveRoom(roomId));
+            const roomState = await intent.roomState(roomId, false) as WeakStateEvent[];
+            for (const evt of roomState) {
+                this.handleIncomingState(evt);
+            }
+        }
+    }
+
+    /**
+     * Is the given room considered part of the bridge's ban list set.
+     * @param roomId A Matrix room ID.
+     * @returns true if state should be handled from the room, false otherwise.
+     */
+    public isInterestedInRoom(roomId: string): boolean {
+        return this.config.rooms.includes(roomId);
+    }
+
+    public handleIncomingState(evt: WeakStateEvent) {
+        const content = evt.content as unknown as MPolicyContent;
+        const entityType = eventTypeToBanEntityType(evt.type);
+        if (!entityType) {
+            return false;
+        }
+        const key = `${evt.room_id}:${evt.state_key}`;
+        if (evt.content.entity === undefined) {
+            // Empty, delete instead.
+            this.bannedEntites.delete(key);
+            return false;
+        }
+        if (content.reccomendation !== "m.ban") {
+            // We only deal with m.ban at the moment.
+            return false;
+        }
+        this.bannedEntites.set(key, {
+            matcher: new MatrixGlob(content.entity),
+            entityType,
+            reason: content.reason || "No reason given",
+        });
+        return true;
+    }
+
+    /**
+     * Check if a user is banned by via a ban list.
+     * @param user A userId string or a MatrixUser object.
+     * @returns Either a string reason for the ban, or false if the user was not banned.
+     */
+    public isUserBanned(user: MatrixUser|string): string|false {
+        const matrixUser = typeof user === "string" ? new MatrixUser(user) : user;
+        for (const entry of this.bannedEntites.values()) {
+            if (entry.entityType === BanEntityType.Server && entry.matcher.test(matrixUser.host)) {
+                return entry.reason;
+            }
+            if (entry.entityType === BanEntityType.User && entry.matcher.test(matrixUser.userId)) {
+                return entry.reason;
+            }
+        }
+        return false;
+    }
+
+    public async updateConfig(config: MatrixBanSyncConfig, intent: Intent) {
+        this.config = config;
+        await this.syncRules(intent);
+    }
+}

--- a/src/bridge/MemberListSyncer.ts
+++ b/src/bridge/MemberListSyncer.ts
@@ -264,6 +264,11 @@ export class MemberListSyncer {
         const idleRegex = this.server.ignoreIdleUsersOnStartupExcludeRegex;
         for (const roomInfo of filteredRooms) {
             for (const uid of roomInfo.realJoinedUsers) {
+                const banReason = this.ircBridge.matrixBanSyncer?.isUserBanned(uid);
+                if (banReason) {
+                    log.debug(`Not syncing ${uid} - user banned (${banReason})`)
+                    continue;
+                }
                 if (this.server.ignoreIdleUsersOnStartup) {
                     const idle = await this.ircBridge.activityTracker?.isUserOnline(
                         uid, this.server.ignoreIdleUsersOnStartupAfterMs, false

--- a/src/config/BridgeConfig.ts
+++ b/src/config/BridgeConfig.ts
@@ -4,6 +4,7 @@ import { IrcHandlerConfig } from "../bridge/IrcHandler";
 import { RoomConfigConfig } from "../bridge/RoomConfig";
 import { MatrixHandlerConfig } from "../bridge/MatrixHandler";
 import { Rules } from "matrix-appservice-bridge";
+import { MatrixBanSyncConfig } from "../bridge/MatrixBanSync";
 
 export interface BridgeConfig {
     database: {
@@ -64,6 +65,7 @@ export interface BridgeConfig {
             minUserActiveDays?: number;
             inactiveAfterDays?: number;
         };
+        banLists?: MatrixBanSyncConfig;
     };
     sentry?: {
         enabled: boolean;

--- a/src/irc/PrivacyProtection.ts
+++ b/src/irc/PrivacyProtection.ts
@@ -84,6 +84,11 @@ export class PrivacyProtection {
             if (userId === this.ircBridge.appServiceUserId) {
                 continue;
             }
+            const banReason = this.ircBridge.matrixBanSyncer?.isUserBanned(userId);
+            if (banReason) {
+                req.log.debug(`Not syncing ${userId} - user banned (${banReason})`)
+                continue;
+            }
             const client = pool.getBridgedClientByUserId(server, userId);
             if (!client) {
                 req.log.warn(`${userId} has not connected to IRC yet, not bridging message`);

--- a/src/irc/PrivacyProtection.ts
+++ b/src/irc/PrivacyProtection.ts
@@ -13,8 +13,9 @@ const MAX_CACHE_SIZE = 64;
  *
  */
 export class PrivacyProtection {
-    private roomBlockedSet = new Set<string>();
-    private memberListCache = new QuickLRU<string, string[]>({ maxSize: MAX_CACHE_SIZE });
+    private readonly roomBlockedSet = new Set<string>();
+    private readonly memberListCache = new QuickLRU<string, string[]>({ maxSize: MAX_CACHE_SIZE });
+    private readonly syncsInProgress = new Set<string>();
     constructor(private ircBridge: IrcBridge) {
 
     }
@@ -84,11 +85,6 @@ export class PrivacyProtection {
             if (userId === this.ircBridge.appServiceUserId) {
                 continue;
             }
-            const banReason = this.ircBridge.matrixBanSyncer?.isUserBanned(userId);
-            if (banReason) {
-                req.log.debug(`Not syncing ${userId} - user banned (${banReason})`)
-                continue;
-            }
             const client = pool.getBridgedClientByUserId(server, userId);
             if (!client) {
                 req.log.warn(`${userId} has not connected to IRC yet, not bridging message`);
@@ -103,8 +99,16 @@ export class PrivacyProtection {
         if (!isMissingUsers) {
             return true;
         }
+        const key = roomId+server.domain+channel;
+        if (this.syncsInProgress.has(key)) {
+            req.log.debug(`Matrix user sync already in progress, waiting for outcome`);
+            return false;
+        }
+        this.syncsInProgress.add(key);
         // For the missing users, attempt to join them to the channel. Any that fail to join should be kicked.
-        this.ircBridge.syncMembersInRoomToIrc(req, roomId, new IrcRoom(server, channel), true);
+        this.ircBridge.syncMembersInRoomToIrc(req, roomId, new IrcRoom(server, channel), true).finally(() => {
+            this.syncsInProgress.delete(key);
+        });
         return false;
     }
 


### PR DESCRIPTION
This PR aims to have the IRC bridge synchronize with https://spec.matrix.org/v1.2/client-server-api/#moderation-policy-lists entries so that when a user is banned via Mjolnir or similar, the bridge can take proactive action to ban them / filter their traffic out. While the bridge shoud not bundle too much in the way of moderation functionality (best left to other projects), this feature is aimed at trying to deal with attacks swiftly rather than waiting for processes to kick in.