### PR TITLE
Enable authenticateThirdpartyEndpoints

### DIFF
--- a/changelog.d/1566.misc
+++ b/changelog.d/1566.misc
@@ -1,0 +1,1 @@
+Thirdparty ID endpoints are now authenticated with the bridge token.

--- a/src/bridge/IrcBridge.ts
+++ b/src/bridge/IrcBridge.ts
@@ -145,6 +145,7 @@ export class IrcBridge {
                " so user activity will not be captured");
         }
         this.bridge = new Bridge({
+            authenticateThirdpartyEndpoints: true,
             registration: this.registration,
             homeserverUrl: this.config.homeserver.url,
             domain: this.config.homeserver.domain,


### PR DESCRIPTION
This has been a problem for years, and we might as well start enabling authentication for these endpoints now. https://github.com/matrix-org/matrix-appservice-bridge/issues/76