### PR TITLE
Make towncrier build the changelog instead of printing its version

### DIFF
--- a/scripts/changelog-release.sh
+++ b/scripts/changelog-release.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 VERSION=`python3 -c "import json; f = open('./package.json', 'r'); v = json.loads(f.read())['version']; f.close(); print(v)"`
-towncrier --version $VERSION $1
+towncrier build --version $VERSION $1


### PR DESCRIPTION
Same as https://github.com/matrix-org/matrix-appservice-slack/pull/677

## Before
```
./scripts/towncrier.sh 
towncrier, version 21.9.0
```

## After
```
./scripts/towncrier.sh
Loading template...
Finding news fragments...
Rendering news fragments...
Writing to newsfile...
Staging newsfile...
Removing news fragments...
I want to remove the following files:
…
```