### PR TITLE
Disable user activity tracking unless explicitly enabled

### DIFF
--- a/changelog.d/1638.removal
+++ b/changelog.d/1638.removal
@@ -1,0 +1,1 @@
+User activity tracking is now disabled by default, unless `userActivity` is enabled in the config.

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -580,6 +580,7 @@ ircService:
   # Maximum number of montly active users, beyond which the bridge gets blocked (both ways)
   # RMAUlimit: 100
   
+  # Optional.
   # userActivity:
     # The "grace period" before we start counting users as active
     # minUserActiveDays: 1


### PR DESCRIPTION
Most hosters don't care about this, and it seems to be fairly CPU heavy on large deployments.