### PR TITLE
Pin `matrix-widget-api` to 1.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "matrix-appservice-bridge": "^9.0.0",
     "matrix-bot-sdk": "npm:@vector-im/matrix-bot-sdk@^0.6.6-element.1",
     "matrix-org-irc": "^2.0.0",
-    "matrix-widget-api": "^1.1.1",
+    "matrix-widget-api": "1.1.1",
     "nopt": "^6.0.0",
     "p-queue": "^6.6.2",
     "pg": "^8.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4259,10 +4259,10 @@ matrix-org-irc@^2.0.0:
     typed-emitter "^2.1.0"
     utf-8-validate "^6.0.3"
 
-matrix-widget-api@^1.1.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/matrix-widget-api/-/matrix-widget-api-1.3.1.tgz#e38f404c76bb15c113909505c1c1a5b4d781c2f5"
-  integrity sha512-+rN6vGvnXm+fn0uq9r2KWSL/aPtehD6ObC50jYmUcEfgo8CUpf9eUurmjbRlwZkWq3XHXFuKQBUCI9UzqWg37Q==
+matrix-widget-api@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/matrix-widget-api/-/matrix-widget-api-1.1.1.tgz#d3fec45033d0cbc14387a38ba92dac4dbb1be962"
+  integrity sha512-gNSgmgSwvOsOcWK9k2+tOhEMYBiIMwX95vMZu0JqY7apkM02xrOzUBuPRProzN8CnbIALH7e3GAhatF6QCNvtA==
   dependencies:
     "@types/events" "^3.0.0"
     events "^3.2.0"


### PR DESCRIPTION
With the switch to yarn recreating our lockfile, `matrix-widget-api` was bumped to 1.3.1 which breaks setup widgets due to an issue with postmessage request origins.

We should pin the version for now, and figure out what has broken in the later versions:
https://github.com/matrix-org/matrix-widget-api/compare/v1.1.1...v1.3.1