### PR TITLE
Surround URL in truncated messages with delimiters

### DIFF
--- a/changelog.d/1547.bugfix
+++ b/changelog.d/1547.bugfix
@@ -1,0 +1,1 @@
+Consistently use URL delimiters without spaces in truncated messages

--- a/src/bridge/MatrixHandler.ts
+++ b/src/bridge/MatrixHandler.ts
@@ -58,7 +58,7 @@ const DEFAULTS: MatrixHandlerConfig = {
     shortReplyTresholdSeconds: 5 * 60,
     shortReplyTemplate: "$NICK: $REPLY",
     longReplyTemplate: "<$NICK> \"$ORIGINAL\" <- $REPLY",
-    truncatedMessageTemplate: "(full message at $URL)",
+    truncatedMessageTemplate: "(full message at <$URL>)",
 };
 
 export interface MatrixEventInvite {

--- a/src/models/MatrixAction.ts
+++ b/src/models/MatrixAction.ts
@@ -201,12 +201,12 @@ export class MatrixAction {
 
                 if (filename) {
                     url += `/${encodeURIComponent(filename)}`;
-                    text = `${fileSize} < ${url} >`;
+                    text = `${fileSize} <${url}>`;
                 }
                 else {
                     fileSize = fileSize ? ` ${fileSize}` : "";
                     // If not a filename, print the body
-                    text = `${event.content.body}${fileSize} < ${url} >`;
+                    text = `${event.content.body}${fileSize} <${url}>`;
                 }
             }
         }


### PR DESCRIPTION
URLs use double quotes, angular brackets or whitespace as delimiters. Parentheses are URL constituent characters (see Wikipedia for example). While many URL regex treat closing delimiters at the end of a URL specially, far from all do, therefore URLs should be delimited with appropriate characters whenever possible.

See https://github.com/matrix-org/matrix-appservice-irc/blob/957e60c48afbfba60cc7fc0d8369bb8eeaea9e57/src/models/MatrixAction.ts#L202-L210 for existing code using a combination of angular brackets and whitespace.