### PR TITLE
Sort by channel name in !listrooms

### DIFF
--- a/changelog.d/1715.bugfix
+++ b/changelog.d/1715.bugfix
@@ -1,0 +1,1 @@
+Sort the list of channels in !listrooms output.

--- a/src/bridge/AdminRoomHandler.ts
+++ b/src/bridge/AdminRoomHandler.ts
@@ -601,7 +601,7 @@ export class AdminRoomHandler {
 
         let chanList = `You are joined to ${client.chanList.size} rooms: \n\n`;
         let chanListHTML = `<p>You are joined to <code>${client.chanList.size}</code> rooms:</p><ul>`;
-        for (const channel of client.chanList) {
+        for (const channel of [...client.chanList].sort()) {
             const rooms = await this.ircBridge.getStore().getMatrixRoomsForChannel(server, channel);
             chanList += `- \`${channel}\` which is bridged to ${rooms.map((r) => r.getId()).join(", ")}`;
             const roomMentions = rooms


### PR DESCRIPTION
It's stored as a set in the client object, which doesn't guarantee anything about the order, so sort it for consistent output.

<!--
Hi there 👋, please check you've read the [CONTRIBUTING](../CONTRIBUTING.md) guide before submitting a PR (it's worth it, honestly).
-->