### PR TITLE
Fix distribution of IrcServer.randomDomain()

### DIFF
--- a/changelog.d/1612.bugfix
+++ b/changelog.d/1612.bugfix
@@ -1,1 +1,1 @@
-Fix distribution IrcServer.randomDomain().
+Fix distribution of IrcServer.randomDomain() which tended to pick domains with a lower index when there are a lot of addresses for a server.

--- a/changelog.d/1612.bugfix
+++ b/changelog.d/1612.bugfix
@@ -1,0 +1,1 @@
+Fix distribution IrcServer.randomDomain().

--- a/src/irc/IrcServer.ts
+++ b/src/irc/IrcServer.ts
@@ -205,12 +205,14 @@ export class IrcServer {
     }
 
     /**
-     * Return a randomised server domain from the default and additional addresses.
+     * Return a random server domain from the default and additional addresses.
      * @return {string}
      */
-    public randomDomain() {
+    public randomDomain(): string {
+        // This cannot return undefined because the construtor and .reconfigure()
+        // ensure that `addresses` isn't an empty array.
         return this.addresses[
-            Math.floor((Math.random() * 1000) % this.addresses.length)
+            Math.floor(Math.random() * this.addresses.length)
         ];
     }
 


### PR DESCRIPTION
Does the former method have any advantages?

The larger the array of domains, the more it will tend to pick an item with a low index.
Extreme case: If the list has more than 1000 domains, only the first 1000 will be picked.
