### PR TITLE
MessageDiff: generate proper regexes on message tail modification

### DIFF
--- a/spec/unit/MessageDiff.spec.js
+++ b/spec/unit/MessageDiff.spec.js
@@ -22,7 +22,7 @@ describe('messageDiff', function() {
             'should only show changes from the line that has changed in multiline messages',
             'in a marmalade forest\nbetween the make-believe trees\nI forgot the third verse, sorry',
             'in a marmalade forest\nbetween the make-believe trees\nin a cottage-cheese cottage...',
-            's/I forgot the third verse, sorry/in a cottage-cheese cottage.../',
+            's/I forgot the third verse, sorry$/in a cottage-cheese cottage.../',
         ],
         [
             'should not use diffs with newlines in them',
@@ -58,6 +58,12 @@ describe('messageDiff', function() {
             'Lorem ipsum dolor sit amet - an arbitrary amount of trailing text will be duplicated in the sed expression, even though it should only include a few words of context',
             undefined,
         ],
+        [
+            'should append to end of string if incomplete',
+            'how many wood would a woodchuck c',
+            'how many wood would a woodchuck chuck if a woodchuck would chuck wood',
+            's/c$/chuck if a woodchuck would chuck wood/'
+        ]
     ].forEach(c => it(c[0], () => {
         const result = messageDiff(c[1], c[2]);
         expect(result).toBe(c[3]);

--- a/src/util/MessageDiff.ts
+++ b/src/util/MessageDiff.ts
@@ -25,8 +25,12 @@ function formatChanges(diff: Diff.Change[]): string[] {
     while (i < diff.length - 1) {
         if (diff[i].removed) {
             let replacement: string;
+            let replaced: string = diff[i].value.trim();
             if (diff[i+1].added) {
                 replacement = diff[i+1].value;
+                if (i+1 == diff.length-1) {
+                    replaced += '$';
+                }
             }
             else if (noChanges(diff[i+1])) {
                 replacement = '';
@@ -35,7 +39,7 @@ function formatChanges(diff: Diff.Change[]): string[] {
                 i++;
                 continue;
             }
-            substitutions.push([diff[i].value.trim(), replacement]);
+            substitutions.push([replaced, replacement]);
         }
         i++;
     }


### PR DESCRIPTION
This PR fixes faulty logic generating bad regexes on message edits in a following case:

In a user sent out a message before finishing it, with an unfinished last word, like here:
`how many wood would a woodchuck c`
and then edited it to
`how many wood would a woodchuck chuck if a woodchuck would chuck wood`,
the bridge would output `s/c/chuck if a woodchuck would chuck wood/`, which,
if evaluated, produces `how many wood would a woodchuck if a woodchuck would chuck woodhuck chuck`.

The bridge did not take the possibility of the replaced part occurring more than one time into the account.

These changes fix it by introducing the regex dollar operator for matching line endings in this very specific case.