### PR TITLE
Wrap URL in angle brackets in truncatedMessageTemplate

### DIFF
--- a/changelog.d/1573.bugfix
+++ b/changelog.d/1573.bugfix
@@ -1,1 +1,1 @@
-truncatedMessageTemplate now defaults to wrapping URLs in angle brackets
+Truncated messages now default to wrapping URLs in angle brackets.

--- a/changelog.d/1573.bugfix
+++ b/changelog.d/1573.bugfix
@@ -1,0 +1,1 @@
+truncatedMessageTemplate now defaults to wrapping URLs in angle brackets

--- a/src/bridge/MatrixHandler.ts
+++ b/src/bridge/MatrixHandler.ts
@@ -58,7 +58,7 @@ const DEFAULTS: MatrixHandlerConfig = {
     shortReplyTresholdSeconds: 5 * 60,
     shortReplyTemplate: "$NICK: $REPLY",
     longReplyTemplate: "<$NICK> \"$ORIGINAL\" <- $REPLY",
-    truncatedMessageTemplate: "(full message at $URL)",
+    truncatedMessageTemplate: "(full message at <$URL>)",
 };
 
 export interface MatrixEventInvite {


### PR DESCRIPTION
The closing parenthesis can confuse parsers, as this character is [allowed in IRI paths](https://datatracker.ietf.org/doc/html/rfc3987#section-2.2)

Angle brackets are a [common URL/IRI delimiter](https://datatracker.ietf.org/doc/html/rfc1738#page-3), which is [not allowed in IRIs](https://datatracker.ietf.org/doc/html/rfc3987#page-13) so they should work much better.

Signed-off-by: Valentin Lorentz \<progval plus git at progval dot net\>