### PR TITLE
Ensure QUIT messages are sent in pooling configuration

### DIFF
--- a/changelog.d/1752.bugfix
+++ b/changelog.d/1752.bugfix
@@ -1,0 +1,1 @@
+Ensure QUIT messages are always sent.

--- a/spec/e2e/basic.spec.ts
+++ b/spec/e2e/basic.spec.ts
@@ -7,7 +7,7 @@ describe('Basic bridge usage', () => {
     let testEnv: IrcBridgeE2ETest;
     beforeEach(async () => {
         testEnv = await IrcBridgeE2ETest.createTestEnv({
-            matrixLocalparts: ['alice'],
+            matrixLocalparts: [TestIrcServer.generateUniqueNick("alice")],
             ircNicks: ['bob'],
         });
         await testEnv.setUp();

--- a/spec/e2e/pooling.spec.ts
+++ b/spec/e2e/pooling.spec.ts
@@ -10,7 +10,7 @@ describeif('Connection pooling', () => {
     beforeEach(async () => {
         // Initial run of the bridge to setup a testing environment
         testEnv = await IrcBridgeE2ETest.createTestEnv({
-            matrixLocalparts: ['alice'],
+            matrixLocalparts: [TestIrcServer.generateUniqueNick('alice')],
             ircNicks: ['bob'],
             config: {
                 connectionPool: {

--- a/spec/e2e/quit.spec.ts
+++ b/spec/e2e/quit.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { TestIrcServer } from "matrix-org-irc";
 import { IrcBridgeE2ETest } from "../util/e2e-test";
 import { describe, it } from "@jest/globals";
@@ -17,7 +16,7 @@ describe('Ensure quit messsage is sent', () => {
     afterEach(() => {
         return testEnv?.tearDown();
     });
-    it('should update powerlevel of IRC user when OPed by an IRC user', async () => {
+    it('should correctly send a quit message on ', async () => {
         const channel = `#${TestIrcServer.generateUniqueNick("test")}`;
         const { homeserver } = testEnv;
         const [alice] = homeserver.users.map(c => c.client);

--- a/spec/e2e/quit.spec.ts
+++ b/spec/e2e/quit.spec.ts
@@ -16,7 +16,7 @@ describe('Ensure quit messsage is sent', () => {
     afterEach(() => {
         return testEnv?.tearDown();
     });
-    it('should correctly send a quit message on ', async () => {
+    it('should correctly send a quit message on !reconnect', async () => {
         const channel = `#${TestIrcServer.generateUniqueNick("test")}`;
         const { homeserver } = testEnv;
         const [alice] = homeserver.users.map(c => c.client);

--- a/spec/e2e/quit.spec.ts
+++ b/spec/e2e/quit.spec.ts
@@ -7,7 +7,7 @@ describe('Ensure quit messsage is sent', () => {
     let testEnv: IrcBridgeE2ETest;
     beforeEach(async () => {
         testEnv = await IrcBridgeE2ETest.createTestEnv({
-            matrixLocalparts: ['alice'],
+            matrixLocalparts: [TestIrcServer.generateUniqueNick('alice')],
             ircNicks: ['bob'],
             traceToFile: true,
         });
@@ -18,7 +18,7 @@ describe('Ensure quit messsage is sent', () => {
     });
     it('should correctly send a quit message on !reconnect', async () => {
         const channel = `#${TestIrcServer.generateUniqueNick("test")}`;
-        const { homeserver } = testEnv;
+        const { homeserver, opts } = testEnv;
         const [alice] = homeserver.users.map(c => c.client);
         const { bob } = testEnv.ircTest.clients;
 
@@ -36,7 +36,7 @@ describe('Ensure quit messsage is sent', () => {
         // Now, have alice quit.
         await alice.sendText(adminRoom, `!reconnect`);
         const [nick, message, channels] = await quitEvent;
-        expect(nick).toEqual('M-alice');
+        expect(nick).toEqual(`M-${opts.matrixLocalparts?.[0]}`);
         expect(message).toEqual('Quit: Reconnecting');
         expect(channels).toContain(channel);
     });

--- a/spec/e2e/quit.spec.ts
+++ b/spec/e2e/quit.spec.ts
@@ -1,0 +1,44 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+import { TestIrcServer } from "matrix-org-irc";
+import { IrcBridgeE2ETest } from "../util/e2e-test";
+import { describe, it } from "@jest/globals";
+
+
+describe('Ensure quit messsage is sent', () => {
+    let testEnv: IrcBridgeE2ETest;
+    beforeEach(async () => {
+        testEnv = await IrcBridgeE2ETest.createTestEnv({
+            matrixLocalparts: ['alice'],
+            ircNicks: ['bob'],
+            traceToFile: true,
+        });
+        await testEnv.setUp();
+    });
+    afterEach(() => {
+        return testEnv?.tearDown();
+    });
+    it('should update powerlevel of IRC user when OPed by an IRC user', async () => {
+        const channel = `#${TestIrcServer.generateUniqueNick("test")}`;
+        const { homeserver } = testEnv;
+        const [alice] = homeserver.users.map(c => c.client);
+        const { bob } = testEnv.ircTest.clients;
+
+        // Create the channel
+        await bob.join(channel);
+        const adminRoom = await testEnv.createAdminRoomHelper(alice)
+        const cRoomId = await testEnv.joinChannelHelper(alice, adminRoom, channel);
+
+        // Ensure we join the IRC side
+        await alice.sendText(cRoomId, `Hello world!`);
+        await bob.waitForEvent('message', 10000);
+
+        const quitEvent = bob.waitForEvent('quit', 10000);
+
+        // Now, have alice quit.
+        await alice.sendText(adminRoom, `!reconnect`);
+        const [nick, message, channels] = await quitEvent;
+        expect(nick).toEqual('M-alice');
+        expect(message).toEqual('Quit: Reconnecting');
+        expect(channels).toContain(channel);
+    });
+});

--- a/spec/util/e2e-test.ts
+++ b/spec/util/e2e-test.ts
@@ -357,9 +357,6 @@ export class IrcBridgeE2ETest {
     }
 
     public async tearDown(): Promise<void> {
-        if (this.traceLog) {
-            this.traceLog.close();
-        }
         await Promise.allSettled([
             this.ircBridge?.kill(),
             this.ircTest.tearDown(),
@@ -368,6 +365,9 @@ export class IrcBridgeE2ETest {
             this.dropDatabase(),
         ]);
         await this.pool?.close();
+        if (this.traceLog) {
+            this.traceLog.close();
+        }
     }
 
     public async createAdminRoomHelper(client: E2ETestMatrixClient): Promise<string> {

--- a/spec/util/e2e-test.ts
+++ b/spec/util/e2e-test.ts
@@ -301,7 +301,9 @@ export class IrcBridgeE2ETest {
             }
             }),
         }, registration);
-        return new IrcBridgeE2ETest(homeserver, ircBridge, registration, postgresDb, ircTest, redisPool, traceStream)
+        return new IrcBridgeE2ETest(
+            homeserver, ircBridge, registration, postgresDb, ircTest, opts, redisPool, traceStream
+        );
     }
 
     private constructor(
@@ -310,6 +312,7 @@ export class IrcBridgeE2ETest {
         public readonly registration: AppServiceRegistration,
         readonly postgresDb: string,
         public readonly ircTest: TestIrcServer,
+        public readonly opts: Opts,
         public readonly pool?: IrcConnectionPool,
         private traceLog?: WriteStream,
     ) {

--- a/src/pool-service/RedisIrcConnection.ts
+++ b/src/pool-service/RedisIrcConnection.ts
@@ -11,10 +11,16 @@ export type RedisIrcConnectionEvents = {
 
 export class RedisIrcConnection extends (EventEmitter as unknown as
     new () => TypedEmitter<RedisIrcConnectionEvents&IrcConnectionEventsMap>) implements IrcConnection {
-    private readonly log = new Logger(`RedisIrcConnection:${this.clientId}`);
+    private readonly log: Logger;
 
     public get connecting() {
         return this.isConnecting;
+    }
+
+    public get readyState() {
+        // TODO: Should this be just pulled directly from the socket.
+        // No support for readonly / writeonly.
+        return this.isConnecting ? 'opening' : 'open';
     }
 
     private isConnecting = true;
@@ -25,6 +31,7 @@ export class RedisIrcConnection extends (EventEmitter as unknown as
                 public readonly clientId: ClientId,
                 public state: IrcClientState) {
         super();
+        this.log = new Logger(`RedisIrcConnection:${this.clientId}`);
         this.once('connect', () => {
             this.isConnecting = false;
         });

--- a/src/pool-service/RedisIrcConnection.ts
+++ b/src/pool-service/RedisIrcConnection.ts
@@ -17,7 +17,7 @@ export class RedisIrcConnection extends (EventEmitter as unknown as
         return this.isConnecting;
     }
 
-    public get readyState() {
+    public get readyState(): string {
         // TODO: Should this be just pulled directly from the socket.
         // No support for readonly / writeonly.
         return this.isConnecting ? 'opening' : 'open';


### PR DESCRIPTION
Failing to specify a readyState means we missed this one.