### PR TITLE
Remove (IRC) as a default suffix for displayNames

### DIFF
--- a/changelog.d/1567.misc
+++ b/changelog.d/1567.misc
@@ -1,1 +1,1 @@
-BREAKING: Remove (IRC) as a default displayName suffix
+BREAKING: Remove (IRC) as a default displayName suffix.

--- a/changelog.d/1567.misc
+++ b/changelog.d/1567.misc
@@ -1,0 +1,1 @@
+BREAKING: Remove (IRC) as a default displayName suffix

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -329,8 +329,8 @@ ircService:
         # The display name to use for created matrix clients. This should have
         # $NICK somewhere in it if it is specified. Can also use $SERVER to
         # insert the IRC domain.
-        # Optional. Default: "$NICK (IRC)". Example: "Alice (IRC)"
-        displayName: "$NICK (IRC)"
+        # Optional. Default: "$NICK". Example: "Alice"
+        displayName: "$NICK"
         # Number of tries a client can attempt to join a room before the request
         # is discarded. You can also use -1 to never retry or 0 to never give up.
         # Optional. Default: -1

--- a/src/irc/IrcServer.ts
+++ b/src/irc/IrcServer.ts
@@ -735,7 +735,7 @@ export class IrcServer {
             excludedUsers: [],
             matrixClients: {
                 userTemplate: "@$SERVER_$NICK",
-                displayName: "$NICK (IRC)",
+                displayName: "$NICK",
                 joinAttempts: -1,
             },
             ircClients: {


### PR DESCRIPTION
This was decided and implemented on matrix.org long ago (with one
exception), but is still an unnecessary default.

See https://github.com/matrix-org/matrix-appservice-irc/issues/194#issuecomment-415734087

Will eventually fix https://github.com/matrix-org/matrix-appservice-irc/issues/1563 once the w3c on matrix.org gets the version with it (can be fixed in the configuration before then).