### PR TITLE
Node18 updates and Timer -> Timeout change

### DIFF
--- a/changelog.d/1788.misc
+++ b/changelog.d/1788.misc
@@ -1,0 +1,1 @@
+Fixup types for Timers so the bridge works with newer node versions.

--- a/src/irc/BridgedClient.ts
+++ b/src/irc/BridgedClient.ts
@@ -95,7 +95,7 @@ export class BridgedClient extends EventEmitter {
     private connectDefer: promiseutil.Defer<void>;
     public readonly log: BridgedClientLogger;
     private cachedOperatorNicksInfo: {[channel: string]: GetNicksResponseOperators} = {};
-    private idleTimeout: NodeJS.Timer|null = null;
+    private idleTimeout: NodeJS.Timeout|null = null;
     private whoisPendingNicks: Set<string> = new Set();
     private state: State = {
         status: BridgedClientStatus.CREATED

--- a/src/irc/ConnectionInstance.ts
+++ b/src/irc/ConnectionInstance.ts
@@ -91,8 +91,8 @@ export class IRCConnectionError extends Error {
 export class ConnectionInstance {
     public dead = false;
     private state: "created"|"connecting"|"connected" = "created";
-    private pingRateTimerId: NodeJS.Timer|null = null;
-    private clientSidePingTimeoutTimerId: NodeJS.Timer|null = null;
+    private pingRateTimerId: NodeJS.Timeout|null = null;
+    private clientSidePingTimeoutTimerId: NodeJS.Timeout|null = null;
     // eslint-disable-next-line no-use-before-define
     private connectDefer: Defer<ConnectionInstance>;
     public onDisconnect?: (reason: string) => void;

--- a/src/pool-service/CommandReader.ts
+++ b/src/pool-service/CommandReader.ts
@@ -12,7 +12,7 @@ export class RedisCommandReader {
     private shouldRun = true;
     private commandStreamId = "$"
     private supportsMinId = false;
-    private trimInterval?: NodeJS.Timer;
+    private trimInterval?: NodeJS.Timeout;
 
     constructor(
         private readonly redis: Redis,

--- a/src/pool-service/IrcConnectionPool.ts
+++ b/src/pool-service/IrcConnectionPool.ts
@@ -52,7 +52,7 @@ export class IrcConnectionPool {
     private commandStreamId = "$";
     private metricsServer?: Server;
     private shouldRun = true;
-    private heartbeatTimer?: NodeJS.Timer;
+    private heartbeatTimer?: NodeJS.Timeout;
     private readonly commandReader: RedisCommandReader;
 
     constructor(private readonly config: typeof Config) {

--- a/src/pool-service/IrcPoolClient.ts
+++ b/src/pool-service/IrcPoolClient.ts
@@ -29,7 +29,7 @@ export class IrcPoolClient extends (EventEmitter as unknown as new () => TypedEm
     private readonly connections = new Map<ClientId, Promise<RedisIrcConnection>>();
     public shouldRun = true;
     private missedHeartbeats = 0;
-    private heartbeatInterval?: NodeJS.Timer;
+    private heartbeatInterval?: NodeJS.Timeout;
     private commandReader: RedisCommandReader;
     cmdReader: Redis;
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,8 @@
     "useUnknownInCatchVariables": false,
      /* matrix-js-sdk throws up errors */
     "skipLibCheck": true,
+    "module": "Node16",
+    "moduleResolution": "Node16"
   },
   "include": [
     "src/**/*"


### PR DESCRIPTION
Minor changes really but this is what got the bridge running for me on Node18 on Debian bookworm.  Mostly a minor update to the package resolution so it all matches, as well as changing the Timer to Timeout, which is what (clear|set)Timeout is using now seemingly.  Confirmed it's up and running and not seemingly doing anything amiss so submitting this upstream.