### PR TITLE
Various formatting adjustments

### DIFF
--- a/changelog.d/1822.bugfix
+++ b/changelog.d/1822.bugfix
@@ -1,0 +1,1 @@
+Change format for file uploads, codeblocks, long replies, self-replies and nicknames. Fixes #1521.

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -332,7 +332,7 @@ ircService:
       ircClients:
         # The template to apply to every IRC client nick. This MUST have either
         # $DISPLAY or $USERID or $LOCALPART somewhere in it.
-        # Optional. Default: "M-$DISPLAY". Example: "M-Alice".
+        # Optional. Default: "$DISPLAY[m]". Example: "Alice[m]".
         nickTemplate: "$DISPLAY[m]"
         # True to allow virtual IRC clients to change their nick on this server
         # by issuing !nick <server> <nick> commands to the IRC AS bot.

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -595,6 +595,8 @@ ircService:
     shortReplyTemplate: "$NICK: $REPLY"
     # format of replies sent a while after the original message
     longReplyTemplate: "$NICK: \"$ORIGINAL\" <- $REPLY"
+    # format of replies where the sender of the original message is the same as the sender of the reply
+    selfReplyTemplate: "<$NICK> $ORIGINAL\n$REPLY"
     # how much time needs to pass between the reply and the original message to switch to the long format
     shortReplyTresholdSeconds: 300
     # Ignore users mentioned in a io.element.functional_members state event when checking admin room membership

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -594,7 +594,7 @@ ircService:
     # format of replies sent shortly after the original message
     shortReplyTemplate: "$NICK: $REPLY"
     # format of replies sent a while after the original message
-    longReplyTemplate: "<$NICK> \"$ORIGINAL\" <- $REPLY"
+    longReplyTemplate: "$NICK: \"$ORIGINAL\" <- $REPLY"
     # how much time needs to pass between the reply and the original message to switch to the long format
     shortReplyTresholdSeconds: 300
     # Ignore users mentioned in a io.element.functional_members state event when checking admin room membership

--- a/config.schema.yml
+++ b/config.schema.yml
@@ -169,6 +169,8 @@ properties:
                         type: "string"
                     shortReplyTresholdSeconds:
                         type: "integer"
+                    selfReplyTemplate:
+                        type: "string"
                     ignoreFunctionalMembersInAdminRooms:
                         type: "boolean"
             mediaProxy:

--- a/spec/integ/matrix-to-irc.spec.js
+++ b/spec/integ/matrix-to-irc.spec.js
@@ -298,7 +298,7 @@ describe("Matrix-to-IRC message bridging", function() {
                 expect(client.nick).toEqual(testUser.nick);
                 expect(client.addr).toEqual(roomMapping.server);
                 expect(channel).toEqual(roomMapping.channel);
-                expect(text).toEqual(`<${repliesUser.nick}> "This is the real message" <- Reply Text`);
+                expect(text).toEqual(`${repliesUser.nick}: "This is the real message" <- Reply Text`);
             }
         );
         const formatted_body = constructHTMLReply(
@@ -389,7 +389,7 @@ describe("Matrix-to-IRC message bridging", function() {
                 expect(client.nick).toEqual(testUser.nick);
                 expect(client.addr).toEqual(roomMapping.server);
                 expect(channel).toEqual(roomMapping.channel);
-                expect(text).toEqual(`<${repliesUser.nick}> "This..." <- Reply Text`);
+                expect(text).toEqual(`${repliesUser.nick}: "This..." <- Reply Text`);
             }
         );
         const formatted_body = constructHTMLReply(
@@ -499,7 +499,7 @@ describe("Matrix-to-IRC message bridging", function() {
                 expect(client.nick).toEqual(testUser.nick);
                 expect(client.addr).toEqual(roomMapping.server);
                 expect(channel).toEqual(roomMapping.channel);
-                expect(text).toEqual('<M-friend> "Message #2" <- Message #3');
+                expect(text).toEqual('M-friend: "Message #2" <- Message #3');
             }
         );
 
@@ -650,7 +650,7 @@ describe("Matrix-to-IRC message bridging", function() {
         });
     });
 
