### PR TITLE
Fix Redis <=6.2 throwing errors when trying to clear the command queue in pooling mode.

### DIFF
--- a/changelog.d/1763.bugfix
+++ b/changelog.d/1763.bugfix
@@ -1,0 +1,2 @@
+Fix Redis <=6.2 failing to clear the command queue in pooling mode.
+

--- a/docs/connection_pooling.md
+++ b/docs/connection_pooling.md
@@ -9,7 +9,9 @@ The IRC bridge can be configured to run it's IRC connections through a seperate 
 allowing you to restart and update (in most cases) the main process while keeping connections alive. This in 
 effect allows you to have a bridge that *appears* to not restart (sometimes nicknamed eternal bridges).
 
-To configure the bridge in this mode you will need to setup a [Redis](https://redis.io/) instance.
+To configure the bridge in this mode you will need to setup a [Redis](https://redis.io/) instance. Ideally, you
+**should** run the bridge with Redis `6.2.0` or greater as it is more efficent when used with streams. The bridge
+requires Redis `5.0.0` or greater to run.
 
 In your bridge, configure the following:
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
   },
   "dependencies": {
     "@sentry/node": "^6.17.9",
-    "@types/semver": "^7.5.0",
     "ajv": "^8.12.0",
     "bluebird": "^3.7.2",
     "classnames": "^2.3.2",
@@ -79,6 +78,7 @@
     "@types/react": "^18.0.26",
     "@types/react-dom": "^18.0.9",
     "@types/sanitize-html": "^2.6.2",
+    "@types/semver": "^7.5.0",
     "@typescript-eslint/eslint-plugin": "^5.38.0",
     "@typescript-eslint/parser": "^5.38.0",
     "@vitejs/plugin-react": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   },
   "dependencies": {
     "@sentry/node": "^6.17.9",
+    "@types/semver": "^7.5.0",
     "ajv": "^8.12.0",
     "bluebird": "^3.7.2",
     "classnames": "^2.3.2",
@@ -54,6 +55,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "sanitize-html": "^2.7.2",
+    "semver": "^7.5.4",
     "typed-emitter": "^2.1.0",
     "typescript": "^5.0.4",
     "url-join": "^5.0.0",

--- a/src/pool-service/CommandReader.ts
+++ b/src/pool-service/CommandReader.ts
@@ -9,7 +9,6 @@ const TRIM_MAXLEN_COUNT = 100_000;
 const log = new Logger('RedisCommandReader');
 
 export class RedisCommandReader {
-
     private shouldRun = true;
     private commandStreamId = "$"
     private supportsMinId = false;

--- a/src/pool-service/CommandReader.ts
+++ b/src/pool-service/CommandReader.ts
@@ -1,0 +1,122 @@
+import { Redis } from "ioredis";
+import { READ_BUFFER_MAGIC_BYTES } from "./types";
+import semver from "semver";
+import { Logger } from "matrix-appservice-bridge";
+
+const TRIM_EVERY_MS = 30000;
+const COMMAND_BLOCK_TIMEOUT = 10000;
+const TRIM_MAXLEN_COUNT = 100_000;
+
+const log = new Logger('RedisCommandReader');
+
+export class RedisCommandReader<CommandType, PayloadType> {
+
+    private shouldRun = true;
+    private commandStreamId = "$"
+    private supportsMinId = false;
+    private trimInterval?: NodeJS.Timer;
+
+    constructor(
+        private readonly redis: Redis,
+        private readonly streamName: string,
+        private readonly onCommand: (cmdType: CommandType, cmdPayload: PayloadType) => Promise<void>) {
+
+    }
+
+    private updateLastRead(lastRead: string) {
+        this.commandStreamId = lastRead;
+    }
+
+    public stop() {
+        this.shouldRun = false;
+        clearInterval(this.trimInterval);
+    }
+
+    public async readQueue() {
+        const newCmds = await this.redis.xread(
+            "BLOCK", COMMAND_BLOCK_TIMEOUT, "STREAMS", this.streamName, this.commandStreamId
+        ).catch(ex => {
+            log.warn(`Failed to read new command:`, ex);
+            return null;
+        });
+        if (newCmds === null) {
+            // This means we've waited for some time and seen no new commands, to be safe revert to the HEAD of the queue.
+            log.info(`Stream has been idle for ${COMMAND_BLOCK_TIMEOUT}ms, listening for messages at $`);
+            this.commandStreamId = '$';
+            return;
+        }
+        // This is a list of keys, containing a list of commands, hence needing to deeply extract the values.
+        for (const [msgId, [cmdType, payload]] of newCmds[0][1]) {
+            // If we crash, we don't want to get stuck on this msg.
+            this.updateLastRead(msgId);
+            const commandType = cmdType as CommandType;
+            let commandData: PayloadType|Buffer;
+            if (typeof payload === 'string' && payload[0] === '{') {
+                commandData = JSON.parse(payload) as PayloadType;
+            }
+            else {
+                commandData = Buffer.from(payload).subarray(READ_BUFFER_MAGIC_BYTES.length);
+            }
+            setImmediate(
+                () => this.onCommand(commandType, commandData)
+                    .catch(ex => log.warn(`Failed to handle msg ${msgId} (${commandType}, ${payload})`, ex)
+                    ),
+            );
+        }
+
+    }
+
+    public async getSupported() {
+        const serverLines = (await
+        this.redis.info("Server")).split('\n').filter(v => !v.startsWith('#')).map(v => v.split(':', 2)
+        ) as [string, string][];
+        const options = new Map(serverLines);
+        const version = options.get('redis_version');
+        this.supportsMinId = !!(version && semver.satisfies(version, '>=6.2'));
+    }
+
+    private async trimCommandStream() {
+        if (this.commandStreamId === '$') {
+            // At the head of the queue, don't trim.
+            return;
+        }
+        try {
+            let trimCount;
+            if (this.supportsMinId) {
+                trimCount = await this.redis.xtrim(
+                    this.streamName, "MINID", this.commandStreamId
+                );
+            }
+            else {
+                // If Redis doesn't support minid (requires >=6.2), we can fallback to
+                // trimming a large amount of messages instead.
+                trimCount = await this.redis.xtrim(
+                    this.streamName, "MAXLEN", TRIM_MAXLEN_COUNT
+                );
+            }
+            log.debug(`Trimmed ${trimCount} commands from the OUT stream`);
+        }
+        catch (ex) {
+            log.warn(`Failed to trim commands from the OUT stream`, ex);
+        }
+    }
+
+    public async start() {
+        await this.getSupported();
+        this.trimInterval = setInterval(this.trimCommandStream.bind(this), TRIM_EVERY_MS);
+        log.info(`Listening for new commands`);
+        let loopCommandCheck: () => void;
+        // eslint-disable-next-line prefer-const
+        loopCommandCheck = () => {
+            if (!this.shouldRun) {
+                log.info(`Finished`);
+                return;
+            }
+            this.readQueue().finally(() => {
+                return loopCommandCheck();
+            });
+        }
+
+        loopCommandCheck();
+    }
+}

--- a/src/pool-service/CommandReader.ts
+++ b/src/pool-service/CommandReader.ts
@@ -63,7 +63,15 @@ export class RedisCommandReader {
         ) as [string, string][];
         const options = new Map(serverLines);
         const version = options.get('redis_version');
-        this.supportsMinId = !!(version && semver.satisfies(version, '>=6.2'));
+        if (!version) {
+            log.warn(`Unable to identify Redis version, assuming unsupported version`);
+            this.supportsMinId = false;
+            return;
+        }
+        if (semver.lt(version, '5.0.0')) {
+            throw new Error('Redis version is unsupported. The minimum required version is 5.0.0');
+        }
+        this.supportsMinId = !!semver.satisfies(version, '>=6.2');
     }
 
     private async trimCommandStream() {

--- a/src/pool-service/IrcConnectionPool.ts
+++ b/src/pool-service/IrcConnectionPool.ts
@@ -337,6 +337,7 @@ export class IrcConnectionPool {
             return;
         }
         try {
+            log.debug(`Trimming up to ${this.commandStreamId}`);
             const trimCount = await this.cmdWriter.xtrim(
                 REDIS_IRC_POOL_COMMAND_IN_STREAM, "MINID", this.commandStreamId
             );

--- a/src/pool-service/IrcConnectionPool.ts
+++ b/src/pool-service/IrcConnectionPool.ts
@@ -20,6 +20,7 @@ import { OutCommandType,
 import { parseMessage } from 'matrix-org-irc';
 import { collectDefaultMetrics, register, Gauge } from 'prom-client';
 import { createServer, Server } from 'http';
+import { RedisCommandReader } from './CommandReader';
 
 collectDefaultMetrics();
 
@@ -52,6 +53,7 @@ export class IrcConnectionPool {
     private metricsServer?: Server;
     private shouldRun = true;
     private heartbeatTimer?: NodeJS.Timer;
+    private readonly commandReader: RedisCommandReader;
 
     constructor(private readonly config: typeof Config) {
         this.shouldRun = false;
@@ -60,6 +62,9 @@ export class IrcConnectionPool {
         this.cmdWriter.on('connecting', () => {
             log.debug('Connecting to', config.redisUri);
         });
+        this.commandReader = new RedisCommandReader(
+            this.cmdReader, REDIS_IRC_POOL_COMMAND_IN_STREAM, this.handleStreamCommand.bind(this)
+        );
     }
 
     private updateLastRead(lastRead: string) {
@@ -307,6 +312,12 @@ export class IrcConnectionPool {
         }
     }
 
+    private async handleStreamCommand(cmdType: string, payload: string) {
+        const commandType = cmdType as InCommandType;
+        const commandData = JSON.parse(payload) as IrcConnectionPoolCommandIn<InCommandType>;
+        return this.handleCommand(commandType, commandData);
+    }
+
     public async handleInternalPing({ info }: IrcConnectionPoolCommandIn<InCommandType.ConnectionPing>) {
         const { clientId } = info;
         const conn = this.connections.get(clientId);
@@ -411,38 +422,11 @@ export class IrcConnectionPool {
             void this.trimCommandStream();
         }, HEARTBEAT_EVERY_MS);
 
-
-        log.info(`Listening for new commands`);
-        setImmediate(async () => {
-            while (this.shouldRun) {
-                const newCmds = await this.cmdReader.xread(
-                    "BLOCK", 0, "STREAMS", REDIS_IRC_POOL_COMMAND_IN_STREAM, this.commandStreamId
-                ).catch(ex => {
-                    log.warn(`Failed to read new command:`, ex);
-                    return null;
-                });
-                if (newCmds === null) {
-                    // Unexpected, this is blocking.
-                    continue;
-                }
-                // This is a list of keys, containing a list of commands, hence needing to deeply extract the values.
-                for (const [msgId, [cmdType, payload]] of newCmds[0][1]) {
-                    const commandType = cmdType as InCommandType;
-
-                    // If we crash, we don't want to get stuck on this msg.
-                    await this.updateLastRead(msgId);
-                    const commandData = JSON.parse(payload) as IrcConnectionPoolCommandIn<InCommandType>;
-                    setImmediate(
-                        () => this.handleCommand(commandType, commandData)
-                            .catch(ex => log.warn(`Failed to handle msg ${msgId} (${commandType}, ${payload})`, ex)
-                            ),
-                    );
-                }
-            }
-        });
+        return this.commandReader.start();
     }
 
     public async close() {
+        this.commandReader.stop();
         if (this.heartbeatTimer) {
             clearInterval(this.heartbeatTimer)
         }

--- a/src/pool-service/IrcConnectionPool.ts
+++ b/src/pool-service/IrcConnectionPool.ts
@@ -67,10 +67,6 @@ export class IrcConnectionPool {
         );
     }
 
-    private updateLastRead(lastRead: string) {
-        this.commandStreamId = lastRead;
-    }
-
     private async sendCommandOut<T extends OutCommandType>(type: T, payload: OutCommandPayload[T]) {
         await this.cmdWriter.xadd(REDIS_IRC_POOL_COMMAND_OUT_STREAM, "*", type, JSON.stringify({
             info: payload,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1138,6 +1138,11 @@
   resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.3.13.tgz#da4bfd73f49bd541d28920ab0e2bf0ee80f71c91"
   integrity sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==
 
+"@types/semver@^7.5.0":
+  version "7.5.0"
+  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.5.0.tgz#591c1ce3a702c45ee15f47a42ade72c2fd78978a"
+  integrity sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==
+
 "@types/serve-static@*":
   version "1.15.1"
   resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-1.15.1.tgz#86b1753f0be4f9a1bee68d459fcda5be4ea52b5d"
@@ -5476,6 +5481,13 @@ semver@^6.0.0, semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
+
+semver@^7.5.4:
+  version "7.5.4"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.4.tgz#483986ec4ed38e1c6c48c34894a9182dbff68a6e"
+  integrity sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==
+  dependencies:
+    lru-cache "^6.0.0"
 
 send@0.18.0:
   version "0.18.0"


### PR DESCRIPTION
Fixes #1761 

Ultimately the problem here is that we failed to specify a minimum Redis version. If you are using less than 6.2, you won't be able to clear the command stream effectively. To get around this for now, we're reverting to previous behaviour of just setting an absolute maximum message count for the stream when running on older Redis versions.