### PR TITLE
Bridge K-lines into Matrix policy lists

### DIFF
--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -668,6 +668,10 @@ ircService:
     # to identify banned users, rooms and servers.
     rooms:
       - "#matrix-org-coc-bl:matrix.org"
+    # Optional: Rooms to sync K-lined users to
+    serverBanLists:
+      # Keys are domains matching entries in ircService.servers
+      irc.example.com: "#exampleircd:matrix.org"
 
 # Options here are generally only applicable to large-scale bridges and may have
 # consequences greater than other options in this configuration file.

--- a/src/bridge/IrcBridge.ts
+++ b/src/bridge/IrcBridge.ts
@@ -634,7 +634,10 @@ export class IrcBridge {
         }
 
         await this.bridge.initialise();
-        this.matrixBanSyncer = this.config.ircService.banLists && new MatrixBanSync(this.bridge.getIntent(), this.config.ircService.banLists);
+        this.matrixBanSyncer = this.config.ircService.banLists && new MatrixBanSync(
+            this.bridge.getIntent(),
+            this.config.ircService.banLists,
+        );
         await this.matrixBanSyncer?.syncRules();
         this.matrixHandler.initialise();
 

--- a/src/irc/ClientPool.ts
+++ b/src/irc/ClientPool.ts
@@ -289,8 +289,8 @@ export class ClientPool {
                 this.removeBridgedClient(bridgedClient);
             }
             if (err instanceof IRCConnectionError && err.code === IRCConnectionErrorCode.Banned) {
-                void this.ircBridge.matrixBanSyncer?.markUserAsBanned(server.domain, userId).catch((err: any) => {
-                    log.error(`Failed to mark ${userId} as banned: ${err.toString}`);
+                void this.ircBridge.matrixBanSyncer?.markUserAsBanned(server.domain, userId).catch((mbsErr: Error) => {
+                    log.error(`Failed to mark ${userId} as banned: ${mbsErr.toString}`);
                 });
             }
             // If we failed to connect
@@ -681,7 +681,10 @@ export class ClientPool {
         }
 
         if (disconnectReason === "banned" && userId) {
-            void this.ircBridge.matrixBanSyncer?.markUserAsBanned(bridgedClient.server.domain, userId).catch((err: any) => {
+            void this.ircBridge.matrixBanSyncer?.markUserAsBanned(
+                bridgedClient.server.domain,
+                userId,
+            ).catch((err: Error) => {
                 log.error(`Failed to mark ${userId} as banned: ${err.toString}`);
             });
             const req = new BridgeRequest(this.ircBridge.getAppServiceBridge().getRequestFactory().newRequest());


### PR DESCRIPTION
Currently, while K-lined users cannot connect to IRC and continue their abuse there, they're not being banned on the Matrix side. This allows to not only hang around in bridged Matrix rooms until manually removed from them, but also continue their abuse on Matrix itself.

This enhances our banSyncing capabilities to enable us to not only to subscribe to existing policylists, but also maintain our own. Each IRC network gets its own policy room (so that they can be subscribed to by mjolnir etc independently) which serves not only as a persistency layer for `MatrixBanSync` which stops us from pointlessly trying to (re)connect K-lined users, but also enables us to protect the wider Matrix network from those who proved to be abusive already.

Currently this does not bother to re-check if the K-line is still active – temporarily banned users have to manually arrange for being removed from the policy list, which the bridge will catch up and reconnect them if needed. We may want to consider allowing them to trigger the re-check manually, perhaps by issuing an explicit `!reconnect` in the bridge status room.