### PR TITLE
Rename infoMapping to initialEvent

### DIFF
--- a/changelog.d/1672.misc
+++ b/changelog.d/1672.misc
@@ -1,1 +1,1 @@
-Rename internal variable infoMapping to initialEvent
+Rename internal variable infoMapping to initialEvent.

--- a/changelog.d/1672.misc
+++ b/changelog.d/1672.misc
@@ -1,0 +1,1 @@
+Rename internal variable infoMapping to initialEvent

--- a/src/provisioning/Provisioner.ts
+++ b/src/provisioning/Provisioner.ts
@@ -571,15 +571,15 @@ export class Provisioner extends ProvisioningApi {
         // Send bridge info state event
         if (this.ircBridge.stateSyncer) {
             const intent = this.ircBridge.getAppServiceBridge().getIntent();
-            const infoMapping = await this.ircBridge.stateSyncer.createInitialState(roomId, {
+            const initialEvent = await this.ircBridge.stateSyncer.createInitialState(roomId, {
                 channel: ircChannel,
                 networkId: server.getNetworkId(),
             })
             await intent.sendStateEvent(
                 roomId,
-                infoMapping.type,
-                infoMapping.state_key,
-                infoMapping.content as unknown as Record<string, unknown>,
+                initialEvent.type,
+                initialEvent.state_key,
+                initialEvent.content as unknown as Record<string, unknown>,
             );
         }
     }


### PR DESCRIPTION
The info mapping is the second argument to createInitialState, not what it returns