### PR TITLE
Fix Widget API origin in setup widget

### DIFF
--- a/changelog.d/1711.bugfix
+++ b/changelog.d/1711.bugfix
@@ -1,0 +1,1 @@
+Fix setup widget failing to authenticate.

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "matrix-appservice-bridge": "^9.0.0",
     "matrix-bot-sdk": "npm:@vector-im/matrix-bot-sdk@^0.6.6-element.1",
     "matrix-org-irc": "^2.0.0",
-    "matrix-widget-api": "^1.1.1",
+    "matrix-widget-api": "^1.4.0",
     "nopt": "^6.0.0",
     "p-queue": "^6.6.2",
     "pg": "^8.8.0",

--- a/widget/src/ProvisioningApp.tsx
+++ b/widget/src/ProvisioningApp.tsx
@@ -72,7 +72,7 @@ export const ProvisioningApp: React.FC<React.PropsWithChildren<{
             return;
         }
 
-        const widgetApi = new WidgetApi(widgetId);
+        const widgetApi = new WidgetApi(widgetId, '*');
         widgetApi.on('ready', () => {
             console.log('Widget API ready');
         });

--- a/yarn.lock
+++ b/yarn.lock
@@ -4259,10 +4259,10 @@ matrix-org-irc@^2.0.0:
     typed-emitter "^2.1.0"
     utf-8-validate "^6.0.3"
 
-matrix-widget-api@^1.1.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/matrix-widget-api/-/matrix-widget-api-1.3.1.tgz#e38f404c76bb15c113909505c1c1a5b4d781c2f5"
-  integrity sha512-+rN6vGvnXm+fn0uq9r2KWSL/aPtehD6ObC50jYmUcEfgo8CUpf9eUurmjbRlwZkWq3XHXFuKQBUCI9UzqWg37Q==
+matrix-widget-api@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/matrix-widget-api/-/matrix-widget-api-1.4.0.tgz#e426ec16a013897f3a4a9c2bff423f54ab0ba745"
+  integrity sha512-dw0dRylGQzDUoiaY/g5xx1tBbS7aoov31PRtFMAvG58/4uerYllV9Gfou7w+I1aglwB6hihTREzKltVjARWV6A==
   dependencies:
     "@types/events" "^3.0.0"
     events "^3.2.0"


### PR DESCRIPTION
With the switch to yarn recreating our lockfile, `matrix-widget-api` was bumped to 1.3.1 which broke setup widgets due to a breaking change with postmessage request origins. https://github.com/matrix-org/matrix-widget-api/issues/83

Bumps `matrix-widget-api` to 1.4.0 and fixes this by specifying the request origin.