### PR TITLE
docker: don't push on a Pull Request

### DIFF
--- a/.github/workflows/docker-hub-latest.yml
+++ b/.github/workflows/docker-hub-latest.yml
@@ -11,7 +11,8 @@ env:
   DOCKER_NAMESPACE: matrixdotorg
   PLATFORMS: linux/amd64
   # Only push if this is develop, otherwise we just want to build
-  PUSH: ${{ github.ref == 'refs/heads/develop' }}
+  # On a PR github.ref is the target branch, so don't push for that either
+  PUSH: ${{ github.ref == 'refs/heads/develop' && github.event_name != 'pull_request' }}
 
 jobs:
   docker-latest:

--- a/.github/workflows/docker-hub-latest.yml
+++ b/.github/workflows/docker-hub-latest.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Login to Docker Hub
         uses: docker/login-action@v2
-        if: ${{ env.PUSH }}
+        if: ${{ env.PUSH == 'true' }}
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}

--- a/changelog.d/1767.bugfix
+++ b/changelog.d/1767.bugfix
@@ -1,0 +1,1 @@
+Fix GitHub CI docker builds failing for community PRs.


### PR DESCRIPTION
Since the github action triggers on a PR too, `github.ref` will be the target branch for merging (typically `develop`). In that case, don't try to login/push to docker hub.

https://docs.github.com/en/actions/learn-github-actions/contexts#github-context

Signed-off-by: Damjan Georgievski <gdamjan@gmail.com>