### PR TITLE
Disable metrics by default

### DIFF
--- a/changelog.d/1596.bugfix
+++ b/changelog.d/1596.bugfix
@@ -1,0 +1,1 @@
+Disable metrics by default.

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -485,7 +485,7 @@ ircService:
   # This key CANNOT be hot-reloaded
   metrics:
     # Whether to actually enable the metric endpoint. Default: false
-    enabled: true
+    enabled: false
     # Which port to listen on (omit to listen on the bindPort)
     port: 7001
     # Which hostname to listen on (omit to listen on 127.0.0.1), requires port to be set


### PR DESCRIPTION
Says that metrics should be disabled by default, but are enabled instead.

Signed-off-by:  `Bob Arctor <neetzsche@tutanota.com>`