### PR TITLE
Fix port specified in config not being used in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN git clone https://github.com/matrix-org/freebindfree.git
 RUN cd freebindfree && make
 
 # Typescript build
-FROM node:16-slim as builder
+FROM node:16 as builder
 
 WORKDIR /build
 

--- a/changelog.d/1654.bugfix
+++ b/changelog.d/1654.bugfix
@@ -1,0 +1,1 @@
+Fix the configured bind port being overridden in Docker.

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -5,4 +5,4 @@ then
   ip route add local $PREFIX dev lo
 fi
 
-exec node app.js -c /data/config.yaml -p 8090 -f /data/appservice-registration-irc.yaml -u http://localhost:8090
+exec node app.js -c /data/config.yaml -f /data/appservice-registration-irc.yaml


### PR DESCRIPTION
Fixes custom port specified in config under `homeserver.bindPort` not being used in Docker.
The run script for Docker was passing a port which would override this.

Also uses `node:16` instead of `node:16-slim` for the builder container because otherwise on ARM64 architecture it would error when trying to build `node-gyp` due to missing Python.