### PR TITLE
Fix mocking of AppService.listen when matrix-appservice-bridge is linked

### DIFF
--- a/src/bridge/IrcBridge.ts
+++ b/src/bridge/IrcBridge.ts
@@ -19,6 +19,10 @@ import { PublicitySyncer } from "./PublicitySyncer";
 import { Histogram } from "prom-client";
 
 import {
+    AppServiceRegistration,
+    AppService,
+} from "matrix-appservice";
+import {
     Bridge,
     MatrixUser,
     MatrixRoom,
@@ -30,8 +34,6 @@ import {
     EphemeralEvent,
     MembershipQueue,
     BridgeInfoStateSyncer,
-    AppServiceRegistration,
-    AppService,
     Rules,
     ActivityTracker,
     BridgeBlocker,


### PR DESCRIPTION
spec/util/test.js uses proxyquire to monkey-patch matrix-appservice relative to lib/main.js; which is located at ~/matrix-appservice-irc/node_modules/matrix-appservice/lib/index.js

However, when using 'yarnpkg link matrix-appservice-bridge', the AppService class reexported by matrix-appservice-bridge is the one that was imported relative to matrix-appservice-bridge; which is located at ~/matrix-appservice-bridge/node_modules/matrix-appservice/lib/index.js which proxyquire didn't identify as a target to the mock.

This resolves the issue I mentioned in `#matrix-irc` and WC in the last two days.