### PR TITLE
Fix `unlink` admin command

### DIFF
--- a/changelog.d/1692.bugfix
+++ b/changelog.d/1692.bugfix
@@ -1,0 +1,1 @@
+Fix unlink command showing an error

--- a/changelog.d/1692.bugfix
+++ b/changelog.d/1692.bugfix
@@ -1,1 +1,1 @@
-Fix unlink command showing an error
+Fix unlink command showing an error.

--- a/src/bridge/AdminRoomHandler.ts
+++ b/src/bridge/AdminRoomHandler.ts
@@ -259,6 +259,7 @@ export class AdminRoomHandler {
                 Provisioner.createFakeRequest(
                     "unplumb",
                     sender,
+                    { },
                     {
                         remote_room_server: serverDomain,
                         remote_room_channel: ircChannel,


### PR DESCRIPTION
This got broken in the move to the new admin API.