### PR TITLE
Show helpful admin command error if it's a IrcProvisioningError

### DIFF
--- a/changelog.d/1702.bugfix
+++ b/changelog.d/1702.bugfix
@@ -1,0 +1,1 @@
+Show a helpful error for !link/!unlink admin failures, rather than "Check the logs for details", in more cases.

--- a/src/bridge/AdminRoomHandler.ts
+++ b/src/bridge/AdminRoomHandler.ts
@@ -27,6 +27,7 @@ import * as RoomCreation from "./RoomCreation";
 import { getBridgeVersion } from "matrix-appservice-bridge";
 import { IdentGenerator } from "../irc/IdentGenerator";
 import { Provisioner } from "../provisioning/Provisioner";
+import { IrcProvisioningError } from "../provisioning/Schema";
 
 const log = logging("AdminRoomHandler");
 
@@ -239,6 +240,9 @@ export class AdminRoomHandler {
         }
         catch (ex) {
             log.error(`Failed to handle !plumb command:`, ex);
+            if (ex instanceof IrcProvisioningError) {
+                return new MatrixAction(ActionType.Notice, `Failed to plumb room. ${ex.message}`);
+            }
             return new MatrixAction(ActionType.Notice, "Failed to plumb room. Check the logs for details.");
         }
         return new MatrixAction(ActionType.Notice, "Room plumbed.");
@@ -272,6 +276,9 @@ export class AdminRoomHandler {
         }
         catch (ex) {
             log.error(`Failed to handle !unlink command:`, ex);
+            if (ex instanceof IrcProvisioningError) {
+                return new MatrixAction(ActionType.Notice, `Failed to plumb room. ${ex.message}`);
+            }
             return new MatrixAction(ActionType.Notice, "Failed to unlink room. Check the logs for details.");
         }
         return new MatrixAction(ActionType.Notice, "Room unlinked.");

--- a/src/bridge/AdminRoomHandler.ts
+++ b/src/bridge/AdminRoomHandler.ts
@@ -289,7 +289,7 @@ export class AdminRoomHandler {
         // check that the server exists and that the user_id is on the whitelist
         const ircChannel = args[0];
         const key = args[1]; // keys can't have spaces in them, so we can just do this.
-        let errText = null;
+        let errText: string|null = null;
         if (!ircChannel || !ircChannel.startsWith("#")) {
             errText = "Format: '!join irc.example.com #channel [key]'";
         }


### PR DESCRIPTION
We now throw helpful error types when failing to run some provisioning commands but we are still showing "check logs for details". I, like many people get really pissed off when applications make me "check logs for details". For the sake of security this still only emits a error message in the case where we know the type of error.