### PR TITLE
PublicitySyncer: Replace Object with Map

### DIFF
--- a/changelog.d/1613.bugfix
+++ b/changelog.d/1613.bugfix
@@ -1,0 +1,1 @@
+PublicitySyncer: Replace Object with Map to avoid risk of prototype pollution by malicious Matrix Room IDs.

--- a/src/datastore/DataStore.ts
+++ b/src/datastore/DataStore.ts
@@ -181,7 +181,7 @@ export interface DataStore {
 
     getAllUserIds(): Promise<string[]>;
 
-    getRoomsVisibility(roomIds: string[]): Promise<{[roomId: string]: "public"|"private"}>;
+    getRoomsVisibility(roomIds: string[]): Promise<Map<string, "public"|"private">>;
 
     setRoomVisibility(roomId: string, vis: "public"|"private"): Promise<void>;
 

--- a/src/datastore/NedbDataStore.ts
+++ b/src/datastore/NedbDataStore.ts
@@ -708,10 +708,10 @@ export class NeDBDataStore implements DataStore {
         return room.get("visibility") as "public"|"private";
     }
 
-    public async getRoomsVisibility(roomIds: string[]) {
-        const map: {[roomId: string]: "public"|"private"} = {};
+    public async getRoomsVisibility(roomIds: string[]): Promise<Map<string, "public"|"private">> {
+        const map: Map<string, "public"|"private"> = new Map();
         for (const roomId of roomIds) {
-            map[roomId] = await this.getRoomVisibility(roomId);
+            map.set(roomId, await this.getRoomVisibility(roomId));
         }
         return map;
     }

--- a/src/datastore/postgres/PgDataStore.ts
+++ b/src/datastore/postgres/PgDataStore.ts
@@ -659,12 +659,12 @@ export class PgDataStore implements DataStore {
         return res.rows.map((u) => u.user_id);
     }
 
-    public async getRoomsVisibility(roomIds: string[]) {
-        const map: {[roomId: string]: "public"|"private"} = {};
+    public async getRoomsVisibility(roomIds: string[]): Promise<Map<string, "public"|"private">> {
+        const map: Map<string, "public"|"private"> = new Map();
         const list = `('${roomIds.join("','")}')`;
         const res = await this.pgPool.query(`SELECT room_id, visibility FROM room_visibility WHERE room_id IN ${list}`);
         for (const row of res.rows) {
-            map[row.room_id] = row.visibility ? "public" : "private";
+            map.set(row.room_id, row.visibility ? "public" : "private");
         }
         return map;
     }


### PR DESCRIPTION
Replace Object with Map to avoid risk of prototype pollution by malicious Matrix Room IDs.

Risk: low – Requires attacker to be able to add unvalidated Matrix Room IDs into the IRCchannel<->MatrixRoom mappings.