### PR TITLE
Add useful information to the CTCP version request

### DIFF
--- a/changelog.d/1559.misc
+++ b/changelog.d/1559.misc
@@ -1,0 +1,1 @@
+Include the bridge version and homeserver in the `CTCP VERSION` response body.

--- a/src/irc/BridgedClient.ts
+++ b/src/irc/BridgedClient.ts
@@ -250,7 +250,9 @@ export class BridgedClient extends EventEmitter {
                     this.server.getIpv6Prefix() ? this.clientConfig.getIpv6Address() : undefined
                 ),
                 encodingFallback: this.encodingFallback,
-            }, (inst: ConnectionInstance) => {
+            },
+            this.server.homeserverDomain,
+            (inst: ConnectionInstance) => {
                 // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                 this.onConnectionCreated(inst, nameInfo, identResolver!);
             });

--- a/src/irc/ConnectionInstance.ts
+++ b/src/irc/ConnectionInstance.ts
@@ -21,6 +21,7 @@ import * as logging from "../logging";
 import Bluebird from "bluebird";
 import { Defer } from "../promiseutil";
 import { IrcServer } from "./IrcServer";
+import { getBridgeVersion } from "matrix-appservice-bridge";
 
 const log = logging.get("client-connection");
 
@@ -42,7 +43,8 @@ const FLOOD_PROTECTION_DELAY_MS = 700;
 const THROTTLE_WAIT_MS = 20 * 1000;
 
 // String reply of any CTCP Version requests
-const CTCP_VERSION = 'matrix-appservice-irc, part of the Matrix.org Network';
+const CTCP_VERSION = 
+    (homeserverName: string) => `matrix-appservice-irc ${getBridgeVersion()} bridged via ${homeserverName}`;
 
 const CONN_LIMIT_MESSAGES = [
     "too many host connections", // ircd-seven
@@ -83,18 +85,20 @@ export class ConnectionInstance {
     private connectDefer: Defer<ConnectionInstance>;
     public onDisconnect?: (reason: string) => void;
     /**
-     * Create an IRC connection instance. Wraps the node-irc library to handle
+     * Create an IRC connection instance. Wraps the matrix-org-irc library to handle
      * connections correctly.
      * @constructor
-     * @param {IrcClient} ircClient The new IRC client.
-     * @param {string} domain The domain (for logging purposes)
-     * @param {string} nick The nick (for logging purposes)
+     * @param client The new IRC client.
+     * @param domain The domain (for logging purposes)
+     * @param nick The nick (for logging purposes)
+     * @param pingOpts Options for automatic pings to the IRCd.
+     * @param homeserverDomain The homeserver's domain, for the CTCP version string.
      */
     constructor (public readonly client: Client, private readonly domain: string, private nick: string,
         private pingOpts: {
         pingRateMs: number;
         pingTimeoutMs: number;
-    }) {
+    }, private readonly homeserverDomain: string) {
         this.listenForErrors();
         this.listenForPings();
         this.listenForCTCPVersions();
@@ -359,10 +363,13 @@ export class ConnectionInstance {
      * @param {string} opts.realname The real name of the user.
      * @param {string} opts.password The password to give NickServ.
      * @param {string} opts.localAddress The local address to bind to when connecting.
+     * @param {string} homeserverDomain Domain of the homeserver bridging requests.
      * @param {Function} onCreatedCallback Called with the client when created.
      * @return {Promise} Resolves to an ConnectionInstance or rejects.
      */
-    public static async create (server: IrcServer, opts: ConnectionOpts,
+    public static async create (server: IrcServer,
+                                opts: ConnectionOpts,
+                                homeserverDomain: string,
                                 onCreatedCallback?: (inst: ConnectionInstance) => void): Promise<ConnectionInstance> {
         if (!opts.nick || !server) {
             throw new Error("Bad inputs. Nick: " + opts.nick);
@@ -396,7 +403,8 @@ export class ConnectionInstance {
                 nodeClient, server.domain, opts.nick, {
                     pingRateMs: server.pingRateMs,
                     pingTimeoutMs: server.pingTimeout,
-                }
+                },
+                homeserverDomain,
             );
             if (onCreatedCallback) {
                 onCreatedCallback(inst);

--- a/src/irc/ConnectionInstance.ts
+++ b/src/irc/ConnectionInstance.ts
@@ -43,7 +43,7 @@ const FLOOD_PROTECTION_DELAY_MS = 700;
 const THROTTLE_WAIT_MS = 20 * 1000;
 
 // String reply of any CTCP Version requests
-const CTCP_VERSION = 
+const CTCP_VERSION =
     (homeserverName: string) => `matrix-appservice-irc ${getBridgeVersion()} bridged via ${homeserverName}`;
 
 const CONN_LIMIT_MESSAGES = [

--- a/src/irc/ConnectionInstance.ts
+++ b/src/irc/ConnectionInstance.ts
@@ -333,7 +333,7 @@ export class ConnectionInstance {
     private listenForCTCPVersions() {
         this.client.addListener("ctcp-version", (from: string) => {
             if (from) { // Ensure the sender is valid before we try to respond
-                this.client.ctcp(from, 'reply', `VERSION ${CTCP_VERSION}`);
+                this.client.ctcp(from, 'reply', `VERSION ${CTCP_VERSION(this.homeserverDomain)}`);
             }
         });
     }

--- a/src/irc/IrcServer.ts
+++ b/src/irc/IrcServer.ts
@@ -174,7 +174,7 @@ export class IrcServer {
      * will never expire.
      */
     constructor(public domain: string, public config: IrcServerConfig,
-                private homeserverDomain: string, private expiryTimeSeconds: number = 0) {
+                public readonly homeserverDomain: string, private expiryTimeSeconds: number = 0) {
         this.reconfigure(config, expiryTimeSeconds);
     }
 


### PR DESCRIPTION
This changes the string from something vague to the specific version running, and the homeserver handling the bridging. This obviously is a breakaway from obscuring our version, though given we already have a version command this doesn't feel like a major security footprint change.