### PR TITLE
Prune non-production dependencies from runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Freebind build
 # node:16-slim uses debian:stretch-slim as a base, so it's safe to build on here.
-FROM debian:stretch-slim as freebind 
+FROM debian:stretch-slim as freebind
 
 RUN apt-get update \
  && apt-get install -y git build-essential
@@ -13,13 +13,14 @@ FROM node:16-slim as builder
 
 WORKDIR /build
 
-COPY src/ /build/src/ 
+COPY src/ /build/src/
 COPY .eslintrc *json /build/
 
 RUN npm ci
 RUN npm run build
+RUN npm prune --omit dev
 
-# App
+# Runtime container image
 FROM node:16-slim
 
 RUN apt-get update && apt-get install -y sipcalc iproute2 openssl --no-install-recommends

--- a/changelog.d/1541.misc
+++ b/changelog.d/1541.misc
@@ -1,0 +1,1 @@
+docker: prune dev dependencies from node_modules.


### PR DESCRIPTION
prune dev packages from the runtime container image, to make it leaner

Before:
```
$ du -sh node_modules/
187M    node_modules
```

After:
```
$ du -sh node_modules/
89M     node_modules/
```