### PR TITLE
Update matrix-appservice-bridge

### DIFF
--- a/changelog.d/1676.misc
+++ b/changelog.d/1676.misc
@@ -1,0 +1,1 @@
+Update matrix-appservice-bridge to `8.1.1`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "extend": "^3.0.2",
         "he": "^1.2.0",
         "logform": "^2.4.2",
-        "matrix-appservice-bridge": "^8.1.0",
+        "matrix-appservice-bridge": "^8.1.1",
         "matrix-bot-sdk": "^0.6.2",
         "matrix-org-irc": "^1.5.0",
         "matrix-widget-api": "^1.1.1",
@@ -6842,9 +6842,9 @@
       }
     },
     "node_modules/matrix-appservice-bridge": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/matrix-appservice-bridge/-/matrix-appservice-bridge-8.1.0.tgz",
-      "integrity": "sha512-yeBXFOo9Iz0lw5kTAMpZPWvKRe+O7g0VN+CI7YB7/jPFINIQ5IA71OIxnrNoBMX7GO5+Ku+n7HX0XA+25uJ7FQ==",
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/matrix-appservice-bridge/-/matrix-appservice-bridge-8.1.1.tgz",
+      "integrity": "sha512-6QYvTxe8kLXa2u+npeFUJph0PVqaOK6BPyC2J4bM0iklS8wNyprwzpToxGUr0WZS6D8vRc8qbyxhN1JTUbu9kw==",
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "@types/pkginfo": "^0.4.0",
@@ -15332,9 +15332,9 @@
       }
     },
     "matrix-appservice-bridge": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/matrix-appservice-bridge/-/matrix-appservice-bridge-8.1.0.tgz",
-      "integrity": "sha512-yeBXFOo9Iz0lw5kTAMpZPWvKRe+O7g0VN+CI7YB7/jPFINIQ5IA71OIxnrNoBMX7GO5+Ku+n7HX0XA+25uJ7FQ==",
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/matrix-appservice-bridge/-/matrix-appservice-bridge-8.1.1.tgz",
+      "integrity": "sha512-6QYvTxe8kLXa2u+npeFUJph0PVqaOK6BPyC2J4bM0iklS8wNyprwzpToxGUr0WZS6D8vRc8qbyxhN1JTUbu9kw==",
       "requires": {
         "@alloc/quick-lru": "^5.2.0",
         "@types/pkginfo": "^0.4.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "extend": "^3.0.2",
     "he": "^1.2.0",
     "logform": "^2.4.2",
-    "matrix-appservice-bridge": "^8.1.0",
+    "matrix-appservice-bridge": "^8.1.1",
     "matrix-bot-sdk": "^0.6.2",
     "matrix-org-irc": "^1.5.0",
     "matrix-widget-api": "^1.1.1",


### PR DESCRIPTION
Updates `matrix-appservice-bridge` to `8.1.1` for auth token fixes.
https://github.com/matrix-org/matrix-appservice-bridge/releases/tag/8.1.1