### PR TITLE
Fix linking rooms from setup widget when a `networkId` is configured

### DIFF
--- a/changelog.d/1706.bugfix
+++ b/changelog.d/1706.bugfix
@@ -1,0 +1,1 @@
+Fix linking rooms from setup widget when a `networkId` is configured.

--- a/widget/src/IrcApp.tsx
+++ b/widget/src/IrcApp.tsx
@@ -316,7 +316,7 @@ const AvailableChannels = ({
                 setNetworks(networks);
 
                 if (networks.servers.length === 1) {
-                    setSelectedServer(networks.servers[0].network_id);
+                    setSelectedServer(networks.servers[0].fields.domain);
                 }
             } catch (e) {
                 console.error(e);
@@ -346,7 +346,7 @@ const AvailableChannels = ({
                     >
                         <option value="" key="blank">Select a server</option>
                         { networks.servers.map(server =>
-                            <option value={server.network_id} key={server.network_id}>
+                            <option value={server.fields.domain} key={server.network_id}>
                                 { server.desc }
                             </option>
                         ) }


### PR DESCRIPTION
Fixes an error when trying to link a room on a server which has a `networkId` configured, by making the request with the domain instead of the `networkId` (which defaults to the domain if not configured).