### PR TITLE
Fix provisioning API base URL in setup widgets

### DIFF
--- a/changelog.d/1677.bugfix
+++ b/changelog.d/1677.bugfix
@@ -1,0 +1,1 @@
+Fix provisioning API base URL in setup widgets.

--- a/widget/src/App.tsx
+++ b/widget/src/App.tsx
@@ -4,7 +4,6 @@ import { IrcApp } from './IrcApp';
 
 const App = () => {
     return <ProvisioningApp
-        apiPrefix="/_matrix/provision"
         tokenName="irc-sessionToken"
     >
         <IrcApp/>

--- a/widget/src/ProvisioningApp.tsx
+++ b/widget/src/ProvisioningApp.tsx
@@ -25,16 +25,13 @@ export const useProvisioningContext = (): ProvisioningContext => {
 };
 
 /**
- * @param apiPrefix Base path for API requests.
  * @param tokenName Name to use for the session token in localstorage.
  * @param children
  * @constructor
  */
 export const ProvisioningApp: React.FC<React.PropsWithChildren<{
-    apiPrefix: string,
     tokenName: string,
 }>> = ({
-   apiPrefix,
    tokenName,
    children,
 }) => {
@@ -97,8 +94,9 @@ export const ProvisioningApp: React.FC<React.PropsWithChildren<{
             return;
         }
 
-        // Assuming the widget is hosted on the same origin as the API
-        const apiBaseUrl = urlJoin(window.location.origin, apiPrefix);
+        // Remove the widget path to get the provisioning API base URL
+        // https://example.com/irc/_matrix/provision/v1/static -> https://example.com/irc/_matrix/provision
+        const apiBaseUrl = window.location.origin + window.location.pathname.replace('/v1/static', '');
 
         const initClient = async() => {
             try {
@@ -118,7 +116,7 @@ export const ProvisioningApp: React.FC<React.PropsWithChildren<{
             }
         };
         void initClient();
-    }, [apiPrefix, tokenName, widgetApi]);
+    }, [tokenName, widgetApi]);
 
     const provisioningContext: ProvisioningContext | undefined = useMemo(() => {
         if (!client || !roomId || !widgetId) {


### PR DESCRIPTION
Fixes how the setup widget determines the API base URL to use, in order to support hosting on different paths.
e.g. `https://example.com/irc/_matrix/provision/v1/static` -> `https://example.com/irc/_matrix/provision`

This takes advantage of the widget always being hosted at `/v1/static`, so we can just strip that to get the base URL:
https://github.com/matrix-org/matrix-appservice-bridge/blob/7ecbe69fb86e92851af3946135867357e8866743/src/provisioning/api.ts#L166-L167