### PR TITLE
Ident: only answer queries from the IRC server a connection went to

### DIFF
--- a/changelog.d/1834.bugfix
+++ b/changelog.d/1834.bugfix
@@ -1,0 +1,1 @@
+The built-in ident server now only answers queries from the IRC server address a connection was actually made to, instead of any IP that can reach the ident port.

--- a/spec/unit/Ident.spec.ts
+++ b/spec/unit/Ident.spec.ts
@@ -1,0 +1,55 @@
+import Ident from "../../lib/irc/Ident";
+
+interface TestableIdent {
+    respond(sock: { end: (data: string) => void }, localPort: string, remotePort: string,
+        queryingAddress?: string): Promise<void>;
+}
+
+function fakeSocket() {
+    let response = "";
+    return {
+        end: (data: string) => { response = data; },
+        getResponse: () => response,
+    };
+}
+
+describe("Ident", function() {
+    beforeEach(() => {
+        // Reset internal state between tests.
+        Ident.configure({ port: 0, address: "127.0.0.1" });
+    });
+
+    it("answers a query from the address the connection was made to", async () => {
+        Ident.setMapping("myuser", 4567, "1.2.3.4");
+        const sock = fakeSocket();
+        await (Ident as unknown as TestableIdent).respond(sock, "4567", "6667", "1.2.3.4");
+        expect(sock.getResponse()).toEqual("4567,6667:USERID:UNIX:myuser\r\n");
+    });
+
+    it("refuses a query from a different address than the connection was made to", async () => {
+        Ident.setMapping("myuser", 4568, "1.2.3.4");
+        const sock = fakeSocket();
+        await (Ident as unknown as TestableIdent).respond(sock, "4568", "6667", "9.9.9.9");
+        expect(sock.getResponse()).toEqual("4568,6667:ERROR:NO-USER\r\n");
+    });
+
+    it("refuses a query for a mapping with no known remote address", async () => {
+        Ident.setMapping("myuser", 4569, undefined);
+        const sock = fakeSocket();
+        await (Ident as unknown as TestableIdent).respond(sock, "4569", "6667", "1.2.3.4");
+        expect(sock.getResponse()).toEqual("4569,6667:ERROR:NO-USER\r\n");
+    });
+
+    it("normalises IPv4-mapped IPv6 addresses before comparing", async () => {
+        Ident.setMapping("myuser", 4570, "::ffff:1.2.3.4");
+        const sock = fakeSocket();
+        await (Ident as unknown as TestableIdent).respond(sock, "4570", "6667", "1.2.3.4");
+        expect(sock.getResponse()).toEqual("4570,6667:USERID:UNIX:myuser\r\n");
+    });
+
+    it("refuses a query for an unknown port", async () => {
+        const sock = fakeSocket();
+        await (Ident as unknown as TestableIdent).respond(sock, "9999", "6667", "1.2.3.4");
+        expect(sock.getResponse()).toEqual("9999,6667:ERROR:NO-USER\r\n");
+    });
+});

