### PR TITLE
Don't require commands be uppercase when using `!cmd`

### DIFF
--- a/changelog.d/1823.feature
+++ b/changelog.d/1823.feature
@@ -1,0 +1,1 @@
+In `!cmd`, don't require commands be all uppercase.

--- a/spec/integ/admin-rooms.spec.js
+++ b/spec/integ/admin-rooms.spec.js
@@ -873,7 +873,7 @@ describe("Admin rooms", function() {
             const newChannel = "#coffee";
 
             // Expect the following commands to be sent in order
-            const recvCommands = ["JOIN", "TOPIC", "PART", "STUPID"];
+            const recvCommands = ["JOIN", "TOPIC", "PART", "STUPID", "lowercase"];
 
             let cmdIx = 0;
             env.ircMock._whenClient(roomMapping.server, userIdNick, "send",
@@ -885,15 +885,15 @@ describe("Admin rooms", function() {
                     cmdIx++;
                 });
 
-            // 4 commands should be executed
             const commands = [
                 `!cmd ${roomMapping.server} JOIN ${newChannel}`,
                 `!cmd ${roomMapping.server} TOPIC ${newChannel} :some new fancy topic`,
                 `!cmd ${roomMapping.server} PART ${newChannel}`,
-                `!cmd ${roomMapping.server} STUPID COMMANDS`];
+                `!cmd ${roomMapping.server} STUPID COMMANDS`,
+                `!cmd ${roomMapping.server} lowercase command`,
+            ];
 
             for (let i = 0; i < commands.length; i++) {
-            // send commands
                 await env.mockAppService._trigger("type:m.room.message", {
                     content: {
                         body: commands[i],

--- a/spec/integ/admin-rooms.spec.js
+++ b/spec/integ/admin-rooms.spec.js
@@ -885,14 +885,12 @@ describe("Admin rooms", function() {
                     cmdIx++;
                 });
 
-            // 5 commands should be executed
-            // rubbishserver should not be accepted
+            // 4 commands should be executed
             const commands = [
                 `!cmd ${roomMapping.server} JOIN ${newChannel}`,
                 `!cmd ${roomMapping.server} TOPIC ${newChannel} :some new fancy topic`,
                 `!cmd ${roomMapping.server} PART ${newChannel}`,
-                `!cmd ${roomMapping.server} STUPID COMMANDS`,
-                `!cmd rubbishserver SOME COMMAND`];
+                `!cmd ${roomMapping.server} STUPID COMMANDS`];
 
             for (let i = 0; i < commands.length; i++) {
             // send commands

--- a/src/bridge/AdminRoomHandler.ts
+++ b/src/bridge/AdminRoomHandler.ts
@@ -428,7 +428,7 @@ export class AdminRoomHandler {
             const keyword = args[0];
 
             // keyword could be a failed server or a malformed command
-            if (!keyword.match(/^[A-Z]+$/)) {
+            if (!keyword.match(/^[A-Za-z]+$/)) {
                 // if not a domain OR is only word (which implies command)
                 if (!keyword.match(/^[a-z0-9:\.-]+$/) || args.length === 1) {
                     throw new Error(`Malformed command: ${keyword}`);

--- a/src/bridge/AdminRoomHandler.ts
+++ b/src/bridge/AdminRoomHandler.ts
@@ -89,12 +89,12 @@ const COMMANDS: {[command: string]: Command|Heading} = {
     'Actions': { heading: true },
     "cmd": {
         example: `!cmd [irc.example.net] COMMAND [arg0 [arg1 [...]]]`,
-        summary: "Issue a raw IRC command. These will not produce a reply." +
+        summary: "Issue a raw IRC command. These will not produce a reply. " +
                 "(Note that the command must be all uppercase.)",
     },
     "feature": {
         example: `!feature feature-name [true/false/default]`,
-        summary: `Enable, disable or default a feature's status for your account.` +
+        summary: `Enable, disable or default a feature's status for your account. ` +
                 `Will display the current feature status if true/false/default not given.`,
     },
     "join": {


### PR DESCRIPTION
Split off from https://github.com/matrix-org/matrix-appservice-irc/pull/1807, credit to @funderscore1