### PR TITLE
Implement a less strict validateUsername for user provided usernames

### DIFF
--- a/changelog.d/1538.bugfix
+++ b/changelog.d/1538.bugfix
@@ -1,0 +1,1 @@
+Allow usernames to include more characters when using the `!username` command.

--- a/src/bridge/AdminRoomHandler.ts
+++ b/src/bridge/AdminRoomHandler.ts
@@ -484,7 +484,7 @@ export class AdminRoomHandler {
                     `Username is longer than the maximum permitted by the bridge (${SANE_USERNAME_LENGTH}).`
                 );
             }
-            else if (IdentGenerator.sanitiseUsername(username) !== username) {
+            else if (IdentGenerator.validateUsername(username)) {
                 notice = new MatrixAction(
                     "notice",
                     `Username contained invalid characters not supported by IRC.`

--- a/src/bridge/AdminRoomHandler.ts
+++ b/src/bridge/AdminRoomHandler.ts
@@ -484,7 +484,7 @@ export class AdminRoomHandler {
                     `Username is longer than the maximum permitted by the bridge (${SANE_USERNAME_LENGTH}).`
                 );
             }
-            else if (IdentGenerator.validateUsername(username)) {
+            else if (!IdentGenerator.validateUsername(username)) {
                 notice = new MatrixAction(
                     "notice",
                     `Username contained invalid characters not supported by IRC.`

--- a/src/irc/IdentGenerator.ts
+++ b/src/irc/IdentGenerator.ts
@@ -32,6 +32,8 @@ export class IdentGenerator {
     private static readonly USER_NAME_DELIMITER = "_";
     // The delimiter of the username.
     private static readonly MAX_USER_NAME_SUFFIX = 9999;
+    // Valid usernames accoridng to solanum
+    private static readonly USERNAME_REGEX = /^[\-\.0-9A-Z\[\]\\\^_`a-z\{\|\}\~]+$/;
 
     private queue: Queue<{ matrixUser: MatrixUser; ircClientConfig: IrcClientConfig, unique: boolean}>;
     constructor (private readonly dataStore: DataStore) {
@@ -231,6 +233,27 @@ export class IdentGenerator {
             suffixLength++;
         }
         throw Error("Ran out of entries: " + username);
+    }
+
+    /**
+     * Checks if a user provided username is valid for an IRC network.
+     * @param username
+     */
+    public static validateUsername(username: string): boolean {
+        // Following rules from
+        // https://github.com/solanum-ircd/solanum/blob/78825899cd6b68037fd1b3c6c77afb7d10c4774e/ircd/s_user.c#L914-L927
+        if (!username || username === "") {
+            return false;
+        }
+        // If the first char is ~, skip forward
+        if (username.startsWith('~')) {
+            username = username.slice(1);
+        }
+        // First char must be alpha num
+        if (!username[0].match(/[A-Za-z0-9]/)) {
+            return false;
+        }
+        return IdentGenerator.USERNAME_REGEX.test(username);
     }
 
     public static sanitiseUsername(username: string, replacementChar = "") {

--- a/src/irc/IdentGenerator.ts
+++ b/src/irc/IdentGenerator.ts
@@ -237,7 +237,7 @@ export class IdentGenerator {
 
     /**
      * Checks if a user provided username is valid for an IRC network.
-     * @param username
+     * @param username User provided username
      */
     public static validateUsername(username: string): boolean {
         // Following rules from


### PR DESCRIPTION
Fixes #1359 
Supercedes #1367 

This change allows for a much more permissive username when users are setting their own username.