### PR TITLE
Prevent low-risk SQL injection from roomId values

### DIFF
--- a/src/datastore/postgres/PgDataStore.ts
+++ b/src/datastore/postgres/PgDataStore.ts
@@ -661,8 +661,9 @@ export class PgDataStore implements DataStore {
 
     public async getRoomsVisibility(roomIds: string[]) {
         const map: {[roomId: string]: "public"|"private"} = {};
-        const list = `('${roomIds.join("','")}')`;
-        const res = await this.pgPool.query(`SELECT room_id, visibility FROM room_visibility WHERE room_id IN ${list}`);
+        const res = await this.pgPool.query("SELECT room_id, visibility FROM room_visibility WHERE room_id IN $1", [
+            roomIds,
+        ]);
         for (const row of res.rows) {
             map[row.room_id] = row.visibility ? "public" : "private";
         }


### PR DESCRIPTION
Prevents low-risk SQL injection from roomId values when checking room visibility.

This fixes a hard to exploit SQL injection vector.
To abuse this, an attacker needs to be able to set malicious Matrix IDs in the room mappings.