### PR TITLE
Stop bridging media from redacted events

### DIFF
--- a/changelog.d/1849.bugfix
+++ b/changelog.d/1849.bugfix
@@ -1,0 +1,1 @@
+The bridge's media proxy no longer serves media whose source Matrix event has since been redacted.

--- a/src/models/MatrixAction.ts
+++ b/src/models/MatrixAction.ts
@@ -213,7 +213,10 @@ export class MatrixAction {
                     fileSize = "(" + Math.round(event.content.info.size / 1024) + "KiB)";
                 }
 
-                const url = await mediaProxy.generateMediaUrl(event.content.url);
+                const url = await mediaProxy.generateMediaUrl(event.content.url, {
+                    roomId: event.room_id,
+                    eventId: event.event_id,
+                });
                 if (!filename && event.content.body && /\S*\.[\w\d]{2,4}$/.test(event.content.body)) {
                     // Add filename to url if body is a filename.
                     filename = event.content.body;


### PR DESCRIPTION
## Summary
- Pass the source room and event ID through to `MediaProxy.generateMediaUrl()` so the proxy can refuse to serve media once the event sharing it has been redacted (e.g. NSFW content removed on Matrix).

## Blocked on
This depends on the corresponding fix in `matrix-appservice-bridge`: matrix-org/matrix-appservice-bridge#527. `generateMediaUrl()`'s new `{ roomId, eventId }` parameter only exists on that unmerged branch, so CI here will fail (`matrix-appservice-bridge` type mismatch) until #527 merges and a new version is released. Marking as draft until then, at which point I'll bump the `matrix-appservice-bridge` dependency version and mark ready for review.

## Test plan
- [x] Verified against a live production bridge running the corresponding bridge fix.
- [ ] Bump `matrix-appservice-bridge` to the released version once matrix-org/matrix-appservice-bridge#527 ships.

Fixes #1849