### PR TITLE
Clear formatted_body when truncating a message to pastebin

### DIFF
--- a/changelog.d/1835.bugfix
+++ b/changelog.d/1835.bugfix
@@ -1,0 +1,1 @@
+Fix a bug where a long HTML-formatted message could bypass truncation/pastebinning and flood the IRC channel with the full, untruncated message.

--- a/spec/integ/matrix-to-irc.spec.js
+++ b/spec/integ/matrix-to-irc.spec.js
@@ -713,6 +713,69 @@ describe("Matrix-to-IRC message bridging", function() {
         });
     });
 
+    it("should not bridge the untruncated HTML body when pastebinning a truncated message", async () => {
+        // formatted_body must survive sanitizeHtml unchanged (only tags from the allow-list,
+        // here: none) or htmlToIrc bails out and falls back to the safe plain-text body,
+        // masking the bug (GH-1835).
+        const tBody = "This\nis\na\nmessage\nwith\nmultiple\nline\nbreaks".split('\n');
+        const sdk = env.clientMock._client(config._botUserId);
+
+        sdk.uploadContent.and.returnValue(Promise.resolve("mxc://deadbeefcafe"));
+
+        const sayTexts = [];
+        env.ircMock._whenClient(roomMapping.server, testUser.nick, "say", (client, channel, text) => {
+            sayTexts.push(text);
+        });
+
+        await env.mockAppService._trigger("type:m.room.message", {
+            content: {
+                body: tBody.join("\n"),
+                formatted_body: tBody.join("\n"),
+                format: "org.matrix.custom.html",
+                msgtype: "m.text"
+            },
+            sender: testUser.id,
+            room_id: roomMapping.roomId,
+            type: "m.room.message"
+        });
+
+        // A single truncated message + pastebin URL should be sent, never the
+        // full HTML-derived body flooding the channel as a wall of separate lines.
+        expect(sayTexts.length).toEqual(1);
+        expect(sayTexts[0].includes(tBody[tBody.length - 1])).toEqual(false);
+        expect(sayTexts[0].includes(config.ircService.mediaProxy.publicUrl)).toEqual(true);
+    });
+
+    it("should not bridge the untruncated HTML body when truncating in-place (upload failure)", async () => {
+        const tBody = "This\nis\na\nmessage\nwith\nmultiple\nline\nbreaks".split('\n');
+        const sdk = env.clientMock._client(config._botUserId);
+
+        sdk.uploadContent.and.callFake(() => Promise.reject(new Error("upload failed")));
+
+        const sayTexts = [];
+        env.ircMock._whenClient(roomMapping.server, testUser.nick, "say", (client, channel, text) => {
+            sayTexts.push(text);
+        });
+
+        await env.mockAppService._trigger("type:m.room.message", {
+            content: {
+                body: tBody.join("\n"),
+                formatted_body: tBody.join("\n"),
+                format: "org.matrix.custom.html",
+                msgtype: "m.text"
+            },
+            sender: testUser.id,
+            room_id: roomMapping.roomId,
+            type: "m.room.message"
+        });
+
+        // A single truncated message should be sent, never the full
+        // HTML-derived body flooding the channel as a wall of separate lines.
+        expect(sayTexts.length).toEqual(1);
+        expect(sayTexts[0].includes(tBody[tBody.length - 1])).toEqual(false);
+        expect(sayTexts[0].includes("truncated")).toEqual(true);
+    });
+
     it("should bridge matrix images as IRC action with a URL", function(done) {
         const tBody = "the_image.jpg";
         const tMxcSegment = "/somecontentid";

--- a/src/bridge/MatrixHandler.ts
+++ b/src/bridge/MatrixHandler.ts
@@ -1207,6 +1207,10 @@ export class MatrixHandler {
 
                 event.content = {
                     ...event.content,
+                    // Clear any HTML formatting so the truncated plain text body above
+                    // isn't overridden by the original, untruncated formatted_body.
+                    format: undefined,
+                    formatted_body: undefined,
                     body: `${messagePreview} ${explanation}`,
                 };
             }
@@ -1228,6 +1232,10 @@ export class MatrixHandler {
             const sendingEvent: MatrixMessageEvent = { ...event,
                 content: {
                     ...event.content,
+                    // Clear any HTML formatting so the truncated plain text body above
+                    // isn't overridden by the original, untruncated formatted_body.
+                    format: undefined,
+                    formatted_body: undefined,
                     body: potentialMessages.splice(0, lineLimit - 1).join('\n') + msg
                 }
             };


### PR DESCRIPTION
## Summary
- When a long Matrix message is too long and gets pastebinned (or truncated in-place), `MatrixHandler` rebuilds `event.content` as `{ ...event.content, body: <truncated text> }` — but this spreads the original `format`/`formatted_body` back in unchanged.
- Downstream, `MatrixAction`/`IrcAction` prefer the HTML-derived body over the plain text body, so the full untruncated message reaches IRC anyway, flooding the channel (and risking an excess-flood kick on strict networks).
- Explicitly clear `format`/`formatted_body` in both branches that rebuild the truncated content, so the truncated plain text body is what actually gets sent.

## Test plan
- [x] Added integration regression tests covering both the pastebin-success and upload-failure (in-place truncation) branches.
- [x] Verified both tests fail against the pre-fix code and pass against the fix.
- [x] Verified against a live production bridge.

Originally reported to security@matrix.org. Fixes #1835