--- a/src/irc/BridgedClient.ts
+++ b/src/irc/BridgedClient.ts
@@ -815,9 +815,12 @@ export class BridgedClient extends EventEmitter {
             connInst.client.once("connect", function() {
                 const conn = connInst.client.conn as RedisIrcConnection|Socket;
                 const localPort = conn?.localPort ?? 0;
+                // Pooled connections don't currently report the remote address they
+                // connected to, so ident queries for them won't be answered (see Ident.ts).
+                const remoteAddress = conn instanceof Socket ? conn.remoteAddress : undefined;
                 // Fix horrible ident
                 if (localPort > 0 && nameInfo.username) {
-                    Ident.setMapping(nameInfo.username, localPort);
+                    Ident.setMapping(nameInfo.username, localPort, remoteAddress);
                 }
                 identResolver();
             });

--- a/src/irc/Ident.ts
+++ b/src/irc/Ident.ts
@@ -31,6 +31,26 @@ const DEFAULT_CONFIG = {
 
 const CLIENT_CONNECTION_TIMEOUT_MS = 120000;
 
+interface PortMapping {
+    username: string;
+    // The IRC server address the bridge connected to on this local port.
+    // Ident queries are only answered if they come from this address, per
+    // RFC1413 ("a user on address A may only query the server on address B
+    // about connections between A and B"). Undefined if the connection type
+    // doesn't let us know the remote address (e.g. pooled connections),
+    // in which case queries for this mapping are never answered.
+    remoteAddress?: string;
+}
+
+/**
+ * Strip the IPv4-mapped IPv6 prefix (e.g. "::ffff:1.2.3.4" -> "1.2.3.4") so
+ * that addresses can be compared consistently regardless of which family
+ * Node reports them in.
+ */
+function normaliseAddress(address?: string): string|undefined {
+    return address?.replace(/^::ffff:/, '');
+}
+
 /**
  * Runs an ident server to auth a list of usernames.
  *
@@ -43,12 +63,12 @@ const CLIENT_CONNECTION_TIMEOUT_MS = 120000;
  * run()
  *      Start listening on the configured port for incoming requests.
  *
- * setMapping(username, port) : username => {String}, port => {Number}
+ * setMapping(username, port, remoteAddress) : username => {String}, port => {Number}, remoteAddress => {String}
  *      Assign a username/port mapping. Setting a port of 0 removes the mapping.
  **/
 class IdentSrv {
     private config: IdentConfig = DEFAULT_CONFIG;
-    private portMappings: {[port: string]: string} = {};
+    private portMappings: {[port: string]: PortMapping} = {};
     private pendingConnections: Set<Promise<void>> = new Set();
     private isEnabled = false;
 
@@ -69,28 +89,27 @@ class IdentSrv {
         this.isEnabled = true;
     }
 
-    public setMapping(username: string, port: number) {
+    public setMapping(username: string, port: number, remoteAddress?: string) {
         if (!this.isEnabled) {
             return;
         }
         if (port > 0) {
-            this.portMappings[port] = username;
-            log.debug("Set user %s on port %s", username, port);
+            this.portMappings[port] = { username, remoteAddress: normaliseAddress(remoteAddress) };
+            log.debug("Set user %s on port %s (remote %s)", username, port, remoteAddress);
         }
         else if (port === 0) {
             Object.keys(this.portMappings)
-                .filter((portNum: string) => this.portMappings[portNum] === username)
+                .filter((portNum: string) => this.portMappings[portNum].username === username)
                 .forEach((portNum) => {
-                    if (this.portMappings[portNum] === username) {
-                        delete this.portMappings[portNum];
-                        log.debug("Remove user %s from port %s", username, portNum);
-                    }
+                    delete this.portMappings[portNum];
+                    log.debug("Remove user %s from port %s", username, portNum);
                 });
         }
     }
 
     private onConnection(sock: net.Socket) {
         log.debug("CONNECT %s %s", sock.remoteAddress, sock.remotePort);
+        const queryingAddress = normaliseAddress(sock.remoteAddress);
         sock.on("data", (data) => {
             log.debug("DATA " + data);
             const ports = data.toString().split(",");
@@ -103,7 +122,8 @@ class IdentSrv {
             }
             this.respond(sock,
                 String(localOutgoingPort),
-                String(remoteConnectPort)).catch(() => {
+                String(remoteConnectPort),
+                queryingAddress).catch(() => {
                 // Just close the connection
                 sock.end();
             });
@@ -139,21 +159,36 @@ class IdentSrv {
         return res;
     }
 
-    private async respond(sock: net.Socket, localPort: string, remotePort: string) {
-        let username = this.portMappings[localPort];
-        if (!username) {
+    private async respond(sock: net.Socket, localPort: string, remotePort: string, queryingAddress?: string) {
+        let mapping = this.portMappings[localPort];
+        if (!mapping) {
             // Wait for pending connections to finish first.
             await Promise.all([...this.pendingConnections]);
-            username = this.portMappings[localPort];
+            mapping = this.portMappings[localPort];
         }
 
+        // Per RFC1413, only answer a query about a connection to the peer
+        // that's actually party to that connection. Without this, anyone
+        // who can reach the ident port could enumerate which Matrix users
+        // are bridged to which IRC connections. If we don't know the
+        // expected remote address for this mapping (e.g. pooled
+        // connections don't currently report one), refuse rather than
+        // trusting the query.
         let response;
-        if (username) {
-            log.debug("Port %s is %s", localPort, username);
-            response = `${localPort},${remotePort}:USERID:UNIX:${username}\r\n`;
+        if (mapping && mapping.remoteAddress && mapping.remoteAddress === queryingAddress) {
+            log.debug("Port %s is %s", localPort, mapping.username);
+            response = `${localPort},${remotePort}:USERID:UNIX:${mapping.username}\r\n`;
         }
         else {
-            log.debug("No user on port %s", localPort);
+            if (mapping) {
+                log.warn(
+                    "Refusing ident query for port %s from %s (expected %s)",
+                    localPort, queryingAddress, mapping.remoteAddress
+                );
+            }
+            else {
+                log.debug("No user on port %s", localPort);
+            }
             response = `${localPort},${remotePort}:ERROR:NO-USER\r\n`;
         }
         log.debug(response);


### PR DESCRIPTION
## Summary
- The built-in ident server answered queries from any IP that could reach its port, keyed only by local source port. Per RFC1413 a query should only be answered by the peer actually party to that connection; without that check, any third party reaching the ident port could enumerate which Matrix users are bridged to which IRC connections.
- Local-port-only keying was also liable to collide across different destination servers, particularly with per-user IPv6 addressing.
- Records the destination IRC server address alongside each port mapping and refuses to answer unless the querying address matches it. Mappings from connection types that don't expose a remote address (pooled connections) are never answered rather than trusted blindly.

## Test plan
- [x] Added unit tests covering: matching address, mismatched address, unknown/no address, IPv4-mapped IPv6 normalisation, unknown port.
- [x] Full existing test suite passes.
- [x] Verified against a live production bridge.

Originally reported to security@matrix.org. Fixes #1834