### PR TITLE
Add a DebugAPI to warn users that they will be idle kicked

### DIFF
--- a/changelog.d/1571.feature
+++ b/changelog.d/1571.feature
@@ -1,0 +1,1 @@
+Add new Debug API `/warnReapUsers` which allows bridges to send a warning to users when they are going to be idle reaped.

--- a/src/DebugApi.ts
+++ b/src/DebugApi.ts
@@ -205,11 +205,12 @@ export class DebugApi {
         const server = query["server"] as string;
         const since = parseInt(query["since"] as string);
         const msg = query["msg"] as string;
+        const limit = query["targetCount"] !== undefined ? parseInt(query["targetCount"] as string) : undefined;
         const defaultOnline = (query["defaultOnline"] ?? "true") === "true";
         const excludeRegex = query["excludeRegex"] as string;
         const req = new BridgeRequest(this.ircBridge.getAppServiceBridge().getRequestFactory().newRequest());
         this.ircBridge.warnConnectionReap(
-            req, server, since, msg, defaultOnline, excludeRegex,
+            req, server, since, msg, defaultOnline, excludeRegex, limit,
         ).catch((err: Error) => {
             log.warn(`Failed to handle onWarnReapUsers`, err);
             if (!response.headersSent) {

--- a/src/bridge/AdminRoomHandler.ts
+++ b/src/bridge/AdminRoomHandler.ts
@@ -76,8 +76,7 @@ const COMMANDS: {[command: string]: Command|Heading} = {
     },
     "!active": {
         example: "!active",
-        summary: "Informs the bridge that you do not wish to be idlekicked. This will reset your idleness timer " +
-                 "but you may need to run this again."
+        summary: "Mark yourself as active, which will exclude you from any idleness kicks."
     },
     'Authentication': { heading: true },
     "!storepass": {

--- a/src/bridge/AdminRoomHandler.ts
+++ b/src/bridge/AdminRoomHandler.ts
@@ -17,7 +17,7 @@ limitations under the License.
 import { BridgeRequest } from "../models/BridgeRequest";
 import { MatrixRoom, MatrixUser } from "matrix-appservice-bridge";
 import { IrcBridge } from "./IrcBridge";
-import { MatrixAction } from "../models/MatrixAction";
+import { ActionType, MatrixAction } from "../models/MatrixAction";
 import { IrcServer } from "../irc/IrcServer";
 import { BridgedClient } from "../irc/BridgedClient";
 import { IrcClientConfig } from "../models/IrcClientConfig";
@@ -119,7 +119,7 @@ const COMMANDS: {[command: string]: Command|Heading} = {
 };
 
 class ServerRequiredError extends Error {
-    notice = new MatrixAction("notice", "A server address must be specified.");
+    notice = new MatrixAction(ActionType.Notice, "A server address must be specified.");
 }
 
 const USER_FEATURES = ["mentions"];
@@ -145,7 +145,7 @@ export class AdminRoomHandler {
             }
             else {
                 req.log.error("Exception while handling command %s from %s: %s", cmd, event.sender, err);
-                response = new MatrixAction("notice", "An unknown error happened while handling your command");
+                response = new MatrixAction(ActionType.Notice, "An unknown error happened while handling your command");
             }
         }
 
@@ -159,7 +159,7 @@ export class AdminRoomHandler {
         const userPermission = this.getUserPermission(event.sender);
         const requiredPermission = (COMMANDS[cmd] as Command|undefined)?.requiresPermission;
         if (requiredPermission && requiredPermission > userPermission) {
-            return new MatrixAction("notice", "You do not have permission to use this command");
+            return new MatrixAction(ActionType.Notice, "You do not have permission to use this command");
         }
         switch (cmd) {
             case "!join":
@@ -194,7 +194,7 @@ export class AdminRoomHandler {
             case "!help":
                 return this.showHelp(event.sender);
             default: {
-                return new MatrixAction("notice",
+                return new MatrixAction(ActionType.Notice,
                     "The command was not recognised. Available commands are listed by !help");
             }
         }
@@ -204,10 +204,10 @@ export class AdminRoomHandler {
         const [matrixRoomId, serverDomain, ircChannel] = args;
         const server = serverDomain && this.ircBridge.getServer(serverDomain);
         if (!server) {
-            return new MatrixAction("notice", "The server provided is not configured on this bridge");
+            return new MatrixAction(ActionType.Notice, "The server provided is not configured on this bridge");
         }
         if (!ircChannel || !ircChannel.startsWith("#")) {
-            return new MatrixAction("notice", "The channel name must start with a #");
+            return new MatrixAction(ActionType.Notice, "The channel name must start with a #");
         }
         // Check if the room exists and the user is invited.
         const intent = this.ircBridge.getAppServiceBridge().getIntent();
@@ -216,7 +216,7 @@ export class AdminRoomHandler {
         }
         catch (ex) {
             log.error(`Could not join the target room of a !plumb command`, ex);
-            return new MatrixAction("notice", "Could not join the target room, you may need to invite the bot");
+            return new MatrixAction(ActionType.Notice, "Could not join the target room, you may need to invite the bot");
         }
         try {
             await this.ircBridge.getProvisioner().doLink(
@@ -230,9 +230,9 @@ export class AdminRoomHandler {
         }
         catch (ex) {
             log.error(`Failed to handle !plumb command:`, ex);
-            return new MatrixAction("notice", "Failed to plumb room. Check the logs for details.");
+            return new MatrixAction(ActionType.Notice, "Failed to plumb room. Check the logs for details.");
         }
-        return new MatrixAction("notice", "Room plumbed.");
+        return new MatrixAction(ActionType.Notice, "Room plumbed.");
     }
 
     private async handleUnlink(args: string[], sender: string) {
@@ -240,10 +240,10 @@ export class AdminRoomHandler {
         const [matrixRoomId, serverDomain, ircChannel] = args;
         const server = serverDomain && this.ircBridge.getServer(serverDomain);
         if (!server) {
-            return new MatrixAction("notice", "The server provided is not configured on this bridge");
+            return new MatrixAction(ActionType.Notice, "The server provided is not configured on this bridge");
         }
         if (!ircChannel || !ircChannel.startsWith("#")) {
-            return new MatrixAction("notice", "The channel name must start with a #");
+            return new MatrixAction(ActionType.Notice, "The channel name must start with a #");
         }
         try {
             await this.ircBridge.getProvisioner().unlink(
@@ -260,9 +260,9 @@ export class AdminRoomHandler {
         }
         catch (ex) {
             log.error(`Failed to handle !unlink command:`, ex);
-            return new MatrixAction("notice", "Failed to unlink room. Check the logs for details.");
+            return new MatrixAction(ActionType.Notice, "Failed to unlink room. Check the logs for details.");
         }
-        return new MatrixAction("notice", "Room unlinked.");
+        return new MatrixAction(ActionType.Notice, "Room unlinked.");
     }
 
     private async handleJoin(req: BridgeRequest, args: string[], sender: string) {
@@ -279,7 +279,7 @@ export class AdminRoomHandler {
         }
 
         if (errText) {
-            return new MatrixAction("notice", errText);
+            return new MatrixAction(ActionType.Notice, errText);
         }
         req.log.info("%s wants to join the channel %s on %s", sender, ircChannel, server.domain);
 
@@ -389,7 +389,7 @@ export class AdminRoomHandler {
             bridgedClient.sendCommands(...sendArgs);
         }
         catch (err) {
-            return new MatrixAction("notice", `${err}\n` );
+            return new MatrixAction(ActionType.Notice, `${err}\n` );
         }
         return undefined;
     }
@@ -400,7 +400,7 @@ export class AdminRoomHandler {
         // Format is: "!whois <nick>"
         const whoisNick = args.length === 1 ? args[0] : null; // ensure 1 arg
         if (!whoisNick) {
-            return new MatrixAction("notice", "Format: '!whois nick|mxid'");
+            return new MatrixAction(ActionType.Notice, "Format: '!whois nick|mxid'");
         }
 
         if (whoisNick[0] === "@") {
@@ -409,7 +409,7 @@ export class AdminRoomHandler {
             const whoisClient = this.ircBridge.getIrcUserFromCache(server, whoisNick);
             try {
                 return new MatrixAction(
-                    "notice",
+                    ActionType.Notice,
                     whoisClient ?
                         `${whoisNick} is connected to ${server.domain} as '${whoisClient.nick}'.` :
                         `${whoisNick} has no IRC connection via this bridge.`);
@@ -418,7 +418,7 @@ export class AdminRoomHandler {
                 if (err.stack) {
                     req.log.error(err);
                 }
-                return new MatrixAction("notice", "Failed to perform whois query.");
+                return new MatrixAction(ActionType.Notice, "Failed to perform whois query.");
             }
         }
 
@@ -427,13 +427,13 @@ export class AdminRoomHandler {
         const bridgedClient = await this.ircBridge.getBridgedClient(server, sender);
         try {
             const response = await bridgedClient.whois(whoisNick);
-            return new MatrixAction("notice", response?.msg || "User not found");
+            return new MatrixAction(ActionType.Notice, response?.msg || "User not found");
         }
         catch (err) {
             if (err.stack) {
                 req.log.error(err);
             }
-            return new MatrixAction("notice", err.message);
+            return new MatrixAction(ActionType.Notice, err.message);
         }
     }
 
@@ -446,17 +446,17 @@ export class AdminRoomHandler {
             if (client) {
                 await client.disconnect("iwanttoreconnect", "Reconnecting", false);
                 return new MatrixAction(
-                    "notice", `Reconnecting to network...`
+                    ActionType.Notice, `Reconnecting to network...`
                 );
             }
             return new MatrixAction(
-                "notice", `No clients connected to this network, not reconnecting`
+                ActionType.Notice, `No clients connected to this network, not reconnecting`
             );
         }
         catch (err) {
             req.log.error(err.stack);
             return new MatrixAction(
-                "notice", `Failed to reconnect`
+                ActionType.Notice, `Failed to reconnect`
             );
         }
     }
@@ -473,20 +473,20 @@ export class AdminRoomHandler {
             const username = args[0]?.trim();
             if (!username) {
                 notice = new MatrixAction(
-                    "notice",
+                    ActionType.Notice,
                     "Format: '!username username' " +
                     "or '!username irc.server.name username'\n"
                 );
             }
             else if (username.length > SANE_USERNAME_LENGTH) {
                 notice = new MatrixAction(
-                    "notice",
+                    ActionType.Notice,
                     `Username is longer than the maximum permitted by the bridge (${SANE_USERNAME_LENGTH}).`
                 );
             }
             else if (IdentGenerator.sanitiseUsername(username) !== username) {
                 notice = new MatrixAction(
-                    "notice",
+                    ActionType.Notice,
                     `Username contained invalid characters not supported by IRC.`
                 );
             }
@@ -500,14 +500,14 @@ export class AdminRoomHandler {
                 config.setUsername(username);
                 await this.ircBridge.getStore().storeIrcClientConfig(config);
                 notice = new MatrixAction(
-                    "notice", `Successfully stored username for ${domain}. Use !reconnect to use this username now.`
+                    ActionType.Notice, `Successfully stored username for ${domain}. Use !reconnect to use this username now.`
                 );
             }
         }
         catch (err) {
             req.log.error(err.stack);
             return new MatrixAction(
-                "notice", `Failed to store username: ${err.message}`
+                ActionType.Notice, `Failed to store username: ${err.message}`
             );
         }
         return notice;
@@ -525,21 +525,21 @@ export class AdminRoomHandler {
             const pass = args.join(' ');
             if (pass.length === 0) {
                 notice = new MatrixAction(
-                    "notice",
+                    ActionType.Notice,
                     "Format: '!storepass password' or '!storepass irc.server.name password'\n"
                 );
             }
             else {
                 await this.ircBridge.getStore().storePass(userId, domain, pass);
                 notice = new MatrixAction(
-                    "notice", `Successfully stored password for ${domain}. Use !reconnect to use this password now.`
+                    ActionType.Notice, `Successfully stored password for ${domain}. Use !reconnect to use this password now.`
                 );
             }
         }
         catch (err) {
             req.log.error(err.stack);
             return new MatrixAction(
-                "notice", `Failed to store password: ${err.message}`
+                ActionType.Notice, `Failed to store password: ${err.message}`
             );
         }
         return notice;
@@ -553,12 +553,12 @@ export class AdminRoomHandler {
         try {
             await this.ircBridge.getStore().removePass(userId, domain);
             return new MatrixAction(
-                "notice", `Successfully removed password.`
+                ActionType.Notice, `Successfully removed password.`
             );
         }
         catch (err) {
             return new MatrixAction(
-                "notice", `Failed to remove password: ${err.message}`
+                ActionType.Notice, `Failed to remove password: ${err.message}`
             );
         }
     }
@@ -569,12 +569,12 @@ export class AdminRoomHandler {
         const client = this.ircBridge.getIrcUserFromCache(server, sender);
         if (!client || client.isDead()) {
             return new MatrixAction(
-                "notice", "You are not currently connected to this irc network"
+                ActionType.Notice, "You are not currently connected to this irc network"
             );
         }
         if (client.chanList.size === 0) {
             return new MatrixAction(
-                "notice", "You are connected, but not joined to any channels."
+                ActionType.Notice, "You are connected, but not joined to any channels."
             );
         }
 
@@ -591,7 +591,7 @@ export class AdminRoomHandler {
         chanListHTML += "</ul>"
 
         return new MatrixAction(
-            "notice", chanList, chanListHTML
+            ActionType.Notice, chanList, chanListHTML
         );
     }
 
@@ -601,7 +601,7 @@ export class AdminRoomHandler {
         const msgText = await this.matrixHandler.quitUser(
             req, sender, clients, server, "issued !quit command"
         );
-        return msgText ? new MatrixAction("notice", msgText) : undefined;
+        return msgText ? new MatrixAction(ActionType.Notice, msgText) : undefined;
     }
 
     private async handleNick(req: BridgeRequest, args: string[], sender: string) {
@@ -610,7 +610,7 @@ export class AdminRoomHandler {
 
         // Format is: "!nick irc.example.com NewNick"
         if (!ircServer.allowsNickChanges()) {
-            return new MatrixAction("notice",
+            return new MatrixAction(ActionType.Notice,
                 "Server " + ircServer.domain + " does not allow nick changes."
             );
         }
@@ -631,7 +631,7 @@ export class AdminRoomHandler {
                         " as " + clientList[i].nick + "\n";
                 }
             }
-            return new MatrixAction("notice",
+            return new MatrixAction(ActionType.Notice,
                 "Format: '!nick DesiredNick' or '!nick irc.server.name DesiredNick'\n" +
                 connectedNetworksStr
             );
@@ -650,7 +650,7 @@ export class AdminRoomHandler {
         try {
             if (bridgedClient) {
                 const response = await bridgedClient.changeNick(nick, true);
-                notice = new MatrixAction("notice", response);
+                notice = new MatrixAction(ActionType.Notice, response);
             }
             // persist this desired nick
             let config = await this.ircBridge.getStore().getIrcClientConfig(
@@ -668,14 +668,14 @@ export class AdminRoomHandler {
             if (err.stack) {
                 req.log.error(err);
             }
-            return new MatrixAction("notice", err.message);
+            return new MatrixAction(ActionType.Notice, err.message);
         }
         return notice;
     }
 
     private async handleFeature(args: string[], sender: string) {
         if (args.length === 0 || !USER_FEATURES.includes(args[0].toLowerCase())) {
-            return new MatrixAction("notice",
+            return new MatrixAction(ActionType.Notice,
                 "Missing or unknown feature flag. Must be one of: " + USER_FEATURES.join(", ")
             );
         }
@@ -693,10 +693,10 @@ export class AdminRoomHandler {
             else {
                 msg += "set to the default value.";
             }
-            return new MatrixAction("notice", msg);
+            return new MatrixAction(ActionType.Notice, msg);
         }
         if (!["true", "false", "default"].includes(args[1].toLowerCase())) {
-            return new MatrixAction("notice",
+            return new MatrixAction(ActionType.Notice,
                 "Parameter must be either true, false or default."
             );
         }
@@ -711,13 +711,13 @@ export class AdminRoomHandler {
                 note = " This bridge has disabled mentions, so this flag will do nothing.";
             }
         }
-        return new MatrixAction("notice",
+        return new MatrixAction(ActionType.Notice,
             `Set ${featureFlag} to ${features[featureFlag]}.${note}`
         );
     }
 
     private showBridgeVersion() {
-        return new MatrixAction("notice", `BridgeVersion: ${getBridgeVersion()}`);
+        return new MatrixAction(ActionType.Notice, `BridgeVersion: ${getBridgeVersion()}`);
     }
 
     private showHelp(sender: string): MatrixAction {
@@ -736,7 +736,7 @@ export class AdminRoomHandler {
                 body += `<li><strong>${command.example}</strong> : ${command.summary}</li>\n\t`;
             }
         }
-        return new MatrixAction("notice", null, body + "</ul>");
+        return new MatrixAction(ActionType.Notice, null, body + "</ul>");
     }
 
     // will mutate args if sucessful

--- a/src/bridge/AdminRoomHandler.ts
+++ b/src/bridge/AdminRoomHandler.ts
@@ -74,6 +74,11 @@ const COMMANDS: {[command: string]: Command|Heading} = {
         summary: "Leave all bridged channels, on all networks, and remove your " +
                 "connections to all networks.",
     },
+    "!active": {
+        example: "!active",
+        summary: "Informs the bridge that you do not wish to be idlekicked. This will reset your idleness timer " +
+                 "but you may need to run this again."
+    },
     'Authentication': { heading: true },
     "!storepass": {
         example: `!storepass [irc.example.net] passw0rd`,
@@ -162,6 +167,10 @@ export class AdminRoomHandler {
             return new MatrixAction(ActionType.Notice, "You do not have permission to use this command");
         }
         switch (cmd) {
+            case "!active":
+                // The bridge treats ANY message appearing over the network as an idleness reset,
+                // so the act of running this commmand resets that timer.
+                return new MatrixAction(ActionType.Notice, "Your have been marked as active by the bridge");
             case "!join":
                 return await this.handleJoin(req, args, event.sender);
             case "!cmd":

--- a/src/bridge/AdminRoomHandler.ts
+++ b/src/bridge/AdminRoomHandler.ts
@@ -225,7 +225,8 @@ export class AdminRoomHandler {
         }
         catch (ex) {
             log.error(`Could not join the target room of a !plumb command`, ex);
-            return new MatrixAction(ActionType.Notice, "Could not join the target room, you may need to invite the bot");
+            return new MatrixAction(
+                ActionType.Notice, "Could not join the target room, you may need to invite the bot");
         }
         try {
             await this.ircBridge.getProvisioner().doLink(
@@ -509,7 +510,8 @@ export class AdminRoomHandler {
                 config.setUsername(username);
                 await this.ircBridge.getStore().storeIrcClientConfig(config);
                 notice = new MatrixAction(
-                    ActionType.Notice, `Successfully stored username for ${domain}. Use !reconnect to use this username now.`
+                    ActionType.Notice,
+                    `Successfully stored username for ${domain}. Use !reconnect to use this username now.`
                 );
             }
         }
@@ -541,7 +543,8 @@ export class AdminRoomHandler {
             else {
                 await this.ircBridge.getStore().storePass(userId, domain, pass);
                 notice = new MatrixAction(
-                    ActionType.Notice, `Successfully stored password for ${domain}. Use !reconnect to use this password now.`
+                    ActionType.Notice,
+                    `Successfully stored password for ${domain}. Use !reconnect to use this password now.`
                 );
             }
         }

--- a/src/bridge/IrcBridge.ts
+++ b/src/bridge/IrcBridge.ts
@@ -1496,9 +1496,9 @@ export class IrcBridge {
      *                     idle before they aren't considered part of the pool. By default, this isn't checked.
      * @returns A ordered set of userIds by their idle time in ascending order.
      */
-    public async calculateIdlenessPool(
+    private async calculateIdlenessPool(
         server: IrcServer, minIdleHours: number,
-        defaultOnline?: boolean, excludeRegex?: string,
+        defaultOnline = true, excludeRegex?: string,
         maxIdleHours?: number,
     ) {
         if (!this.activityTracker) {

--- a/src/bridge/IrcBridge.ts
+++ b/src/bridge/IrcBridge.ts
@@ -42,7 +42,7 @@ import {
 } from "matrix-appservice-bridge";
 import { IrcAction } from "../models/IrcAction";
 import { DataStore } from "../datastore/DataStore";
-import { MatrixAction, MatrixMessageEvent } from "../models/MatrixAction";
+import { ActionType, MatrixAction, MatrixMessageEvent } from "../models/MatrixAction";
 import { BridgeConfig } from "../config/BridgeConfig";
 import { Registry } from "prom-client";
 import { spawnMetricsWorker } from "../workers/MetricsWorker";
@@ -901,12 +901,12 @@ export class IrcBridge {
         await promiseutil.allSettled(promises);
     }
 
-    public async sendMatrixAction(room: MatrixRoom, from: MatrixUser, action: MatrixAction): Promise<void> {
+    public async sendMatrixAction(room: MatrixRoom, from: MatrixUser|undefined, action: MatrixAction): Promise<void> {
         if (this.bridgeBlocker?.isBlocked) {
             log.info("Bridge is blocked, dropping Matrix action");
             return;
         }
-        const intent = this.bridge.getIntent(from.userId);
+        const intent = this.bridge.getIntent(from?.userId);
         const extraContent: Record<string, unknown> = {};
         if (action.replyEvent) {
             extraContent["m.relates_to"] = {

--- a/src/bridge/IrcBridge.ts
+++ b/src/bridge/IrcBridge.ts
@@ -1486,9 +1486,10 @@ export class IrcBridge {
         log.info(`Ghost migration to ${newRoomId} complete`);
     }
 
-    public async connectionReap(logCb: (line: string) => void, reqServerName: string,
-                                maxIdleHours: number, reason = "User is inactive", dry = false,
-                                defaultOnline?: boolean, excludeRegex?: string, limit?: number) {
+    public async calculateIdlenessPool(
+        server: IrcServer, maxIdleHours: number,
+        defaultOnline?: boolean, excludeRegex?: string
+    ) {
         if (!this.activityTracker) {
             throw Error("activityTracker is not enabled");
         }
@@ -1496,16 +1497,9 @@ export class IrcBridge {
             throw Error("'since' must be greater than 0");
         }
         const maxIdleTime = maxIdleHours * 60 * 60 * 1000;
-        const server = reqServerName ? this.getServer(reqServerName) : this.getServers()[0];
-        const serverName = server?.getReadableName();
-        if (server === null) {
-            throw Error("Server not found");
-        }
-        log.warn(`Running connection reaper for ${serverName} dryrun=${dry}`);
-        const req = new BridgeRequest(this.bridge.getRequestFactory().newRequest());
-        logCb(`Connection reaping for ${serverName}`);
+
         const users: (string|null)[] = this.clientPool.getConnectedMatrixUsersForServer(server);
-        logCb(`${users.length} users are connected to the bridge`);
+        log.debug(`${users.length} users are connected to the bridge`);
         const exclude = excludeRegex ? new RegExp(excludeRegex) : null;
         const usersToActiveTime = new Map<string, number>();
         for (const userId of users) {
@@ -1514,7 +1508,7 @@ export class IrcBridge {
                 continue;
             }
             if (exclude && exclude.test(userId)) {
-                logCb(`${userId} is excluded`);
+                log.debug(`${userId} is excluded`);
                 continue;
             }
             const {online, inactiveMs} = await this.activityTracker.isUserOnline(userId, maxIdleTime, defaultOnline);
@@ -1523,16 +1517,61 @@ export class IrcBridge {
             }
             const clients = this.clientPool.getBridgedClientsForUserId(userId);
             if (clients.length === 0) {
-                logCb(`${userId} has no active clients`);
+                log.debug(`${userId} has no active clients`);
                 continue;
             }
             usersToActiveTime.set(userId, inactiveMs);
         }
-        logCb(`${usersToActiveTime.size} users are considered idle`);
 
-        const sortedByActiveTime = [...usersToActiveTime.entries()].sort((a, b) => b[1] - a[1]).map(user => user[0]);
+        return [...usersToActiveTime.entries()].sort((a, b) => b[1] - a[1]).map(user => user[0]);
+    }
+
+    /**
+     * Warn users that they are in danger of being reaped from a room.
+     * @param serverName The name of the IRC server which we want to scope the idle check to.
+     * @param maxIdleHours The maximum number of hours a user can be considered idle for.
+     * @param defaultOnline Whether the user should be defaulted to online or offline if we hold no data for them.
+     * @param excludeRegex A regex of users to exclude from the check.
+     * @param msg A message to send to affected idle users.
+     */
+    public async warnConnectionReap(
+        req: BridgeRequest, serverName: string, maxIdleHours: number, msg: string,
+        defaultOnline?: boolean, excludeRegex?: string, ) {
+        if (!maxIdleHours || maxIdleHours < 0) {
+            throw Error("'since' must be greater than 0");
+        }
+        const server = serverName ? this.getServer(serverName) : this.getServers()[0];
+        if (server === null) {
+            throw Error("Server not found");
+        }
+
+        for (const user of await this.calculateIdlenessPool(server, maxIdleHours, defaultOnline, excludeRegex)) {
+            const internalRoom = await this.ircHandler.getOrCreateAdminRoom(req, user, server);
+            this.sendMatrixAction(internalRoom, undefined, new MatrixAction(ActionType.Notice, msg));
+        }
+    }
+
+    public async connectionReap(logCb: (line: string) => void, reqServerName: string,
+                                maxIdleHours: number, reason = "User is inactive", dry = false,
+                                defaultOnline?: boolean, excludeRegex?: string, limit?: number) {
+        if (!maxIdleHours || maxIdleHours < 0) {
+            throw Error("'since' must be greater than 0");
+        }
+        const server = reqServerName ? this.getServer(reqServerName) : this.getServers()[0];
+        if (server === null) {
+            throw Error("Server not found");
+        }
+
+        const req = new BridgeRequest(this.bridge.getRequestFactory().newRequest());
+        const idleUsers = await this.calculateIdlenessPool(server, maxIdleHours, defaultOnline, excludeRegex);
+
+        logCb(`${(await idleUsers).length} users are considered idle`);
+
+        const serverName = server?.getReadableName();
+        log.warn(`Running connection reaper for ${serverName} dryrun=${dry}`);
+
         let userNumber = 0;
-        for (const userId of sortedByActiveTime) {
+        for (const userId of idleUsers) {
             userNumber++;
             if (limit && userNumber > limit) {
                 logCb(`Hit limit. Not kicking any more users.`);
@@ -1544,10 +1583,10 @@ export class IrcBridge {
                 logCb(`Didn't quit ${userId}: ${quitRes}`);
                 continue;
             }
-            logCb(`Quit ${userId} (${userNumber}/${usersToActiveTime.size})`);
+            logCb(`Quit ${userId} (${userNumber}/${idleUsers.length})`);
         }
 
-        logCb(`Quit ${userNumber}/${users.length}`);
+        logCb(`Quit ${userNumber}/${idleUsers.length}`);
     }
 
     public async atBridgedRoomLimit() {

--- a/src/bridge/IrcHandler.ts
+++ b/src/bridge/IrcHandler.ts
@@ -8,7 +8,7 @@ import { MatrixRoom, MatrixUser, MembershipQueue } from "matrix-appservice-bridg
 import { IrcUser } from "../models/IrcUser";
 import { IrcAction } from "../models/IrcAction";
 import { IrcRoom } from "../models/IrcRoom";
-import { MatrixAction } from "../models/MatrixAction";
+import { ActionType, MatrixAction } from "../models/MatrixAction";
 import { RequestLogger } from "../logging";
 import { RoomOrigin } from "../datastore/DataStore";
 import QuickLRU from "quick-lru";
@@ -948,14 +948,15 @@ export class IrcHandler {
                 if (ircMsg.command === "err_nosuchnick") {
                     return this.ircBridge.sendMatrixAction(
                         room, otherUser, new MatrixAction(
-                            "notice", `User is not online or does not exist. Message not sent.`
+                            ActionType.Notice, `User is not online or does not exist. Message not sent.`
                         ),
                     );
                 }
                 else if (ircMsg.command === "err_nononreg") {
                     return this.ircBridge.sendMatrixAction(
                         room, otherUser, new MatrixAction(
-                            "notice", `User is blocking messages from unregistered users, and you are not registered.`
+                            ActionType.Notice,
+                            `User is blocking messages from unregistered users, and you are not registered.`
                         ),
                     );
                 }

--- a/src/bridge/MatrixHandler.ts
+++ b/src/bridge/MatrixHandler.ts
@@ -10,7 +10,7 @@ import {
     Intent,
 } from "matrix-appservice-bridge";
 import { IrcUser } from "../models/IrcUser";
-import { MatrixAction, MatrixMessageEvent } from "../models/MatrixAction";
+import { ActionType, MatrixAction, MatrixMessageEvent } from "../models/MatrixAction";
 import { IrcRoom } from "../models/IrcRoom";
 import { BridgedClient } from "../irc/BridgedClient";
 import { IrcServer } from "../irc/IrcServer";
@@ -209,7 +209,7 @@ export class MatrixHandler {
             req.log.error("Accepting invite, and then leaving: This server does not allow PMs.");
             await intent.join(event.room_id);
             await this.ircBridge.sendMatrixAction(mxRoom, invitedUser, new MatrixAction(
-                "notice",
+                ActionType.Notice,
                 MSG_PMS_DISABLED
             ));
             await intent.leave(event.room_id);
@@ -226,7 +226,7 @@ export class MatrixHandler {
                 );
                 await intent.join(event.room_id);
                 await this.ircBridge.sendMatrixAction(mxRoom, invitedUser, new MatrixAction(
-                    "notice",
+                    ActionType.Notice,
                     MSG_PMS_DISABLED_FEDERATION
                 ));
                 await intent.leave(event.room_id);
@@ -277,7 +277,7 @@ export class MatrixHandler {
             );
 
             // Notify users in admin room
-            const notice = new MatrixAction("notice",
+            const notice = new MatrixAction(ActionType.Notice,
                 "There are more than 2 users in this admin room"
             );
             await this.ircBridge.sendMatrixAction(adminRoom, botUser, notice);

--- a/src/models/MatrixAction.ts
+++ b/src/models/MatrixAction.ts
@@ -22,25 +22,42 @@ import escapeStringRegexp from "escape-string-regexp";
 import logging from "../logging";
 const log = logging("MatrixAction");
 
-const ACTION_TYPES = ["message", "emote", "topic", "notice", "file", "image", "video", "audio", "command"];
-const EVENT_TO_TYPE: {[mxKey: string]: string} = {
-    "m.room.message": "message",
-    "m.room.topic": "topic"
+export enum ActionType {
+    Audio = "audio",
+    Command = "command",
+    Emote = "emote",
+    File = "file",
+    Image = "image",
+    Message = "message",
+    Notice = "notice",
+    Topic = "topic",
+    Video = "video",
+}
+
+const EVENT_TO_TYPE: Record<string, ActionType> = {
+    "m.room.message": ActionType.Message,
+    "m.room.topic": ActionType.Topic,
 };
 
-const ACTION_TYPE_TO_MSGTYPE = {
-    message: "m.text",
+const ACTION_TYPE_TO_MSGTYPE: Record<ActionType, string|undefined> = {
+    audio: undefined,
+    command: undefined,
     emote: "m.emote",
-    notice: "m.notice"
+    file: undefined,
+    image: undefined,
+    message: "m.text",
+    notice: "m.notice",
+    topic: undefined,
+    video: undefined,
 };
 
-const MSGTYPE_TO_TYPE: {[mxKey: string]: string} = {
-    "m.emote": "emote",
-    "m.notice": "notice",
-    "m.image": "image",
-    "m.video": "video",
-    "m.audio": "audio",
-    "m.file": "file"
+const MSGTYPE_TO_TYPE: {[mxKey: string]: ActionType} = {
+    "m.emote": ActionType.Emote,
+    "m.notice": ActionType.Notice,
+    "m.image": ActionType.Image,
+    "m.video": ActionType.Video,
+    "m.audio": ActionType.Audio,
+    "m.file": ActionType.File,
 };
 
 const PILL_MIN_LENGTH_TO_MATCH = 4;
@@ -88,16 +105,12 @@ const MentionRegex = function(matcher: string): RegExp {
 export class MatrixAction {
 
     constructor(
-        public readonly type: string,
+        public readonly type: ActionType,
         public text: string|null = null,
         public htmlText: string|null = null,
         public readonly ts: number = 0,
         public replyEvent?: string,
-    ) {
-        if (!ACTION_TYPES.includes(type)) {
-            throw new Error("Unknown MatrixAction type: " + type);
-        }
-    }
+    ) { }
 
     public get msgType() {
         return (ACTION_TYPE_TO_MSGTYPE as {[key: string]: string|undefined})[this.type];
@@ -176,7 +189,7 @@ export class MatrixAction {
         else if (event.type === "m.room.message") {
             if (event.content.msgtype === 'm.text' && event.content.body?.startsWith('!irc ')) {
                 // This might be a command
-                type = "command";
+                type = ActionType.Command;
                 return new MatrixAction(type, text, null, event.origin_server_ts, event.event_id);
             }
             if (event.content.format === "org.matrix.custom.html") {
@@ -220,7 +233,7 @@ export class MatrixAction {
             case "notice": {
                 const htmlText = ircFormatting.ircToHtml(ircAction.text);
                 return new MatrixAction(
-                    ircAction.type,
+                    ircAction.type as ActionType,
                     ircFormatting.stripIrcFormatting(ircAction.text),
                     // only set HTML text if we think there is HTML, else the bridge
                     // will send everything as HTML and never text only.
@@ -228,7 +241,7 @@ export class MatrixAction {
                 );
             }
             case "topic":
-                return new MatrixAction("topic", ircAction.text);
+                return new MatrixAction(ActionType.Topic, ircAction.text);
             default:
                 log.error("MatrixAction.fromIrcAction: Unknown action: %s", ircAction.type);
                 return null;


### PR DESCRIPTION
Partial fix to https://github.com/matrix-org/matrix-appservice-irc/issues/1397 (doesn't allow opt out, but does warn you now)

This PR will allow services to advance-notify users that they are going to be idle kicked. Like user reaping, this is called from the DebugAPI. This also includes a dummy command "!active" to let the bridge know that you are active. I left this in just so the user has something tangible to do, but any messages sent to the bridge will reset your timeout anyway.