### PR TITLE
Sync bans from legacy Mjolnir-y rules

### DIFF
--- a/changelog.d/1755.bugfix
+++ b/changelog.d/1755.bugfix
@@ -1,0 +1,1 @@
+Fix a case where the bridge would not listen for and apply bans for legacy/unspec'd `m.room.rule.*` types in use by Mjolnir.

--- a/src/bridge/IrcBridge.ts
+++ b/src/bridge/IrcBridge.ts
@@ -844,6 +844,10 @@ export class IrcBridge {
         log.info("Startup complete.");
 
         this.bridgeState = "running";
+
+        // After completing setup, double check that we're not running any clients for banned users.
+        await this.clientPool.checkForBannedConnectedUsers();
+
     }
 
     private async setupStateSyncer(config: BridgeConfig) {

--- a/src/bridge/IrcBridge.ts
+++ b/src/bridge/IrcBridge.ts
@@ -847,7 +847,6 @@ export class IrcBridge {
 
         // After completing setup, double check that we're not running any clients for banned users.
         await this.clientPool.checkForBannedConnectedUsers();
-
     }
 
     private async setupStateSyncer(config: BridgeConfig) {

--- a/src/bridge/MatrixBanSync.ts
+++ b/src/bridge/MatrixBanSync.ts
@@ -30,11 +30,14 @@ interface MPolicyContent {
 }
 
 function eventTypeToBanEntityType(eventType: string): BanEntityType|null {
+    // `m.room.*` variants were in use until https://github.com/matrix-org/mjolnir/pull/336 by Mjolnir. For compatibilty we accept it.
     switch (eventType) {
         case "m.policy.rule.user":
+        case "m.room.rule.user":
         case "org.matrix.mjolnir.rule.user":
             return BanEntityType.User;
         case "m.policy.rule.server":
+        case "m.room.rule.server":
         case "org.matrix.mjolnir.rule.server":
             return BanEntityType.Server
         default:

--- a/src/irc/ClientPool.ts
+++ b/src/irc/ClientPool.ts
@@ -137,16 +137,25 @@ export class ClientPool {
             return;
         }
 
+        // XXX: This is a safe assumption *for now* but when the proxy supports multiple
+        // servers this will break!
+        const server = this.ircBridge.getServers()[0];
         for await (const connection of this.redisPool.getPreviouslyConnectedClients()) {
-            if (connection.clientId === 'bot') {
+            if (connection.clientId) {
                 // The bot will be connected via the usual process.
                 continue;
             }
-            // XXX: This is a safe assumption *for now* but when the proxy supports multiple
-            // servers this will break!
-            const server = this.ircBridge.getServers()[0];
+            const mxUser = new MatrixUser(connection.clientId) ;
+            if (this.getBridgedClientByUserId(server, mxUser.userId)) {
+                continue;
+            }
+
             try {
-                await this.getBridgedClient(server, connection.clientId);
+                const config = (await this.store.getIrcClientConfig(mxUser.userId, server.domain)) ||
+                    IrcClientConfig.newConfig(
+                        mxUser, server.domain
+                    );
+                await this.createIrcClient(config, mxUser, false, false);
                 log.info(`Connected previously connected user ${connection.clientId}`);
             }
             catch (ex) {
@@ -280,7 +289,9 @@ export class ClientPool {
         }
     }
 
-    private createBridgedClient(ircClientConfig: IrcClientConfig, matrixUser: MatrixUser|null, isBot: boolean) {
+    private createBridgedClient(
+        ircClientConfig: IrcClientConfig, matrixUser: MatrixUser|null, isBot: boolean, checkConditions = true
+    ) {
         const server = this.ircBridge.getServer(ircClientConfig.getDomain());
         if (server === null) {
             throw Error(
@@ -289,7 +300,7 @@ export class ClientPool {
             );
         }
 
-        if (matrixUser) { // Don't bother with the bot user
+        if (matrixUser && checkConditions) { // Don't bother with the bot user
             const excluded = server.isExcludedUser(matrixUser.userId);
             if (excluded) {
                 throw Error("Cannot create bridged client - user is excluded from bridging");
@@ -315,9 +326,11 @@ export class ClientPool {
         );
     }
 
-    public createIrcClient(ircClientConfig: IrcClientConfig, matrixUser: MatrixUser|null, isBot: boolean) {
+    private createIrcClient(
+        ircClientConfig: IrcClientConfig, matrixUser: MatrixUser|null, isBot: boolean, checkConditions = true
+    ) {
         const bridgedClient = this.createBridgedClient(
-            ircClientConfig, matrixUser, isBot
+            ircClientConfig, matrixUser, isBot, checkConditions
         );
         const server = bridgedClient.server;
 

--- a/src/irc/ClientPool.ts
+++ b/src/irc/ClientPool.ts
@@ -155,7 +155,8 @@ export class ClientPool {
                     IrcClientConfig.newConfig(
                         mxUser, server.domain
                     );
-                await this.createIrcClient(config, mxUser, false, false);
+                const bridgeClient = await this.createIrcClient(config, mxUser, false, false);
+                await bridgeClient.connect();
                 log.info(`Connected previously connected user ${connection.clientId}`);
             }
             catch (ex) {

--- a/src/irc/ClientPool.ts
+++ b/src/irc/ClientPool.ts
@@ -141,7 +141,7 @@ export class ClientPool {
         // servers this will break!
         const server = this.ircBridge.getServers()[0];
         for await (const connection of this.redisPool.getPreviouslyConnectedClients()) {
-            if (connection.clientId) {
+            if (connection.clientId === 'bot') {
                 // The bot will be connected via the usual process.
                 continue;
             }


### PR DESCRIPTION
Mjolnir used to use these old event types for moderation, but we implemented the Matrix-spec and MSC variants. This total miss meant we didn't catch older rules.