### PR TITLE
usage.md: clarify instructions

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -37,8 +37,8 @@ section.
 
 ### Customising your experience
 
-You may also want to customise your nickname or set a password to authenticate with services, you
-can do this by PMing the bridge bot user.
+You may also want to customise your nickname or set a password to authenticate with services.
+You can do this by PMing the Appservice user as follows:
 
 ```
 !nick Alice


### PR DESCRIPTION
The `!nick` command needs to be sent to the appservice user, not the bridge bot. I just got bit by this; following the instructions [here](https://matrix-org.github.io/matrix-appservice-irc/latest/usage.html#customising-your-experience) led to confusion, whereas [this external documentation](https://meta.wikimedia.org/wiki/Matrix.org#Configuring_your_IRC_nick) helped me get unblocked.

CC @bd808.