### PR TITLE
Drop support for legacy groups

### DIFF
--- a/changelog.d/1772.removal
+++ b/changelog.d/1772.removal
@@ -1,0 +1,1 @@
+Drop `dynamicChannels.groupId` config option. Groups were unstable and are no longer supported by any Matrix implementations.

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -202,12 +202,6 @@ ircService:
         # join_rules will be set to 'invite' until these modes are removed.
         # Default: "public".
         joinRule: public
-        # This will set the m.room.related_groups state event in newly created rooms
-        # with the given groupId. This means flares will show up on IRC users in those rooms.
-        # This should be set to the same thing as namespaces.users.group_id in irc_registration.
-        # This does not alter existing rooms.
-        # Leaving this option empty will not set the event.
-        groupId: +myircnetwork:localhost
         # Should created Matrix rooms be federated? If false, only users on the
         # HS attached to this AS will be able to interact with this room.
         # Default: true.

--- a/config.schema.yml
+++ b/config.schema.yml
@@ -369,8 +369,6 @@ properties:
                                     type: "boolean"
                                 createAlias:
                                     type: "boolean"
-                                groupId:
-                                    type: "string"
                                 joinRule:
                                     type: "string"
                                     enum: ["invite", "public"]

--- a/src/bridge/RoomCreation.ts
+++ b/src/bridge/RoomCreation.ts
@@ -40,15 +40,6 @@ export async function trackChannelAndCreateRoom(ircBridge: IrcBridge, req: Bridg
             }
         }
     ];
-    if (server.areGroupsEnabled()) {
-        initialState.push({
-            type: "m.room.related_groups",
-            state_key: "",
-            content: {
-                groups: [server.getGroupId()],
-            }
-        });
-    }
     if (ircBridge.stateSyncer) {
         initialState.push(
             // RoomId isn't used by this bridge


### PR DESCRIPTION
A feature from long ago when Synapse supported the concept of groups. This has been replaced by Spaces. Spaces hasn't yet added support for flairs or suggested groups, so there isn't a direct replacement.

This feature does nothing though and can be removed.