-    it("should bridge mutliline code blocks as IRC action with URL", function(done) {
+    it("should bridge mutliline code blocks as a URL", function(done) {
         let tBody =
             "```javascript\n" +
             "    expect(text.indexOf(\"javascript\")).not.toEqual(-1);\n" +
@@ -662,13 +662,12 @@ describe("Matrix-to-IRC message bridging", function() {
         const sdk = env.clientMock._client(config._botUserId);
         sdk.uploadContent.and.returnValue(Promise.resolve("mxc://deadbeefcafe"));
 
-        env.ircMock._whenClient(roomMapping.server, testUser.nick, "action", (client, channel, text) => {
+        env.ircMock._whenClient(roomMapping.server, testUser.nick, "say", (client, channel, text) => {
                 expect(client.nick).toEqual(testUser.nick);
                 expect(client.addr).toEqual(roomMapping.server);
                 expect(channel).toEqual(roomMapping.channel);
                 // don't be too brittle when checking this, but I expect to see the
                 // code type and the media proxy url
-                expect(text.indexOf('javascript')).not.toEqual(-1);
                 expect(text.includes(config.ircService.mediaProxy.publicUrl)).toEqual(true);
                 done();
             });
@@ -713,11 +712,11 @@ describe("Matrix-to-IRC message bridging", function() {
         });
     });
 
-    it("should bridge matrix images as IRC action with a URL", function(done) {
+    it("should bridge matrix images as a URL", function(done) {
         const tBody = "the_image.jpg";
         const tMxcSegment = "/somecontentid";
 
-        env.ircMock._whenClient(roomMapping.server, testUser.nick, "action", (client, channel, text) => {
+        env.ircMock._whenClient(roomMapping.server, testUser.nick, "say", (client, channel, text) => {
             expect(client.nick).toEqual(testUser.nick);
             expect(client.addr).toEqual(roomMapping.server);
             expect(channel).toEqual(roomMapping.channel);
@@ -737,11 +736,11 @@ describe("Matrix-to-IRC message bridging", function() {
         });
     });
 
-    it("should bridge matrix files as IRC action with a URL", function(done) {
+    it("should bridge matrix files as a URL", function(done) {
         const tBody = "a_file.apk";
         const tMxcSegment = "/somecontentid";
 
-        env.ircMock._whenClient(roomMapping.server, testUser.nick, "action", (client, channel, text) => {
+        env.ircMock._whenClient(roomMapping.server, testUser.nick, "say", (client, channel, text) => {
             expect(client.nick).toEqual(testUser.nick);
             expect(client.addr).toEqual(roomMapping.server);
             expect(channel).toEqual(roomMapping.channel);
@@ -1074,11 +1073,11 @@ describe("Matrix-to-IRC message bridging with media URL and drop time", function
         expect(said).toBe(true);
     });
 
-    it("should bridge matrix files as IRC action with a configured media URL", function(done) {
+    it("should bridge matrix files as IRC message with a configured media URL", function(done) {
         let tBody = "a_file.apk";
         let tMxcSegment = "/somecontentid";
 
-        env.ircMock._whenClient(roomMapping.server, testUser.nick, "action",
+        env.ircMock._whenClient(roomMapping.server, testUser.nick, "say",
         function(client, channel, text) {
             expect(client.nick).toEqual(testUser.nick);
             expect(client.addr).toEqual(roomMapping.server);

--- a/spec/unit/BridgedClient.spec.js
+++ b/spec/unit/BridgedClient.spec.js
@@ -31,8 +31,8 @@ describe("BridgedClient", function() {
             expect(BridgedClient.getValidNick("f+/\u3052oobar", false, STATE_DISC)).toBe("foobar");
         });
         it("will ensure nicks start with a letter or special character", function() {
-            expect(BridgedClient.getValidNick("-foobar", false, STATE_DISC)).toBe("M-foobar");
-            expect(BridgedClient.getValidNick("12345", false, STATE_DISC)).toBe("M12345");
+            expect(BridgedClient.getValidNick("-foobar", false, STATE_DISC)).toBe("`-foobar");
+            expect(BridgedClient.getValidNick("12345", false, STATE_DISC)).toBe("`12345");
         });
         it("will throw if the nick is invalid", function() {
             expect(() => BridgedClient.getValidNick("f+/\u3052oobar", true, STATE_DISC)).toThrowError();

--- a/src/bridge/MatrixHandler.ts
+++ b/src/bridge/MatrixHandler.ts
@@ -1175,8 +1175,8 @@ export class MatrixHandler {
             if (codeBlockMatch) {
                 const type = codeBlockMatch[1] ? ` ${codeBlockMatch[1]}` : '';
                 event.content = {
-                    msgtype: "m.emote",
-                    body:    `sent a${type} code block: ${httpUrl}`
+                    ...event.content,
+                    body:    `${httpUrl}`
                 };
             }
             else {
@@ -1207,7 +1207,7 @@ export class MatrixHandler {
             // Modify the event to become a truncated version of the original
             //  the truncation limits the number of lines sent to lineLimit.
 
-            const msg = '\n...(truncated)';
+            const msg = '\n(truncated)';
 
             const sendingEvent: MatrixMessageEvent = { ...event,
                 content: {

--- a/src/bridge/MatrixHandler.ts
+++ b/src/bridge/MatrixHandler.ts
@@ -55,6 +55,8 @@ export interface MatrixHandlerConfig {
     shortReplyTemplate: string;
     // Format of replies sent a while after the original message
     longReplyTemplate: string;
+    // format of replies where the sender of the original message is the same as the sender of the reply
+    selfReplyTemplate: string;
     // Format of the text explaining why a message is truncated and pastebinned
     truncatedMessageTemplate: string;
     // Ignore io.element.functional_members members joining admin rooms.
@@ -68,6 +70,7 @@ export const DEFAULTS: MatrixHandlerConfig = {
     shortReplyTresholdSeconds: 5 * 60,
     shortReplyTemplate: "$NICK: $REPLY",
     longReplyTemplate: "$NICK: \"$ORIGINAL\" <- $REPLY",
+    selfReplyTemplate: "<$NICK> $ORIGINAL\n$REPLY",
     truncatedMessageTemplate: "(full message at <$URL>)",
     ignoreFunctionalMembersInAdminRooms: false,
 };
@@ -1392,7 +1395,11 @@ export class MatrixHandler {
 
         let replyTemplate: string;
         const thresholdMs = (this.config.shortReplyTresholdSeconds) * 1000;
-        if (rplSource && event.origin_server_ts - cachedEvent.timestamp > thresholdMs) {
+        if (cachedEvent.sender === event.sender) {
+            // They're replying to their own message.
+            replyTemplate = this.config.selfReplyTemplate;
+        }
+        else if (rplSource && event.origin_server_ts - cachedEvent.timestamp > thresholdMs) {
             replyTemplate = this.config.longReplyTemplate;
         }
         else {

--- a/src/bridge/MatrixHandler.ts
+++ b/src/bridge/MatrixHandler.ts
@@ -1176,7 +1176,6 @@ export class MatrixHandler {
             // we check event.content.body since ircAction already has the markers stripped
             const codeBlockMatch = event.content.body.match(/^```(\w+)?/);
             if (codeBlockMatch) {
-                const type = codeBlockMatch[1] ? ` ${codeBlockMatch[1]}` : '';
                 event.content = {
                     ...event.content,
                     body:    `${httpUrl}`

--- a/src/bridge/MatrixHandler.ts
+++ b/src/bridge/MatrixHandler.ts
@@ -1297,7 +1297,7 @@ export class MatrixHandler {
         const bridgeIntent = this.ircBridge.getAppServiceBridge().getIntent();
         // strips out the quotation of the original message, if needed
         const replyText = (body: string): string => {
-            const REPLY_REGEX = /> <(.*?)>(.*?)\n\n([\s\S]*)/;
+            const REPLY_REGEX = /> <(.*?)>(.*?)\n\n([\s\S]*)/s;
             const match = REPLY_REGEX.exec(body);
             if (match === null || match.length !== 4) {
                 return body;

--- a/src/bridge/MatrixHandler.ts
+++ b/src/bridge/MatrixHandler.ts
@@ -67,7 +67,7 @@ export const DEFAULTS: MatrixHandlerConfig = {
     replySourceMaxLength: 32,
     shortReplyTresholdSeconds: 5 * 60,
     shortReplyTemplate: "$NICK: $REPLY",
-    longReplyTemplate: "<$NICK> \"$ORIGINAL\" <- $REPLY",
+    longReplyTemplate: "$NICK: \"$ORIGINAL\" <- $REPLY",
     truncatedMessageTemplate: "(full message at <$URL>)",
     ignoreFunctionalMembersInAdminRooms: false,
 };

--- a/src/irc/BridgedClient.ts
+++ b/src/irc/BridgedClient.ts
@@ -738,9 +738,9 @@ export class BridgedClient extends EventEmitter {
                     `Nick '${nick}' must start with a letter or special character (dash is not a special character).`
                 );
             }
-            // Add arbitrary letter prefix. This is important for guest user
+            // Add arbitrary prefix. This is important for guest user
             // IDs which are all numbers.
-            n = "M" + n;
+            n = "`" + n;
         }
 
         if (state.status === BridgedClientStatus.CONNECTED) {

--- a/src/models/IrcAction.ts
+++ b/src/models/IrcAction.ts
@@ -54,18 +54,18 @@ export class IrcAction {
                 return new IrcAction(matrixAction.type, matrixAction.text, matrixAction.ts);
             case "image":
                 return new IrcAction(
-                    "emote", "uploaded an image: " + matrixAction.text, matrixAction.ts
+                    "message", "" + matrixAction.text, matrixAction.ts
                 );
             case "video":
                 return new IrcAction(
-                    "emote", "uploaded a video: " + matrixAction.text, matrixAction.ts
+                    "message", "" + matrixAction.text, matrixAction.ts
                 );
             case "audio":
                 return new IrcAction(
-                    "emote", "uploaded an audio file: " + matrixAction.text, matrixAction.ts
+                    "message", "" + matrixAction.text, matrixAction.ts
                 );
             case "file":
-                return new IrcAction("emote", "posted a file: " + matrixAction.text, matrixAction.ts);
+                return new IrcAction("message", "" + matrixAction.text, matrixAction.ts);
             case "topic":
                 if (matrixAction.text === null) {
                     break;

--- a/src/models/MatrixAction.ts
+++ b/src/models/MatrixAction.ts
@@ -220,12 +220,12 @@ export class MatrixAction {
                 }
 
                 if (filename) {
-                    text = `${fileSize} < ${url} >`;
+                    text = `${url} ${fileSize}`;
                 }
                 else {
                     fileSize = fileSize ? ` ${fileSize}` : "";
                     // If not a filename, print the body
-                    text = `${event.content.body}${fileSize} < ${url} >`;
+                    text = `${url} ${event.content.body}${fileSize}`;
                 }
             }
         }


### PR DESCRIPTION
Formatting-related changes from https://github.com/matrix-org/matrix-appservice-irc/pull/1807, including:

 - Better matching IRC conventions when bridging file uploads
 - Changing default reply-to format
 - Replacing "M" letter prefix with "`" when nick starts with an invalid character
 - A fix for #1521
 - Sensible handling of self-replies

Credit to @funderscore1